### PR TITLE
Clean up of counting structure for replaced links

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriterBase.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriterBase.java
@@ -212,15 +212,7 @@ public abstract class RewriterBase {
 			String content, String baseURL, String crawlDate, Map<String, IndexDocShort> urlMap, PACKAGING packaging)
 			throws Exception {
 
-		CountingMap<String, IndexDocShort> countingMap = null;
-		if (urlMap instanceof CountingMap) {
-			countingMap = (CountingMap<String, IndexDocShort>) urlMap;
-		} else {
-			countingMap = new CountingMap<>();
-			countingMap.putAll(urlMap);
-		}
-		ParseResult result = new ParseResult(replaceLinks(content, baseURL, crawlDate, countingMap));
-		result.addStats(countingMap.getFoundCount(), countingMap.getFoundCount());
+		ParseResult result = new ParseResult(replaceLinks(content, baseURL, crawlDate, urlMap));
 		escapeContent(result, packaging);
 		return result;
 	}

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterTest.java
@@ -38,6 +38,12 @@ public class HtmlParserUrlRewriterTest {
         assertRewrite("simple", 11);
     }
 
+    // No verification of result, only count of replaced
+    @Test
+    public void testSimpleRewritingCount() throws Exception {
+        assertCount("simple", 11);
+    }
+
     @Test
     public void testMultiSourceRewriting() throws Exception {
         assertRewrite("multisource", 16);
@@ -60,8 +66,7 @@ public class HtmlParserUrlRewriterTest {
 
     @Test
     public void testScriptRewriting() throws Exception {
-        // TODO: Why is it not 7?
-        assertRewrite("script", 8);
+        assertRewrite("script", 7);
     }
 
     /* *************************************************************************************
@@ -75,10 +80,21 @@ public class HtmlParserUrlRewriterTest {
 
         ParseResult rewritten = HtmlParserUrlRewriter.replaceLinks(
                 input, "http://example.com/somefolder/", "2020-04-30T13:07:00",
-                RewriteTestHelper.createMockResolver());
+                RewriteTestHelper.createOXResolver());
 
         assertEquals("The result should be as expected for test '" + testPrefix + "'",
                      expected, rewritten.getReplaced().replaceAll(" +\n", "\n"));
+        assertEquals("The number of replaced links should be as expected",
+                     expectedReplaced, rewritten.getNumberOfLinksReplaced());
+    }
+
+    private void assertCount(String testPrefix, int expectedReplaced) throws Exception {
+        final String input = RewriteTestHelper.fetchUTF8("example_rewrite/" + testPrefix + ".html");
+
+        ParseResult rewritten = HtmlParserUrlRewriter.replaceLinks(
+                input, "http://example.com/somefolder/", "2020-04-30T13:07:00",
+                RewriteTestHelper.createIdentityResolver());
+
         assertEquals("The number of replaced links should be as expected",
                      expectedReplaced, rewritten.getNumberOfLinksReplaced());
     }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriteTestHelper.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriteTestHelper.java
@@ -43,11 +43,27 @@ public class RewriteTestHelper {
      * Creates a mock resolver that resolves all input that contains {@code _oXXX}, where XXX is a number.
      * @return a mock resolver.
      */
-    static HtmlParserUrlRewriter.NearestResolver createMockResolver() {
+    static HtmlParserUrlRewriter.NearestResolver createOXResolver() {
         final AtomicLong counter = new AtomicLong(0);
         return (urls, timeStamp)-> urls.stream().
                 map(url -> makeIndexDoc(url, timeStamp, counter)).
                 filter(Objects::nonNull).
+                collect(Collectors.toList());
+    }
+
+    /**
+     * @return a resolver that returns the URLs unchanged.
+     */
+    static HtmlParserUrlRewriter.NearestResolver createIdentityResolver() {
+        return (urls, timeStamp)-> urls.stream().
+                map(url -> {
+                    IndexDocShort doc = new IndexDocShort();
+                    doc.setUrl(url);
+                    doc.setUrl_norm(Normalisation.canonicaliseURL(url));
+                    doc.setSource_file_path("somesourcefile");
+                    doc.setOffset(0);
+                    return doc;
+                }).
                 collect(Collectors.toList());
     }
 

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/ScriptRewriterTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/ScriptRewriterTest.java
@@ -42,7 +42,7 @@ public class ScriptRewriterTest {
 
         ScriptRewriter rewriter = new ScriptRewriter();
         String actual = rewriter.replaceLinks(
-                SCRIPT, "http://example.com", MOCK_DATE, RewriteTestHelper.createMockResolver(), RewriterBase.PACKAGING.attribute
+                SCRIPT, "http://example.com", MOCK_DATE, RewriteTestHelper.createOXResolver(), RewriterBase.PACKAGING.attribute
         ).getReplaced();
         assertEquals(EXPECTED, actual);
     }
@@ -53,7 +53,7 @@ public class ScriptRewriterTest {
         final String expected = RewriteTestHelper.fetchUTF8("example_rewrite/script_external_expected.js").
                 replaceAll(" +\n", "\n");
         ParseResult rewritten = ScriptRewriter.getInstance().replaceLinks(
-                input, "http://example.com", MOCK_DATE, RewriteTestHelper.createMockResolver(), RewriterBase.PACKAGING.identity
+                input, "http://example.com", MOCK_DATE, RewriteTestHelper.createOXResolver(), RewriterBase.PACKAGING.identity
         );
 
         assertEquals(expected, rewritten.getReplaced());


### PR DESCRIPTION
The old version over-counted replaced & not found links for rewriting. This version cleans up the counting logic and fixes the error.