### PR TITLE
Soback 40 and 41 button to links and added to all images

### DIFF
--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -316,6 +316,7 @@
   height:auto;
   display: flex;
   flex-wrap: wrap;
+  padding-bottom:15px;
 }
 
 .singleEntryImages .singleEntryImagesHeadline {
@@ -334,6 +335,8 @@
 .singleEntryImages .previewImageContainer {
   display: inline-block;
   margin: 1em;
+  margin-bottom: 2em;
+  position: relative;
   flex-grow: 0;
   width: calc(25% -  2em);
   background-color: rgb(255, 250, 223);
@@ -482,6 +485,15 @@
   padding-bottom:5px;
 }
 
+.previewImageContainer:hover .imageButtonContainer {
+  transition: all 300ms linear 0s;
+  height:42px;
+  opacity:1;
+  padding-top:10px;
+  padding-bottom:5px;
+  bottom:-50px;
+}
+
 .images .column .columnImageContainer .number {
   color:var(--main-highlight-color);
   position: relative;
@@ -491,7 +503,7 @@
   text-align: right;
 }
 
-.images .imageButtonContainer {
+.images .imageButtonContainer, .previewImageContainer .imageButtonContainer {
   position: relative;
   height:20px;
   opacity:0;
@@ -504,11 +516,16 @@
 	margin-right: 5px;
 }
 
-.images .imageButtonContainer button {
+.previewImageContainer .imageButtonContainer {
+  position:absolute;
+  bottom:0px;
+}
+
+.images .imageButtonContainer a, .previewImageContainer .imageButtonContainer a {
   background-color: white;
 	//box-shadow: inset 0 0 7px var(--seethrough-black);
   border-radius: 0% 0 0% 0;
-  border:0px solid transparent;
+  border-bottom:2px solid transparent;
 	color:var(--main-highlight-color);
   float: right;
   background-color:transparent;
@@ -523,15 +540,17 @@
   text-align: center;
   font-size: 80%;
   padding:1px 0;
+  text-decoration: none;
 }
 
-.images .imageButtonContainer button:first-of-type {
+.images .imageButtonContainer a:first-of-type, .previewImageContainer .imageButtonContainer a:first-of-type {
   margin-left:5px;
   margin-right:0px;
 }
 
-.images .imageButtonContainer button:hover span {
-  font-weight:bold;
+.images .imageButtonContainer a:hover span, .previewImageContainer .imageButtonContainer a:hover span {
+  border-bottom:1px solid var(--main-highlight-color);
+
 }
 .singleEntryResult .imageEntry {
   max-width:200px;

--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -212,11 +212,11 @@ export default {
       console.log(selected)
       if(selected === 'imgSearch') {
         this.updateFutureSolrSettingImgSearch(!this.futureSolrSettings.imgSearch)
-        this.futureSolrSettings.imgSearch === true ? this.updateFutureSolrSettingUrlSearch(false) : null
+        this.futureSolrSettings.imgSearch ? this.updateFutureSolrSettingUrlSearch(false) : null
       }
       else if(selected === 'urlSearch') {
         this.updateFutureSolrSettingUrlSearch(!this.futureSolrSettings.urlSearch)
-        this.futureSolrSettings.urlSearch === true ? this.updateFutureSolrSettingImgSearch(false) : null
+        this.futureSolrSettings.urlSearch ? this.updateFutureSolrSettingImgSearch(false) : null
       }
     },
     clearResultsAndSearch() {

--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -91,10 +91,10 @@ export default {
     if(this.$router.history.current.query.q) {
       this.updateQuery(this.$router.history.current.query.q)
       this.futureQuery = this.$router.history.current.query.q
-      this.$router.history.current.query.facets ? this.updateSearchAppliedFacets(this.$router.history.current.query.facets) : null
-      this.$router.history.current.query.grouping === 'true' ? (this.updateSolrSettingGrouping(true), this.futureGrouped = true) : null
-      this.$router.history.current.query.imgSearch === 'true' ? (this.updateSolrSettingImgSearch(true), this.futureImgSearch = true) : null
-      this.$router.history.current.query.urlSearch === 'true' ? (this.updateSolrSettingUrlSearch(true), this.futureUrlSearch = true) : null
+      this.$router.history.current.query.facets ? this.updateSearchAppliedFacets(this.$router.history.current.query.facets) : this.updateSearchAppliedFacets('')
+      this.$router.history.current.query.grouping === 'true' ? (this.updateSolrSettingGrouping(true), this.futureGrouped = true) : (this.updateSolrSettingGrouping(false), this.futureGrouped = false)
+      this.$router.history.current.query.imgSearch === 'true' ? (this.updateSolrSettingImgSearch(true), this.futureImgSearch = true) : (this.updateSolrSettingImgSearch(false), this.futureImgSearch = false)
+      this.$router.history.current.query.urlSearch === 'true' ? (this.updateSolrSettingUrlSearch(true), this.futureUrlSearch = true) : (this.updateSolrSettingUrlSearch(false), this.futureUrlSearch = false)
       if(this.solrSettings.imgSearch) {
            this.requestImageSearch({query:this.query})
            this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
@@ -129,7 +129,7 @@ export default {
           this.futureUrlSearch !== this.solrSettings.urlSearch ||
           this.futureImgSearch !== this.solrSettings.imgSearch) 
         {
-        console.log('search params changed!')
+        console.log('search params changed!', this.query)
         this.clearResults()
         this.updateQuery(this.futureQuery)
         this.updateSolrSettingGrouping(this.futureGrouped)

--- a/src/js/src/components/SearchResults/ImageSearchResults.vue
+++ b/src/js/src/components/SearchResults/ImageSearchResults.vue
@@ -36,7 +36,7 @@ import HistoryRoutingUtils from './../../mixins/HistoryRoutingUtils'
 import SearchMasonryImage from './../SearchSingleItemComponents/SearchMasonryImage'
 
 export default {
-  name: 'AllSearchResults',
+  name: 'ImageSearchResults',
   components: {
     SearchMasonryImage
   },

--- a/src/js/src/components/SearchResults/PostSearchResults.vue
+++ b/src/js/src/components/SearchResults/PostSearchResults.vue
@@ -35,7 +35,7 @@ import ImageSearchResults from './ImageSearchResults'
 
 
 export default {
-  name: 'AllSearchResults',
+  name: 'PostSearchResults',
   components: {
     SearchSingleItemDefault: () => import('./../SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemDefault'),
     SearchSingleItemTweet: () => import('./../SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemTweet'),

--- a/src/js/src/components/SearchSingleItemComponents/SearchMasonryImage.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchMasonryImage.vue
@@ -12,10 +12,10 @@
                                     :index="row + number * rowNumber"
                                     @close-window="closeWindow" />
     <div class="imageButtonContainer">
-      <router-link :to="{ path: $_startImageSearch(result.hash)}">
+      <router-link :to="{ path: $_startImageSearchFromImage(result.hash)}">
         <span @click="$_addHistory('hash',result.hash)">Search for image</span>
       </router-link>
-      <router-link :to="{ path: $_startPageSearch(result.urlNorm)}">
+      <router-link :to="{ path: $_startPageSearchFromImage(result.urlNorm)}">
         <span @click="$_addHistory('links_images',result.urlNorm)">Pages linking to image</span>
       </router-link>
     </div>

--- a/src/js/src/components/SearchSingleItemComponents/SearchMasonryImage.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchMasonryImage.vue
@@ -12,12 +12,12 @@
                                     :index="row + number * rowNumber"
                                     @close-window="closeWindow" />
     <div class="imageButtonContainer">
-      <button @click="startImageSearch()">
-        <span>Search for image</span>
-      </button>
-      <button @click="startPageSearch()">
-        <span>Pages linking to image</span>
-      </button>
+      <router-link :to="{ path: $_startImageSearch(result.hash)}">
+        <span @click="$_addHistory('hash',result.hash)">Search for image</span>
+      </router-link>
+      <router-link :to="{ path: $_startPageSearch(result.urlNorm)}">
+        <span @click="$_addHistory('links_images',result.urlNorm)">Pages linking to image</span>
+      </router-link>
     </div>
   </div>
 </template>
@@ -27,13 +27,14 @@
 import { mapActions, mapState } from 'vuex'
 import SearchSingleItemFocusImage from './SearchSingleItemFocusImage'
 import HistoryRoutingUtils from './../../mixins/HistoryRoutingUtils'
+import ImageSearchUtils from './../../mixins/ImageSearchUtils'
 
 export default {
   name: 'SearchMasonryImage',
   components: {
     SearchSingleItemFocusImage
   },
-  mixins: [HistoryRoutingUtils],
+  mixins: [HistoryRoutingUtils, ImageSearchUtils],
   props: {
     result: {
       type: Object,
@@ -72,22 +73,6 @@ export default {
       updateSearchAppliedFacets:'updateSearchAppliedFacets',
       updateSolrSettingImgSearch:'updateSolrSettingImgSearch',
     }),
-    startPageSearch() {
-      this.updateQuery('links_images:"' + this.result.urlNorm + '"')
-      this.updateSearchAppliedFacets('')
-      this.updateSolrSettingImgSearch(false)
-      this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
-      this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
-      this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
-    },
-    startImageSearch() {
-      this.updateQuery('hash:"' + this.result.hash + '"')
-      this.updateSearchAppliedFacets('')
-      this.updateSolrSettingImgSearch(false)
-      this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
-      this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
-      this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
-    },
      toggleFullImage(index) {
       this.showFullImage !== null ? this.showFullImage = null : this.showFullImage = index
     },

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemImages.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemImages.vue
@@ -23,6 +23,14 @@
                                       :image="inputType === 'multiple' ? item.downloadUrl + '&height=200&width=200' : item"
                                       :index="index"
                                       @close-window="closeWindow" />
+      <div class="imageButtonContainer">
+        <router-link :to="{ path: $_startImageSearch(item.hash ? item.hash : hash )}">
+          <span @click="$_addHistory('hash', item.hash ? item.hash : hash)">Search for image</span>
+        </router-link>
+        <router-link :to="{ path: $_startPageSearch(item.urlNorm ? item.urlNorm : urlNorm)}">
+          <span @click="$_addHistory('links_images', item.urlNorm ? item.urlNorm : urlNorm)">Pages linking to image</span>
+        </router-link>
+      </div>
     </div>
   </div>
 </template>
@@ -32,12 +40,14 @@
 import { requestService } from '../../services/RequestService'
 import SearchSingleItemFocusImage from './SearchSingleItemFocusImage.vue'
 import configs from '../../configs'
+import ImageSearchUtils from './../../mixins/ImageSearchUtils'
 
 export default {
   name: 'SearchSingleItemImages',
   components: {  
     SearchSingleItemFocusImage
   },
+  mixins: [ImageSearchUtils],
   props: {
     offset: {
       type: Number,
@@ -50,7 +60,16 @@ export default {
     inputType: {
       type:String,
       required:true
+    },
+    hash: {
+      type:String,
+      required:true
+    },
+    urlNorm: {
+      type:String,
+      required: true
     }
+
   },
   data () {
     return {     

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemImages.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemImages.vue
@@ -24,10 +24,10 @@
                                       :index="index"
                                       @close-window="closeWindow" />
       <div class="imageButtonContainer">
-        <router-link :to="{ path: $_startImageSearch(item.hash ? item.hash : hash )}">
+        <router-link :to="{ path: $_startImageSearchFromImage(item.hash ? item.hash : hash )}">
           <span @click="$_addHistory('hash', item.hash ? item.hash : hash)">Search for image</span>
         </router-link>
-        <router-link :to="{ path: $_startPageSearch(item.urlNorm ? item.urlNorm : urlNorm)}">
+        <router-link :to="{ path: $_startPageSearchFromImage(item.urlNorm ? item.urlNorm : urlNorm)}">
           <span @click="$_addHistory('links_images', item.urlNorm ? item.urlNorm : urlNorm)">Pages linking to image</span>
         </router-link>
       </div>

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemDefault.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemDefault.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="singleEntryResult">
     <search-single-item-standard-info :rank="rankNumber" :result="result" />
-    <search-single-item-images :source="result.source_file_path" :offset="result.source_file_offset" input-type="multiple" />
+    <search-single-item-images :hash="result.hash"
+                               :url-norm="result.url_norm"
+                               :source="result.source_file_path"
+                               :offset="result.source_file_offset"
+                               input-type="multiple" />
     <search-single-item-all-data :id="result.id" />
   </div>
 </template>

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemImage.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemImage.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="singleEntryResult">
     <search-single-item-standard-info :result="result" :rank="rankNumber" />
-    <search-single-item-images :source="result.source_file_path" :offset="result.source_file_offset" input-type="singluar" />
+    <search-single-item-images :hash="result.hash"
+                               :url-norm="result.url_norm"
+                               :source="result.source_file_path"
+                               :offset="result.source_file_offset"
+                               input-type="singluar" />
     <search-single-item-all-data :id="result.id" />
   </div>
 </template>

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemTweet.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemTweet.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="singleEntryResult">
     <search-single-item-standard-info :rank="rankNumber" :result="result" />
-    <search-single-item-images :source="result.source_file_path" :offset="result.source_file_offset" input-type="multiple" />
+    <search-single-item-images :hash="result.hash"
+                               :url-norm="result.url_norm"
+                               :source="result.source_file_path"
+                               :offset="result.source_file_offset"
+                               input-type="multiple" />
     <search-single-item-all-data :id="result.id" />
   </div>
 </template>

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemWeb.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemTypes/SearchSingleItemWeb.vue
@@ -1,7 +1,11 @@
 <template>
   <div class="singleEntryResult">
     <search-single-item-standard-info :rank="rankNumber" :result="result" />
-    <search-single-item-images :source="result.source_file_path" :offset="result.source_file_offset" input-type="multiple" />
+    <search-single-item-images :hash="result.hash"
+                               :url-norm="result.url_norm" 
+                               :source="result.source_file_path" 
+                               :offset="result.source_file_offset" 
+                               input-type="multiple" />
     <search-single-item-all-data :id="result.id" />
   </div>
 </template>

--- a/src/js/src/mixins/HistoryRoutingUtils.js
+++ b/src/js/src/mixins/HistoryRoutingUtils.js
@@ -1,6 +1,8 @@
 export default {
   methods: {
     $_pushSearchHistory(destination, query, appliedFacets, solrSettings) {
+    // Should be deleted before production.
+    console.log('We pushed a history.')
     let newFacetUrl = appliedFacets !== '' ? '&facets=' + encodeURIComponent(appliedFacets) : ''
     let newOptionsUrl = '&offset=' + solrSettings.offset + '&grouping=' + solrSettings.grouping + '&imgSearch=' + solrSettings.imgSearch + '&urlSearch=' + solrSettings.urlSearch
     history.pushState({name: destination}, destination, '?q=' + query + newFacetUrl + newOptionsUrl)

--- a/src/js/src/mixins/ImageSearchUtils.js
+++ b/src/js/src/mixins/ImageSearchUtils.js
@@ -14,10 +14,10 @@ export default {
       updateSearchAppliedFacets:'updateSearchAppliedFacets',
       updateSolrSettingImgSearch:'updateSolrSettingImgSearch',
     }),
-    $_startPageSearch(searchItem) {
+    $_startPageSearchFromImage(searchItem) {
       return '/?q=' + 'links_images:"' + searchItem + '"' + '&offset=' + this.solrSettings.offset + '&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false'
     },
-    $_startImageSearch(searchItem) {
+    $_startImageSearchFromImage(searchItem) {
       return '/?q=' + 'hash:"' + searchItem + '"' + '&offset=' + this.solrSettings.offset + '&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false'
     },
     $_addHistory(field, searchItem) {

--- a/src/js/src/mixins/ImageSearchUtils.js
+++ b/src/js/src/mixins/ImageSearchUtils.js
@@ -1,0 +1,37 @@
+import HistoryRoutingUtils from './HistoryRoutingUtils'
+import { mapState, mapActions } from 'vuex'
+
+export default {
+  mixins: [HistoryRoutingUtils],
+  computed: {
+    ...mapState({
+      searchAppliedFacets: state => state.Search.searchAppliedFacets,
+      solrSettings: state => state.Search.solrSettings,
+    }),
+  },
+  methods: {
+    ...mapActions('Search', {
+      updateSearchAppliedFacets:'updateSearchAppliedFacets',
+      updateSolrSettingImgSearch:'updateSolrSettingImgSearch',
+    }),
+    $_startPageSearch(searchItem) {
+      return '/?q=' + 'links_images:"' + searchItem + '"' + '&offset=' + this.solrSettings.offset + '&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false'
+    },
+    $_startImageSearch(searchItem) {
+      return '/?q=' + 'hash:"' + searchItem + '"' + '&offset=' + this.solrSettings.offset + '&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false'
+    },
+    $_addHistory(field, searchItem) {
+      console.log('adding history with', field)
+      let query
+      if(field === 'hash') {
+        query = 'hash:"' + searchItem + '"'
+      } 
+      else if(field === 'links_images') {
+        query = 'links_images:"' + searchItem + '"'
+      }  
+      this.updateSearchAppliedFacets('')
+      this.updateSolrSettingImgSearch(false)
+      this.$_pushSearchHistory('SolrWayback', query, this.searchAppliedFacets, this.solrSettings)
+    },
+  }
+}

--- a/src/js/src/store/modules/search.store.js
+++ b/src/js/src/store/modules/search.store.js
@@ -13,6 +13,11 @@ const initialState = () => ({
     imgSearch:false,
     urlSearch:false
   },
+  futureSolrSettings:{
+    grouping:false,
+    imgSearch:false,
+    urlSearch:false
+  },
   loading:false,
 })
 
@@ -36,6 +41,15 @@ const actions = {
   },
   updateSolrSettingUrlSearch ( {commit}, param ) {
     commit('updateSolrSettingUrlSearchSuccess', param)
+  },
+  updateFutureSolrSettingGrouping ( {commit}, param ) {
+    commit('updateFutureSolrSettingGroupingSuccess', param)
+  },
+  updateFutureSolrSettingImgSearch ( {commit}, param ) {
+    commit('updateFutureSolrSettingImgSearchSuccess', param)
+  },
+  updateFutureSolrSettingUrlSearch ( {commit}, param ) {
+    commit('updateFutureSolrSettingUrlSearchSuccess', param)
   },
   updateSearchAppliedFacets ( {commit}, param ) {
     commit('updateSearchAppliedFacetsSuccess', param)
@@ -91,6 +105,15 @@ const mutations = {
   },
   updateSolrSettingUrlSearchSuccess(state, param) {
     state.solrSettings.urlSearch = param
+  },
+  updateFutureSolrSettingGroupingSuccess(state, param) {
+    state.futureSolrSettings.grouping = param
+  },
+  updateFutureSolrSettingImgSearchSuccess(state, param) {
+    state.futureSolrSettings.imgSearch = param
+  },
+  updateFutureSolrSettingUrlSearchSuccess(state, param) {
+    state.futureSolrSettings.urlSearch = param
   },
   updateSearchAppliedFacetsSuccess(state, param) {
     state.searchAppliedFacets = param

--- a/src/js/src/views/SolrWayback.vue
+++ b/src/js/src/views/SolrWayback.vue
@@ -54,7 +54,10 @@ export default {
       updateSearchAppliedFacets:'updateSearchAppliedFacets',
       updateSolrSettingGrouping:'updateSolrSettingGrouping',
       updateSolrSettingImgSearch:'updateSolrSettingImgSearch',
-      updateSolrSettingUrlSearch:'updateSolrSettingUrlSearch'
+      updateSolrSettingUrlSearch:'updateSolrSettingUrlSearch',
+      updateFutureSolrSettingGrouping:'updateFutureSolrSettingGrouping',
+      updateFutureSolrSettingImgSearch:'updateFutureSolrSettingImgSearch',
+      updateFutureSolrSettingUrlSearch:'updateFutureSolrSettingUrlSearch'
     }),
     onScroll(e) {
     e.target.documentElement.scrollTop > 0 ? this.scrolledFromTop = true : this.scrolledFromTop = false
@@ -66,9 +69,9 @@ export default {
   beforeRouteUpdate (to, from, next) {
     //console.log('route changed!',to)
     this.updateQuery(to.query.q)
-    to.query.grouping === 'true' ? this.updateSolrSettingGrouping(true) : this.updateSolrSettingGrouping(false)
-    to.query.imgSearch === 'true' ? this.updateSolrSettingImgSearch(true) : this.updateSolrSettingImgSearch(false)
-    to.query.urlSearch === 'true' ? this.updateSolrSettingUrlSearch(true) :  this.updateSolrSettingUrlSearch(false)
+    to.query.grouping === 'true' ? (this.updateSolrSettingGrouping(true), this.updateFiutureSolrSettingGrouping(true)) : (this.updateSolrSettingGrouping(false), this.updateFutureSolrSettingGrouping(false))
+    to.query.imgSearch === 'true' ? (this.updateSolrSettingImgSearch(true), this.updateFutureSolrSettingImgSearch(true)) : (this.updateSolrSettingImgSearch(false), this.updateFutureSolrSettingImgSearch(false))
+    to.query.urlSearch === 'true' ? (this.updateSolrSettingUrlSearch(true), this.updateFutureSolrSettingUrlSearch(true)) :  (this.updateSolrSettingUrlSearch(false), this.updateFutureSolrSettingUrlSearch(false))
     to.query.facets ? this.updateSearchAppliedFacets(to.query.facets) : this.updateSearchAppliedFacets('')
     if(this.solrSettings.imgSearch) {
       this.requestImageSearch({query:this.query})

--- a/src/js/src/views/SolrWayback.vue
+++ b/src/js/src/views/SolrWayback.vue
@@ -46,6 +46,8 @@ export default {
     }),
   },
   beforeRouteUpdate (to, from, next) {
+    //Should be deleted before production.
+    console.log('passed through beforeRouteUpdate',to, from)
     this.updateQuery(to.query.q)
     to.query.grouping === 'true' ? this.updateSolrSettingGrouping(true) : this.updateSolrSettingGrouping(false)
     to.query.imgSearch === 'true' ? this.updateSolrSettingImgSearch(true) : this.updateSolrSettingImgSearch(false)
@@ -53,15 +55,12 @@ export default {
     to.query.facets ? this.updateSearchAppliedFacets(to.query.facets) : this.updateSearchAppliedFacets('')
     if(this.solrSettings.imgSearch) {
       this.requestImageSearch({query:this.query})
-      return
     }
     else if(this.solrSettings.urlSearch) {
-      return
     } 
     else {
       this.requestSearch({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
       this.requestFacets({query:this.query, facets:this.searchAppliedFacets, options:this.solrSettings})
-      return
     }
   } 
 }


### PR DESCRIPTION
'Search for image' and 'pages linking to image' Added to pictures shown in regular posts (not just in image search). They appear on hover on the image.

Reworked both to be links instead of buttons

Moved the functions used to make the links/routes into mixin, as it's used by two different templates now.

Reworked the 3 variables futureGrouping, futureImgSearch and futureUrlSearch to be in the store, so they can be altered from other places (needed when searches are triggered by the beforeRouteUpdate in SolrWayback.vue that captures cases like this.

Did a little bit of styling. And renamed two templates that i'd forgotten :S
