### PR TITLE
Fixed encoding on field searches.

### DIFF
--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -94,8 +94,8 @@ export default {
   mounted () {
     //console.log(this.$router.history.current.query)
     if(this.$router.history.current.query.q) {
-      this.updateQuery(this.$router.history.current.query.q)
-      this.futureQuery = this.$router.history.current.query.q
+      this.updateQuery(encodeURIComponent(this.$router.history.current.query.q))
+      this.futureQuery = encodeURIComponent(this.$router.history.current.query.q)
       this.$router.history.current.query.facets ? this.updateSearchAppliedFacets(this.$router.history.current.query.facets) : this.updateSearchAppliedFacets('')
       this.$router.history.current.query.grouping === 'true' ? (this.updateSolrSettingGrouping(true), this.updateFutureSolrSettingGrouping(true)) : (this.updateSolrSettingGrouping(false), this.updateFutureSolrSettingGrouping(false))
       this.$router.history.current.query.imgSearch === 'true' ? (this.updateSolrSettingImgSearch(true), this.updateFutureSolrSettingImgSearch(true)) : (this.updateSolrSettingImgSearch(false), this.updateFutureSolrSettingImgSearch(false))

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemAllData.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemAllData.vue
@@ -118,7 +118,7 @@ export default {
     },
     searchFromAllValues(attribute, value) {
       this.allDataShown = !this.allDataShown
-      let searchString = attribute + ':"' + value + '"'
+      let searchString = attribute + ':"' + encodeURIComponent(value) + '"'
       this.updateQuery(searchString)
       this.updateSearchAppliedFacets('')
       this.requestSearch({query:searchString, facets:this.searchAppliedFacets, options:this.solrSettings})

--- a/src/js/src/mixins/ImageSearchUtils.js
+++ b/src/js/src/mixins/ImageSearchUtils.js
@@ -15,19 +15,19 @@ export default {
       updateSolrSettingImgSearch:'updateSolrSettingImgSearch',
     }),
     $_startPageSearchFromImage(searchItem) {
-      return '/?q=' + 'links_images:"' + searchItem + '"' + '&offset=' + this.solrSettings.offset + '&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false'
+      return '/?q=' + 'links_images:"' + encodeURIComponent(searchItem) + '"' + '&offset=' + this.solrSettings.offset + '&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false'
     },
     $_startImageSearchFromImage(searchItem) {
-      return '/?q=' + 'hash:"' + searchItem + '"' + '&offset=' + this.solrSettings.offset + '&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false'
+      return '/?q=' + 'hash:"' + encodeURIComponent(searchItem) + '"' + '&offset=' + this.solrSettings.offset + '&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false'
     },
     $_addHistory(field, searchItem) {
       console.log('adding history with', field)
       let query
       if(field === 'hash') {
-        query = 'hash:"' + searchItem + '"'
+        query = 'hash:"' + encodeURIComponent(searchItem) + '"'
       } 
       else if(field === 'links_images') {
-        query = 'links_images:"' + searchItem + '"'
+        query = 'links_images:"' + encodeURIComponent(searchItem) + '"'
       }  
       this.updateSearchAppliedFacets('')
       this.updateSolrSettingImgSearch(false)


### PR DESCRIPTION
This should fix the issue. Added encoding in the places where its needed before we fire off a search to the solr instance.

To summarize, it is when we do any kid of field search (from any of the fields in the full raw data or images)