### PR TITLE
Soback 7 offset and start params in solr query

### DIFF
--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -157,6 +157,19 @@
   width:100px;
 }
 
+.pagingContainer button:disabled {
+  color: rgba(30,30,30,0.5);
+	border: 2px solid rgba(30,30,30,0.5);
+}
+
+.pagingContainer button:disabled:hover {
+  color: rgba(30,30,30,0.5);
+  border: 2px solid rgba(30,30,30,0.5);
+  background-color:white;
+  cursor:default;
+}
+
+
 .pagingContainer {
   text-align: center;
 }

--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -77,6 +77,10 @@
   margin-left:10px;
 }
 
+.SingleEntryStandardInfo .scoreInfo .textAlignRight {
+  text-align: right;
+}
+
 .SingleEntryStandardInfo .entryInfo {
   padding-bottom:5px;
   padding-top:5px;
@@ -101,7 +105,12 @@
   font-size:130%;
 }
 
-.SingleEntryStandardInfo .titleInfo, .SingleEntryStandardInfo .domainInfo, .SingleEntryStandardInfo .typeInfo {
+.SingleEntryStandardInfo .titleInfo a {
+  color: var(--secondary-text-color);
+  text-decoration-color: var(--secondary-highlight-color);
+}
+
+.SingleEntryStandardInfo, .SingleEntryStandardInfo .domainInfo, .SingleEntryStandardInfo .typeInfo {
   margin-right:3px;
   margin-left:3px;
 
@@ -128,7 +137,7 @@
   height:30px;
 }
 
-.showAllButtonContainer button, .singleEntryImages button {
+.showAllButtonContainer button, .singleEntryImages button, .pagingContainer button {
   float:right;
   border:2px solid var(--secondary-bg-color);
   border-radius: 0;
@@ -141,7 +150,18 @@
   transition:all 0.2s linear 0s;
 }
 
-.showAllButtonContainer button:hover, .singleEntryImages button:hover {
+.pagingContainer button {
+  float:none;
+  margin-left:5px;
+  margin-right:5px;
+  width:100px;
+}
+
+.pagingContainer {
+  text-align: center;
+}
+
+.showAllButtonContainer button:hover, .singleEntryImages button:hover, .pagingContainer button:hover {
   border:2px solid var(--secondary-bg-color);
   color:white;
   background-color:var(--secondary-bg-color);

--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -215,7 +215,12 @@
 
 
 .pagingContainer {
+  margin-top: 15px;
   text-align: center;
+}
+
+.tonedDownText {
+  color:rgba(30,30,30, 0.5)
 }
 
 .showAllButtonContainer button:hover, .singleEntryImages button:hover, .pagingContainer button:hover {

--- a/src/js/src/assets/styles/search.scss
+++ b/src/js/src/assets/styles/search.scss
@@ -48,6 +48,11 @@ color:var(--secondary-text-color);
   box-shadow: inset 0 0 7px var(--seethrough-black);
 }
 
+.searchForm .buttonExplanation {
+  cursor:default;
+  color:rgba(30,30,30,0.5)
+}
+
 .searchForm #querySubmit {
   box-sizing: border-box;
   width:60px;
@@ -148,7 +153,7 @@ color:var(--secondary-text-color);
 
 .searchForm input[type="checkbox"] {
   position: relative;
-  top: 2px;
+  top: 3px;
   height: 15px;
 	width: 15px;
 }

--- a/src/js/src/assets/styles/search.scss
+++ b/src/js/src/assets/styles/search.scss
@@ -145,3 +145,62 @@ color:var(--secondary-text-color);
   outline:1px solid var(--seethrough-black);
   border-radius:0;
 }
+
+.searchForm input[type="checkbox"] {
+  position: relative;
+  top: 2px;
+  height: 15px;
+	width: 15px;
+}
+
+.searchForm label {
+  cursor:pointer;
+}
+
+.searchForm .sortOptions {
+  margin-top:10px;
+  width: calc(100% - 80px);
+  padding-bottom:15px;
+  border-bottom: 1px solid var(--secondary-highlight-color);
+  text-transform: uppercase;
+	font-size: 80%;
+}
+
+.searchForm .tools {
+  margin-top: 17px;
+	width: calc(100% - 80px);
+	padding-bottom: 10px;
+	text-transform: uppercase;
+	margin-bottom: 10px;
+	display: flex;
+	cursor: pointer;
+	justify-content: space-between;
+	font-size: 80%;
+}
+
+.searchForm .tools span {
+  display:inline-block;
+  color: var(--main-highlight-color);
+  border-bottom:1px solid var(--secondary-highlight-color);
+}
+
+.searchForm .sortOptions .marginRight {
+  margin-right:15px;
+}
+
+.searchForm .sortOptions div {
+  display: inline-block;
+  color: var(--main-highlight-color);
+}
+
+.searchForm .sortOptions label {
+  user-select: none;
+}
+
+.searchForm #groupedSearch {
+  margin-left: 0px;
+}
+
+.searchForm .sortOptions .floatRight {
+  float:right;
+}

--- a/src/js/src/components/AppliedSearchFacets.vue
+++ b/src/js/src/components/AppliedSearchFacets.vue
@@ -41,9 +41,9 @@ export default {
       this.updateSearchAppliedFacets(this.searchAppliedFacets.replace('&fq=' + facet,''))
       this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
       this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
+      this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
       //let newFacetUrl = this.searchAppliedFacets !== '' ? '&facets=' + encodeURIComponent(this.searchAppliedFacets) : ''
       //history.pushState({name: 'SolrWayback'}, 'SolrWayback', '?q=' + this.query + newFacetUrl)
-      this.pushHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
       //this.$router.replace({query: {q:this.query, facets:this.searchAppliedFacets !== '' ?  this.searchAppliedFacets : undefined }})
     }
   }

--- a/src/js/src/components/AppliedSearchFacets.vue
+++ b/src/js/src/components/AppliedSearchFacets.vue
@@ -13,18 +13,19 @@
 
 import { mapState, mapActions } from 'vuex'
 import AppliedSearchFacetsUtils from './../mixins/AppliedSearchFacetsUtils'
-
+import HistoryRoutingUtils from './../mixins/HistoryRoutingUtils'
 
 export default {
   name: 'AppliedSearchFacets',
   
-  mixins: [AppliedSearchFacetsUtils],
+  mixins: [AppliedSearchFacetsUtils, HistoryRoutingUtils],
 
   computed: {
     ...mapState({
       searchAppliedFacets: state => state.Search.searchAppliedFacets,
       facets: state => state.Search.facets,
-      query: state => state.Search.query
+      query: state => state.Search.query,
+      solrSettings: state => state.Search.solrSettings,
     }),
   },
   mounted () {
@@ -38,10 +39,11 @@ export default {
     }),
     removeFacet(facet) {
       this.updateSearchAppliedFacets(this.searchAppliedFacets.replace('&fq=' + facet,''))
-      this.requestSearch({query:this.query, facets:this.searchAppliedFacets})
-      this.requestFacets({query:this.query, facets:this.searchAppliedFacets})
-      let newFacetUrl = this.searchAppliedFacets !== '' ? '&facets=' + encodeURIComponent(this.searchAppliedFacets) : ''
-      history.pushState({name: 'SolrWayback'}, 'SolrWayback', '?q=' + this.query + newFacetUrl)
+      this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
+      this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
+      //let newFacetUrl = this.searchAppliedFacets !== '' ? '&facets=' + encodeURIComponent(this.searchAppliedFacets) : ''
+      //history.pushState({name: 'SolrWayback'}, 'SolrWayback', '?q=' + this.query + newFacetUrl)
+      this.pushHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
       //this.$router.replace({query: {q:this.query, facets:this.searchAppliedFacets !== '' ?  this.searchAppliedFacets : undefined }})
     }
   }

--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -21,7 +21,7 @@
                  :checked="solrSettings.grouping"
                  type="checkbox"
                  name="groupedSearch">
-          <label for="male">Grouped search <span class="buttonExplanation" title="Grouping results by URL, meaning you only seen an URL as one hit, even though it might have been a hit on several params.">[ ? ]</span></label>
+          <label for="groupedSearch">Grouped search <span class="buttonExplanation" title="Grouping results by URL, meaning you only seen an URL as one hit, even though it might have been a hit on several params.">[ ? ]</span></label>
         </div>
         <div class="floatRight" @click="selectSearchMethod('urlSearch')">
           <input id="urlSearch"
@@ -29,7 +29,7 @@
                  type="checkbox"
                  name="urlSearch"
                  @click.stop="selectSearchMethod('urlSearch')">
-          <label for="male">URL search <span class="buttonExplanation" title="Explanation goes here.">[ ? ]</span></label>
+          <label for="urlSearch">URL search <span class="buttonExplanation" title="Explanation goes here.">[ ? ]</span></label>
         </div>
         <div class="floatRight marginRight" @click="selectSearchMethod('imgSearch')">
           <input id="imgSearch"
@@ -37,7 +37,7 @@
                  type="checkbox"
                  name="imgSearch"
                  @click.stop="selectSearchMethod('imgSearch')">
-          <label for="male">Image search <span class="buttonExplanation" title="Explanation goes here">[ ? ]</span></label>
+          <label for="imgSearch">Image search <span class="buttonExplanation" title="Explanation goes here">[ ? ]</span></label>
         </div>
       </div>
       <div class="tools">
@@ -120,7 +120,7 @@ export default {
         this.futureImgSearch = this.solrSettings.imgSearch
         this.requestSearch({query:this.futureQuery, facets:this.searchAppliedFacets, options:this.solrSettings})
         this.requestFacets({query:this.futureQuery, facets:this.searchAppliedFacets, options:this.solrSettings})
-        this.pushHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
+        this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
       }
     },
     selectSearchMethod(selected) {

--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -16,14 +16,14 @@
               type="button"
               @click="clearResultsAndSearch" />
       <div class="sortOptions">
-        <div @click="updateSolrSettingGrouping(!solrSettings.grouping)">
+        <div @click.prevent="updateSolrSettingGrouping(!solrSettings.grouping)">
           <input id="groupedSearch"
                  :checked="solrSettings.grouping"
                  type="checkbox"
                  name="groupedSearch">
           <label for="groupedSearch">Grouped search <span class="buttonExplanation" title="Grouping results by URL, meaning you only seen an URL as one hit, even though it might have been a hit on several params.">[ ? ]</span></label>
         </div>
-        <div class="floatRight" @click="selectSearchMethod('urlSearch')">
+        <div class="floatRight" @click.prevent="selectSearchMethod('urlSearch')">
           <input id="urlSearch"
                  :checked="solrSettings.urlSearch"
                  type="checkbox"
@@ -31,7 +31,7 @@
                  @click.stop="selectSearchMethod('urlSearch')">
           <label for="urlSearch">URL search <span class="buttonExplanation" title="Explanation goes here.">[ ? ]</span></label>
         </div>
-        <div class="floatRight marginRight" @click="selectSearchMethod('imgSearch')">
+        <div class="floatRight marginRight" @click.prevent="selectSearchMethod('imgSearch')">
           <input id="imgSearch"
                  :checked="solrSettings.imgSearch"
                  type="checkbox"
@@ -124,13 +124,17 @@ export default {
       }
     },
     selectSearchMethod(selected) {
+      console.log(selected, 'heer!')
       if(selected === 'imgSearch') {
+        console.log('here!')
         this.solrSettings.urlSearch ? this.updateSolrSettingUrlSearch(!this.solrSettings.urlSearch) : null
         this.updateSolrSettingImgSearch(!this.solrSettings.imgSearch)
+        return
       }
       if(selected === 'urlSearch') {
         this.solrSettings.imgSearch ? this.updateSolrSettingImgSearch(!this.solrSettings.imgSearch) : null
         this.updateSolrSettingUrlSearch(!this.solrSettings.urlSearch)
+        return
       }
     },
     clearResultsAndSearch() {

--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -21,7 +21,7 @@
                  :checked="solrSettings.grouping"
                  type="checkbox"
                  name="groupedSearch">
-          <label for="male">Grouped search</label>
+          <label for="male">Grouped search <span class="buttonExplanation" title="Grouping results by URL, meaning you only seen an URL as one hit, even though it might have been a hit on several params.">[ ? ]</span></label>
         </div>
         <div class="floatRight" @click="selectSearchMethod('urlSearch')">
           <input id="urlSearch"
@@ -29,7 +29,7 @@
                  type="checkbox"
                  name="urlSearch"
                  @click.stop="selectSearchMethod('urlSearch')">
-          <label for="male">URL search</label>
+          <label for="male">URL search <span class="buttonExplanation" title="Explanation goes here.">[ ? ]</span></label>
         </div>
         <div class="floatRight marginRight" @click="selectSearchMethod('imgSearch')">
           <input id="imgSearch"
@@ -37,7 +37,7 @@
                  type="checkbox"
                  name="imgSearch"
                  @click.stop="selectSearchMethod('imgSearch')">
-          <label for="male">Image search</label>
+          <label for="male">Image search <span class="buttonExplanation" title="Explanation goes here">[ ? ]</span></label>
         </div>
       </div>
       <div class="tools">
@@ -51,14 +51,19 @@
 <script>
 import { mapState, mapActions } from 'vuex'
 import AppliedSearchFacets from './AppliedSearchFacets.vue'
+import HistoryRoutingUtils from './../mixins/HistoryRoutingUtils'
 
 export default {
   components: {
     AppliedSearchFacets
   },
+  mixins: [HistoryRoutingUtils],
   data () {
     return {    
       futureQuery:'',
+      futureGrouped:false,
+      futureUrlSearch:false,
+      futureImgSearch:false,
     }
   },
   computed: {
@@ -76,12 +81,14 @@ export default {
     },
   },
   mounted () {
+    console.log(this.$router.history.current.query)
     if(this.$router.history.current.query.q) {
       this.updateQuery(this.$router.history.current.query.q)
       this.futureQuery = this.$router.history.current.query.q
-      if(this.$router.history.current.query.facets) {
-        this.updateSearchAppliedFacets(this.$router.history.current.query.facets)
-      }
+      this.$router.history.current.query.facets ? this.updateSearchAppliedFacets(this.$router.history.current.query.facets) : null
+      this.$router.history.current.query.grouping === 'true' ? this.updateSolrSettingGrouping(true) : null
+      this.$router.history.current.query.imgSearch === 'true' ? this.updateSolrSettingImgSearch(true) : null
+      this.$router.history.current.query.urlSearch === 'true' ? this.updateSolrSettingUrlSearch(true) : null
       this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
       this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
       }
@@ -101,18 +108,25 @@ export default {
 
     }),
     handleSubmit() {
-      if (this.futureQuery !== this.query) {
+      if (this.futureQuery !== this.query ||
+          this.futureGrouped !== this.solrSettings.grouping ||
+          this.futureUrlSearch !== this.solrSettings.urlSearch ||
+          this.futureImgSearch !== this.solrSettings.imgSearch) 
+        {
+        console.log('search fired!')
         this.updateQuery(this.futureQuery)
+        this.futureGrouped = this.solrSettings.grouping
+        this.futureUrlSearch = this.solrSettings.urlSearch
+        this.futureImgSearch = this.solrSettings.imgSearch
         this.requestSearch({query:this.futureQuery, facets:this.searchAppliedFacets, options:this.solrSettings})
         this.requestFacets({query:this.futureQuery, facets:this.searchAppliedFacets, options:this.solrSettings})
-        let newFacetUrl = this.searchAppliedFacets !== '' ? '&facets=' + encodeURIComponent(this.searchAppliedFacets) : ''
-        history.pushState({name: 'SolrWayback'}, 'SolrWayback', '?q=' + this.query + newFacetUrl)
+        this.pushHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
       }
     },
     selectSearchMethod(selected) {
       if(selected === 'imgSearch') {
         this.solrSettings.urlSearch ? this.updateSolrSettingUrlSearch(!this.solrSettings.urlSearch) : null
-        this.updateSolrSettingImgSearch(!this.solrSettings.imageSearch)
+        this.updateSolrSettingImgSearch(!this.solrSettings.imgSearch)
       }
       if(selected === 'urlSearch') {
         this.solrSettings.imgSearch ? this.updateSolrSettingImgSearch(!this.solrSettings.imgSearch) : null

--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -14,7 +14,35 @@
               id="clearSubmit"
               title="Clear search and results"
               type="button"
-              @click="clearResultsAndSearch" />     
+              @click="clearResultsAndSearch" />
+      <div class="sortOptions">
+        <div @click="updateSolrSettingGrouping(!solrSettings.grouping)">
+          <input id="groupedSearch"
+                 :checked="solrSettings.grouping"
+                 type="checkbox"
+                 name="groupedSearch">
+          <label for="male">Grouped search</label>
+        </div>
+        <div class="floatRight" @click="selectSearchMethod('urlSearch')">
+          <input id="urlSearch"
+                 :checked="solrSettings.urlSearch"
+                 type="checkbox"
+                 name="urlSearch"
+                 @click.stop="selectSearchMethod('urlSearch')">
+          <label for="male">URL search</label>
+        </div>
+        <div class="floatRight marginRight" @click="selectSearchMethod('imgSearch')">
+          <input id="imgSearch"
+                 :checked="solrSettings.imgSearch"
+                 type="checkbox"
+                 name="imgSearch"
+                 @click.stop="selectSearchMethod('imgSearch')">
+          <label for="male">Image search</label>
+        </div>
+      </div>
+      <div class="tools">
+        <span>Search with uploaded file</span> <span>Search for HTML-tags</span> <span>Domain stats</span><span>Link graphs</span>
+      </div>
     </form>
     <applied-search-facets />
   </div>
@@ -30,7 +58,7 @@ export default {
   },
   data () {
     return {    
-      futureQuery:'' 
+      futureQuery:'',
     }
   },
   computed: {
@@ -66,7 +94,11 @@ export default {
       updateQuery: 'updateQuery',
       clearResults: 'clearResults',
       updateSearchAppliedFacets:'updateSearchAppliedFacets',
-      resetSearchState:'resetState'
+      resetSearchState:'resetState',
+      updateSolrSettingGrouping:'updateSolrSettingGrouping',
+      updateSolrSettingImgSearch:'updateSolrSettingImgSearch',
+      updateSolrSettingUrlSearch:'updateSolrSettingUrlSearch'
+
     }),
     handleSubmit() {
       if (this.futureQuery !== this.query) {
@@ -75,7 +107,16 @@ export default {
         this.requestFacets({query:this.futureQuery, facets:this.searchAppliedFacets, options:this.solrSettings})
         let newFacetUrl = this.searchAppliedFacets !== '' ? '&facets=' + encodeURIComponent(this.searchAppliedFacets) : ''
         history.pushState({name: 'SolrWayback'}, 'SolrWayback', '?q=' + this.query + newFacetUrl)
-
+      }
+    },
+    selectSearchMethod(selected) {
+      if(selected === 'imgSearch') {
+        this.solrSettings.urlSearch ? this.updateSolrSettingUrlSearch(!this.solrSettings.urlSearch) : null
+        this.updateSolrSettingImgSearch(!this.solrSettings.imageSearch)
+      }
+      if(selected === 'urlSearch') {
+        this.solrSettings.imgSearch ? this.updateSolrSettingImgSearch(!this.solrSettings.imgSearch) : null
+        this.updateSolrSettingUrlSearch(!this.solrSettings.urlSearch)
       }
     },
     clearResultsAndSearch() {

--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -38,19 +38,20 @@ export default {
       query: state => state.Search.query,
       searchAppliedFacets: state => state.Search.searchAppliedFacets,
       results: state => state.Search.results,
+      solrSettings: state => state.Search.solrSettings,
       loading: state => state.Search.loading,
     })
   },
   mounted () {
-    console.log('NEW MOUNT, CHECK THE PARAMS FROM URL:',this.$router.history.current.query)
+    //console.log('NEW MOUNT, CHECK THE PARAMS FROM URL:',this.$router.history.current.query)
     if(this.query === '' && this.$router.history.current.query.q) {
       this.updateQuery(this.$router.history.current.query.q)
       this.futureQuery = this.$router.history.current.query.q
       if(this.$router.history.current.query.facets) {
         this.updateSearchAppliedFacets(this.$router.history.current.query.facets)
       }
-      this.requestSearch({query:this.query, facets:this.searchAppliedFacets})
-      this.requestFacets({query:this.query, facets:this.searchAppliedFacets})
+      this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
+      this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
       }
   },
   
@@ -66,8 +67,8 @@ export default {
     handleSubmit() {
       if (this.futureQuery !== this.query) {
         this.updateQuery(this.futureQuery)
-        this.requestSearch({query:this.futureQuery, facets:this.searchAppliedFacets})
-        this.requestFacets({query:this.futureQuery, facets:this.searchAppliedFacets})
+        this.requestSearch({query:this.futureQuery, facets:this.searchAppliedFacets, options:this.solrSettings})
+        this.requestFacets({query:this.futureQuery, facets:this.searchAppliedFacets, options:this.solrSettings})
         this.$router.replace({ query: {q:this.query }})
       }
     },

--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -18,14 +18,17 @@
 <script>
 
 import { mapState, mapActions } from 'vuex'
+import HistoryRoutingUtils from './../mixins/HistoryRoutingUtils'
 
 export default {
   name: 'SearchFacetOptions',
+  mixins: [HistoryRoutingUtils],
   computed: {
     ...mapState({
       searchAppliedFacets: state => state.Search.searchAppliedFacets,
       facets: state => state.Search.facets,
-      query: state => state.Search.query
+      query: state => state.Search.query,
+      solrSettings: state => state.Search.solrSettings
     }),
   },
   mounted () {
@@ -39,10 +42,10 @@ export default {
     applyFacet(facetCategory, facet) {
       let newFacet = '&fq=' + facetCategory + ':"' + facet + '"'
       this.updateSearchAppliedFacets(this.searchAppliedFacets + newFacet)
-      this.requestSearch({query:this.query, facets:this.searchAppliedFacets})
-      this.requestFacets({query:this.query, facets:this.searchAppliedFacets})
-      // test with null!
-      history.pushState({name: 'SolrWayback'}, 'SolrWayback', '?q=' + this.query + '&facets=' + encodeURIComponent(this.searchAppliedFacets))
+      this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options: this.solrSettings})
+      this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options: this.solrSettings})
+      this.pushHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
+      //history.pushState({name: 'SolrWayback'}, 'SolrWayback', '?q=' + this.query + '&facets=' + encodeURIComponent(this.searchAppliedFacets))
       //this.$router.replace({query: {q:this.query, facets:this.searchAppliedFacets !== '' ?  this.searchAppliedFacets : undefined }})
     }
   }

--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -44,7 +44,7 @@ export default {
       this.updateSearchAppliedFacets(this.searchAppliedFacets + newFacet)
       this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options: this.solrSettings})
       this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options: this.solrSettings})
-      this.pushHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
+      this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
       //history.pushState({name: 'SolrWayback'}, 'SolrWayback', '?q=' + this.query + '&facets=' + encodeURIComponent(this.searchAppliedFacets))
       //this.$router.replace({query: {q:this.query, facets:this.searchAppliedFacets !== '' ?  this.searchAppliedFacets : undefined }})
     }

--- a/src/js/src/components/SearchResult.vue
+++ b/src/js/src/components/SearchResult.vue
@@ -73,13 +73,13 @@ export default {
       this.updateSolrSettingOffset(this.solrSettings.offset + 20)
       this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
       this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
-      this.pushHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
+      this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
     },
     getPreviousResults() {
       this.updateSolrSettingOffset(this.solrSettings.offset - 20)
       this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
       this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
-      this.pushHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
+      this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
     },
     SingleEntryComponent(type) {
       switch(type) {   

--- a/src/js/src/components/SearchResult.vue
+++ b/src/js/src/components/SearchResult.vue
@@ -4,12 +4,23 @@
       <search-facet-options />
     </div>
     <div class="resultContainer">
-      <h2>Results</h2><p>Found <span class="highlightText">{{ results.numFound }}</span> entries matching <span class="highlightText">{{ query }}</span></p>
+      <h2>Results</h2><span>Found <span class="highlightText">{{ results.numFound }}</span> entries matching <span class="highlightText">{{ query }}. </span>
+        <span>Showing {{ solrSettings.offset }}  - {{ solrSettings.offset + 20 > results.numFound ? results.numFound : solrSettings.offset + 20 }}.</span>
+      </span>
+      <div class="pagingContainer">
+        <button :disabled="solrSettings.offset < 20" @click="getPreviousResults()">
+          Previous 20
+        </button>
+        <button :disabled="solrSettings.offset + 20 > results.numFound" @click="getNextResults()">
+          Next 20
+        </button>
+      </div>
       <div v-if="results && results !== {}" class="results">
         <component :is="SingleEntryComponent(result.type)"
                    v-for="(result, index) in results.docs"
                    :key="index"
-                   :result="result" />
+                   :result="result"
+                   :rank-number="index" />
       </div>
     </div>
     <div class="marginContainer" />
@@ -35,7 +46,9 @@ export default {
   computed: {
     ...mapState({
       query: state => state.Search.query,
+      searchAppliedFacets: state => state.Search.searchAppliedFacets,
       results: state => state.Search.results,
+      solrSettings: state => state.Search.solrSettings
     }),
   },
   mounted () {
@@ -44,7 +57,19 @@ export default {
   methods: {
     ...mapActions('Search', {
       requestSearch: 'requestSearch',
+      requestFacets: 'requestFacets',
+      updateSolrSettingOffset:'updateSolrSettingOffset'
     }),
+    getNextResults() {
+      this.updateSolrSettingOffset(this.solrSettings.offset + 20)
+      this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
+      this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
+    },
+    getPreviousResults() {
+      this.updateSolrSettingOffset(this.solrSettings.offset - 20)
+      this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
+      this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
+    },
     SingleEntryComponent(type) {
       switch(type) {   
         case 'Web Page': return 'SearchSingleItemWeb'

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemAllData.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemAllData.vue
@@ -124,7 +124,7 @@ export default {
       this.requestSearch({query:searchString, facets:this.searchAppliedFacets, options:this.solrSettings})
       this.requestFacets({query:searchString, facets:this.searchAppliedFacets, options:this.solrSettings})
       //this.$router.push({ name:'SolrWayback', params:{query:searchString }})
-      this.pushHistory('SolrWayback', searchString, this.searchAppliedFacets, this.solrSettings)
+      this.$_pushSearchHistory('SolrWayback', searchString, this.searchAppliedFacets, this.solrSettings)
       //this.$router.replace({ query: {q:searchString }})
     },
     toggleShownData(index) {

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemAllData.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemAllData.vue
@@ -51,11 +51,13 @@
 <script>
 import { mapState, mapActions } from 'vuex'
 import { requestService } from '../../services/RequestService'
+import HistoryRoutingUtils from './../../mixins/HistoryRoutingUtils'
 
 export default {
   name: 'SearchSingleItemAllData',
   components: {  
   },
+  mixins: [HistoryRoutingUtils],
   props: {
     id: {
       type: String,
@@ -75,7 +77,8 @@ export default {
   computed: {
     ...mapState({
       results: state => state.Search.results,
-      results: state => state.Search.query,
+      query: state => state.Search.query,
+      solrSettings: state => state.Search.solrSettings,
       searchAppliedFacets: state => state.Search.searchAppliedFacets,
     }),
     allDataButtonText: function () {
@@ -118,10 +121,10 @@ export default {
       let searchString = attribute + ':"' + value + '"'
       this.updateQuery(searchString)
       this.updateSearchAppliedFacets('')
-      this.requestSearch({query:searchString, facets:this.searchAppliedFacets})
-      this.requestFacets({query:searchString, facets:this.searchAppliedFacets})
+      this.requestSearch({query:searchString, facets:this.searchAppliedFacets, options:this.solrSettings})
+      this.requestFacets({query:searchString, facets:this.searchAppliedFacets, options:this.solrSettings})
       //this.$router.push({ name:'SolrWayback', params:{query:searchString }})
-      history.pushState({name: 'SolrWayback'}, 'SolrWayback', '?q=' + searchString)
+      this.pushHistory('SolrWayback', searchString, this.searchAppliedFacets, this.solrSettings)
       //this.$router.replace({ query: {q:searchString }})
     },
     toggleShownData(index) {

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemStandardInfo.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemStandardInfo.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="SingleEntryStandardInfo">
-    <p class="scoreInfo">
-      score: <span class="highlightText">{{ result.score }}</span>
-    </p>
+    <div class="scoreInfo">
+      <p class="textAlignRight">
+        #<span class="highlightText">{{ solrSettings.offset + rank + 1 }}</span>
+      </p>
+      <p>score: <span class="highlightText"> {{ result.score }}</span></p>
+    </div>
     <p class="entryInfo">
       <span class="highlightText titleInfo">
         <a :href="getPlaybackURL(result.source_file_path, result.source_file_offset)" target="_blank"><span>{{ result.title || 'No title' }}</span></a>
@@ -32,6 +35,8 @@
 
 <script>
 import configs from '../../configs'
+import { mapState } from 'vuex'
+
 
 export default {
   name: 'SearchSingleItemStandardInfo',
@@ -39,7 +44,16 @@ export default {
     result: {
       type: Object,
       required: true
+    },
+    rank: {
+      type: Number,
+      required: true
     }
+  },
+  computed: {
+    ...mapState({
+      solrSettings: state => state.Search.solrSettings
+    }),
   },
   methods: {
     refactoredDate(date) {

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemDefault.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemDefault.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="singleEntryResult">
-    <search-single-item-standard-info :result="result" />
+    <search-single-item-standard-info :rank="rankNumber" :result="result" />
     <search-single-item-images :source="result.source_file_path" :offset="result.source_file_offset" />
     <search-single-item-all-data :result="result" />
   </div>
@@ -26,6 +26,10 @@ export default {
       type: Object,
       required: true
     },
+    rankNumber: {
+      type:Number,
+      required:true
+    }
   },
   data () {
     return {     

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemTweet.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemTweet.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="singleEntryResult">
-    <search-single-item-standard-info :result="result" />
+    <search-single-item-standard-info :rank="rankNumber" :result="result" />
     <search-single-item-images :source="result.source_file_path" :offset="result.source_file_offset" />
     <search-single-item-all-data :result="result" />
   </div>
@@ -26,6 +26,10 @@ export default {
       type: Object,
       required: true
     },
+    rankNumber: {
+      type:Number,
+      required:true
+    }
   },
   data () {
     return {     

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemWeb.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemWeb.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="singleEntryResult">
-    <search-single-item-standard-info :result="result" />
+    <search-single-item-standard-info :rank="rankNumber" :result="result" />
     <search-single-item-images :source="result.source_file_path" :offset="result.source_file_offset" />
     <search-single-item-all-data :result="result" />
   </div>
@@ -26,6 +26,10 @@ export default {
       type: Object,
       required: true
     },
+    rankNumber: {
+      type:Number,
+      required:true
+    }
   },
   data () {
     return {     

--- a/src/js/src/mixins/AppliedSearchFacetsUtils.js
+++ b/src/js/src/mixins/AppliedSearchFacetsUtils.js
@@ -1,6 +1,4 @@
 export default {
-  computed: {
-  },
   methods: {
     seperateFacets(facets) {
       let dividedFacets = facets.split('&fq=').filter(Boolean)

--- a/src/js/src/mixins/HistoryRoutingUtils.js
+++ b/src/js/src/mixins/HistoryRoutingUtils.js
@@ -1,8 +1,6 @@
 export default {
-  computed: {
-  },
   methods: {
-    pushHistory(destination, query, appliedFacets, solrSettings) {
+    $_pushSearchHistory(destination, query, appliedFacets, solrSettings) {
     let newFacetUrl = appliedFacets !== '' ? '&facets=' + encodeURIComponent(appliedFacets) : ''
     let newOptionsUrl = '&offset=' + solrSettings.offset + '&grouping=' + solrSettings.grouping + '&imgSearch=' + solrSettings.imgSearch + '&urlSearch=' + solrSettings.urlSearch
     history.pushState({name: destination}, destination, '?q=' + query + newFacetUrl + newOptionsUrl)

--- a/src/js/src/mixins/HistoryRoutingUtils.js
+++ b/src/js/src/mixins/HistoryRoutingUtils.js
@@ -1,0 +1,11 @@
+export default {
+  computed: {
+  },
+  methods: {
+    pushHistory(destination, query, appliedFacets, solrSettings) {
+    let newFacetUrl = appliedFacets !== '' ? '&facets=' + encodeURIComponent(appliedFacets) : ''
+    let newOptionsUrl = '&offset=' + solrSettings.offset + '&grouping=' + solrSettings.grouping + '&imgSearch=' + solrSettings.imgSearch + '&urlSearch=' + solrSettings.urlSearch
+    history.pushState({name: destination}, destination, '?q=' + query + newFacetUrl + newOptionsUrl)
+    },
+  }
+}

--- a/src/js/src/services/RequestService.js
+++ b/src/js/src/services/RequestService.js
@@ -6,9 +6,10 @@ export const requestService = {
   fireImagesRequest
 }
 
-function fireSearchRequest (query, facets) {
+function fireSearchRequest (query, facets, options) {
+  let optionString = '&start=' + options.offset + '&grouping=' + options.grouping
   // Split url and move to config
-  const url = 'services/frontend/solr/search/results/' + `?query=${query + facets}`
+  const url = 'services/frontend/solr/search/results/' + `?query=${query + facets + optionString}`
   return axios.get(
     url, {
       transformResponse: [
@@ -26,9 +27,10 @@ function fireSearchRequest (query, facets) {
   })
 }
 
-function fireFacetRequest (query, facets) {
+function fireFacetRequest (query, facets, options) {
+  let optionString = '&start=' + options.offset + '&grouping=' + options.grouping
   // Split url and move to config
-  const url = 'services/frontend/solr/search/facets/' + `?query=${query + facets}`
+  const url = 'services/frontend/solr/search/facets/' + `?query=${query + facets + optionString}`
   return axios.get(
     url).then(response => {
     console.log('facets', response.data.facet_counts)

--- a/src/js/src/services/RequestService.js
+++ b/src/js/src/services/RequestService.js
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import dataTransformationHelper from './dataTransformationHelper'
 
 export const requestService = {
   fireSearchRequest,
@@ -17,23 +18,11 @@ function fireSearchRequest (query, facets, options) {
         function(response) {
           let returnObj = JSON.parse(response)
           if(options.grouping === false) {
-            for(let i = 0; i < returnObj.response.docs.length; i++) {
-              returnObj.response.docs[i].highlight = returnObj.highlighting[returnObj.response.docs[i].id]
-              }
+            returnObj = dataTransformationHelper.transformSearchResponse(returnObj)
           }
           else {
-            returnObj.response = {}
-            returnObj.response.docs = []
-            returnObj.response.numFound = returnObj.grouped.url.doclist.numFound
-            returnObj.response.maxScore = returnObj.grouped.url.doclist.maxScore
-            returnObj.response.start = returnObj.grouped.url.doclist.start
-            returnObj.response.cardinality = returnObj.stats.stats_fields.url.cardinality
-            for(let i = 0; i < returnObj.grouped.url.doclist.docs.length; i++) {
-              returnObj.response.docs[i] = returnObj.grouped.url.doclist.docs[i]
-              returnObj.response.docs[i].highlight = returnObj.highlighting[returnObj.grouped.url.doclist.docs[i].id]
-            }
+            returnObj = dataTransformationHelper.transformGroupedSearchResponse(returnObj)
           }
-          console.log(returnObj)
           return returnObj
         }
       ]}).then(returnObj => {

--- a/src/js/src/services/RequestService.js
+++ b/src/js/src/services/RequestService.js
@@ -16,9 +16,24 @@ function fireSearchRequest (query, facets, options) {
       transformResponse: [
         function(response) {
           let returnObj = JSON.parse(response)
-          for(let i = 0; i < returnObj.response.docs.length; i++) {
-            returnObj.response.docs[i].highlight = returnObj.highlighting[returnObj.response.docs[i].id]
+          if(options.grouping === false) {
+            for(let i = 0; i < returnObj.response.docs.length; i++) {
+              returnObj.response.docs[i].highlight = returnObj.highlighting[returnObj.response.docs[i].id]
+              }
           }
+          else {
+            returnObj.response = {}
+            returnObj.response.docs = []
+            returnObj.response.numFound = returnObj.grouped.url.doclist.numFound
+            returnObj.response.maxScore = returnObj.grouped.url.doclist.maxScore
+            returnObj.response.start = returnObj.grouped.url.doclist.start
+            returnObj.response.cardinality = returnObj.stats.stats_fields.url.cardinality
+            for(let i = 0; i < returnObj.grouped.url.doclist.docs.length; i++) {
+              returnObj.response.docs[i] = returnObj.grouped.url.doclist.docs[i]
+              returnObj.response.docs[i].highlight = returnObj.highlighting[returnObj.grouped.url.doclist.docs[i].id]
+            }
+          }
+          console.log(returnObj)
           return returnObj
         }
       ]}).then(returnObj => {

--- a/src/js/src/services/dataTransformationHelper.js
+++ b/src/js/src/services/dataTransformationHelper.js
@@ -1,0 +1,21 @@
+export default {
+  transformSearchResponse(data) {
+    for(let i = 0; i < data.response.docs.length; i++) {
+      data.response.docs[i].highlight = data.highlighting[data.response.docs[i].id]
+      }
+      return data
+  },
+  transformGroupedSearchResponse(data) {
+    data.response = {}
+    data.response.docs = []
+    data.response.numFound = data.grouped.url.doclist.numFound
+    data.response.maxScore = data.grouped.url.doclist.maxScore
+    data.response.start = data.grouped.url.doclist.start
+    data.response.cardinality = data.stats.stats_fields.url.cardinality
+    for(let i = 0; i < data.grouped.url.doclist.docs.length; i++) {
+      data.response.docs[i] = data.grouped.url.doclist.docs[i]
+      data.response.docs[i].highlight = data.highlighting[data.grouped.url.doclist.docs[i].id]
+    }
+    return data
+  }
+}

--- a/src/js/src/store/modules/search.store.js
+++ b/src/js/src/store/modules/search.store.js
@@ -7,6 +7,10 @@ const initialState = () => ({
   searchAppliedFacets:'',
   results: {},
   facets: {},
+  solrSettings:{
+    grouping:false,
+    offset:0,
+  },
   error: '',
   loading:false,
   facetLoading:false,
@@ -21,6 +25,12 @@ const actions = {
   updateQuery ( {commit}, param ) {
     commit('updateQuerySuccess', param)
   },
+  updateSolrSettingGrouping ( {commit}, param ) {
+    commit('updateSolrSettingGroupingSuccess', param)
+  },
+  updateSolrSettingOffset ( {commit}, param ) {
+    commit('updateSolrSettingOffsetSuccess', param)
+  },
   updateSearchAppliedFacets ( {commit}, param ) {
     commit('updateSearchAppliedFacetsSuccess', param)
   },
@@ -30,14 +40,14 @@ const actions = {
   requestSearch ({ commit }, params) {
     commit('setLoadingStatus',true)
     requestService
-      .fireSearchRequest(params.query, params.facets)
+      .fireSearchRequest(params.query, params.facets, params.options)
       .then(result => commit('doSearchSuccess', result), error =>
         commit('doSearchError', error))
   },
   requestFacets({commit}, params) {
     commit('setFacetLoadingStatus')
     requestService
-      .fireFacetRequest(params.query, params.facets)
+      .fireFacetRequest(params.query, params.facets, params.options)
       .then(result => commit('facetRequestSuccess', result), error =>
         commit('facetRequestError', error))
   },
@@ -49,6 +59,12 @@ const actions = {
 const mutations = {
   updateQuerySuccess(state, param) {
     state.query = param
+  },
+  updateSolrSettingGroupingSuccess(state, param) {
+    state.solrSettings.grouping = param
+  },
+  updateSolrSettingOffsetSuccess(state, param) {
+    state.solrSettings.offset = param
   },
   updateSearchAppliedFacetsSuccess(state, param) {
     state.searchAppliedFacets = param

--- a/src/js/src/store/modules/search.store.js
+++ b/src/js/src/store/modules/search.store.js
@@ -10,6 +10,8 @@ const initialState = () => ({
   solrSettings:{
     grouping:false,
     offset:0,
+    imgSearch:false,
+    urlSearch:false
   },
   error: '',
   loading:false,
@@ -30,6 +32,12 @@ const actions = {
   },
   updateSolrSettingOffset ( {commit}, param ) {
     commit('updateSolrSettingOffsetSuccess', param)
+  },
+  updateSolrSettingImgSearch ( {commit}, param ) {
+    commit('updateSolrSettingImgSearchSuccess', param)
+  },
+  updateSolrSettingUrlSearch ( {commit}, param ) {
+    commit('updateSolrSettingUrlSearchSuccess', param)
   },
   updateSearchAppliedFacets ( {commit}, param ) {
     commit('updateSearchAppliedFacetsSuccess', param)
@@ -65,6 +73,12 @@ const mutations = {
   },
   updateSolrSettingOffsetSuccess(state, param) {
     state.solrSettings.offset = param
+  },
+  updateSolrSettingImgSearchSuccess(state, param) {
+    state.solrSettings.imgSearch = param
+  },
+  updateSolrSettingUrlSearchSuccess(state, param) {
+    state.solrSettings.urlSearch = param
   },
   updateSearchAppliedFacetsSuccess(state, param) {
     state.searchAppliedFacets = param


### PR DESCRIPTION
**THIS PR COVERS BOTH SOBACK-7 AND SOBACK-12**

@thomasegense added for visual input and critique.
@jorntx added for code inspection and review (and visual input if he feels like it!).

- Made important solr settings part of the URL, so URLs can be shared (and perserve state)
- Moved pushState function to mixin, to be used by all the places that need to initiate a new search, nicer this way
- Added grouped search param to the search function, and altered the response so we can use it
- Made so we show unique hits in the count when we search with the grouped param - and not when we search regularly
- Added number to each post
- Added paging
- small css adjustments
- Added the future options for searching to the interface (subject to change if people aren't happy with it)

URL and Image search doesn't work right now - and the under-the-hood code needs to be implemented when we got backend support ready for it.

The four links to different search / analysis tools arent working either - since they've not been implemented yet either.