### PR TITLE
Soback 82 navigation bug

### DIFF
--- a/src/js/src/App.vue
+++ b/src/js/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <div id="app">
-    <router-view />
+    <!-- En enforce component SolrWayback update when moving from '/' to '/search' -->
+    <router-view :key="$route.path" />
   </div>
 </template>
 <script>

--- a/src/js/src/components/AppliedSearchFacets.vue
+++ b/src/js/src/components/AppliedSearchFacets.vue
@@ -38,7 +38,7 @@ export default {
     removeFacet(index) {
       this.updateSolrSettingOffset(0)
       this.removeFromSearchAppliedFacets(index)
-      this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
+      this.$_pushSearchHistory('Search', this.query, this.searchAppliedFacets, this.solrSettings)
     }
   }
 }

--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -151,7 +151,7 @@ export default {
     launchNewSearch() {
       this.emptySearchAppliedFacets()
       this.updateSolrSettingOffset(0)
-      this.$_pushSearchHistory('SolrWayback', this.futureQuery, this.searchAppliedFacets, this.solrSettings)
+      this.$_pushSearchHistory('Search', this.futureQuery, this.searchAppliedFacets, this.solrSettings)
     }
   }
 }

--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -40,7 +40,7 @@ export default {
       let newFacet = '&fq=' + facetCategory + ':"' + facet + '"'
       this.updateSolrSettingOffset(0)
       this.addToSearchAppliedFacets(newFacet)
-      this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
+      this.$_pushSearchHistory('Search', this.query, this.searchAppliedFacets, this.solrSettings)
     }
   }
 }

--- a/src/js/src/components/SearchResults/ImageSearchResults.vue
+++ b/src/js/src/components/SearchResults/ImageSearchResults.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <span>Showing <span class="highlightText">{{ results.images.length }}</span> images matching <span class="highlightText">{{ query }}. </span> </span>
+    <span>Showing <span class="highlightText">{{ results.images.length }}</span> images matching query. </span>
     <div class="images">
       <div class="column 1">
         <search-masonry-image v-for="(result, index) in getOffsetArray(results.images,0)"

--- a/src/js/src/components/SearchResults/PostSearchResults.vue
+++ b/src/js/src/components/SearchResults/PostSearchResults.vue
@@ -2,11 +2,11 @@
   <div>
     <span v-if="!results.cardinality">
       <span>Showing <span class="highlightText">{{ solrSettings.offset }}</span>  - <span class="highlightText">{{ solrSettings.offset + 20 > results.numFound ? results.numFound : solrSettings.offset + 20 }}</span> of </span>
-      <span class="highlightText">{{ results.numFound.toLocaleString("en") }}</span> entries matching <span class="highlightText">{{ query }}. </span>
+      <span class="highlightText">{{ results.numFound.toLocaleString("en") }}</span> entries matching query.
     </span>
     <span v-if="results.cardinality">
       <span>Showing <span class="highlightText">{{ solrSettings.offset }}</span> - <span class="highlightText">{{ solrSettings.offset + 20 > results.cardinality ? results.cardinality : solrSettings.offset + 20 }}</span> of </span>
-      <span class="highlightText">{{ results.cardinality.toLocaleString("en") }}</span> unique entries matching <span class="highlightText">{{ query }} </span>
+      <span class="highlightText">{{ results.cardinality.toLocaleString("en") }}</span> unique entries matching query 
       <span class="tonedDownText">(total hits: {{ results.numFound.toLocaleString("en") }})</span>.
     </span>
     <div class="pagingContainer">

--- a/src/js/src/components/SearchResults/PostSearchResults.vue
+++ b/src/js/src/components/SearchResults/PostSearchResults.vue
@@ -66,11 +66,11 @@ export default {
     }),
     getNextResults() {
       this.updateSolrSettingOffset(this.solrSettings.offset + this.hitsPerPage)
-      this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
+      this.$_pushSearchHistory('Search', this.query, this.searchAppliedFacets, this.solrSettings)
     },
     getPreviousResults() {
       this.updateSolrSettingOffset(this.solrSettings.offset - this.hitsPerPage)
-      this.$_pushSearchHistory('SolrWayback', this.query, this.searchAppliedFacets, this.solrSettings)
+      this.$_pushSearchHistory('Search', this.query, this.searchAppliedFacets, this.solrSettings)
     },
     SingleEntryComponent(type) {
       //console.log('search result type', type)

--- a/src/js/src/components/SearchSingleItemComponents/SearchSingleItemAllData.vue
+++ b/src/js/src/components/SearchSingleItemComponents/SearchSingleItemAllData.vue
@@ -115,7 +115,7 @@ export default {
       const searchString = attribute + ':"' + encodeURIComponent(value) + '"'
       this.updateQuery(searchString)
       this.emptySearchAppliedFacets()
-      this.$_pushSearchHistory('SolrWayback', searchString, this.searchAppliedFacets, this.solrSettings)
+      this.$_pushSearchHistory('Search', searchString, this.searchAppliedFacets, this.solrSettings)
     },
     toggleShownData(index) {
       index === this.currentDataShown ? this.currentDataShown = null : this.currentDataShown = index

--- a/src/js/src/components/SearchUploadFile.vue
+++ b/src/js/src/components/SearchUploadFile.vue
@@ -49,7 +49,7 @@ export default {
      requestService.uploadFileRequest(this.fileToUpload[0])
         .then(response => {
          this.updateQuery(this.createRequestQuery(response.data))
-         this.$_pushSearchHistory('SolrWayback', this.createRequestQuery(response.data), this.searchAppliedFacets, this.solrSettings)
+         this.$_pushSearchHistory('Search', this.createRequestQuery(response.data), this.searchAppliedFacets, this.solrSettings)
         })
         .catch((error) => {
           this.setNotification({

--- a/src/js/src/mixins/ImageSearchUtils.js
+++ b/src/js/src/mixins/ImageSearchUtils.js
@@ -14,10 +14,10 @@ export default {
       updateSolrSettingImgSearch:'updateSolrSettingImgSearch',
     }),
     $_startPageSearchFromImage(searchItem) {
-      return '/?query=' + 'links_images:"' + encodeURIComponent(searchItem) + '"' + '&offset=0&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false&facets='
+      return '/search?query=' + 'links_images:"' + encodeURIComponent(searchItem) + '"' + '&offset=0&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false&facets='
     },
     $_startImageSearchFromImage(searchItem) {
-      return '/?query=' + 'hash:"' + encodeURIComponent(searchItem) + '"' + '&offset=0&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false&facets='
+      return '/search?query=' + 'hash:"' + encodeURIComponent(searchItem) + '"' + '&offset=0&grouping=' + this.solrSettings.grouping + '&imgSearch=false&urlSearch=false&facets='
     },
   }
 }

--- a/src/js/src/mixins/SearchUtils.js
+++ b/src/js/src/mixins/SearchUtils.js
@@ -38,7 +38,7 @@ export default {
     deliverSearchRequest(futureQuery, updateHistory) {
       this.requestSearch({query:futureQuery, facets:this.searchAppliedFacets, options:this.solrSettings})
       this.requestFacets({query:futureQuery, facets:this.searchAppliedFacets, options:this.solrSettings})
-      updateHistory ? this.$_pushSearchHistory('SolrWayback', futureQuery, this.searchAppliedFacets, this.solrSettings) : null
+      updateHistory ? this.$_pushSearchHistory('Search', futureQuery, this.searchAppliedFacets, this.solrSettings) : null
     },
     //Deliver an URL search
     deliverUrlSearchRequest(futureQuery, updateHistory) {
@@ -46,7 +46,7 @@ export default {
       if(this.$_validateUrlSearchPrefix(this.DisectQueryForNewUrlSearch(futureQuery))) {
         this.requestUrlSearch({query:this.DisectQueryForNewUrlSearch(futureQuery), facets:this.searchAppliedFacets, options:this.solrSettings})
         this.requestFacets({query:'url_norm:"' + this.DisectQueryForNewUrlSearch(futureQuery) + '"', facets:this.searchAppliedFacets, options:this.solrSettings})
-        updateHistory ? this.$_pushSearchHistory('SolrWayback', this.DisectQueryForNewUrlSearch(futureQuery), this.searchAppliedFacets, this.solrSettings) : null
+        updateHistory ? this.$_pushSearchHistory('Search', this.DisectQueryForNewUrlSearch(futureQuery), this.searchAppliedFacets, this.solrSettings) : null
       }
       else {
         this.setNotification({
@@ -60,7 +60,7 @@ export default {
     // Deliver an image search
     deliverImgSearchRequest(futureQuery, updateHistory) {
       this.requestImageSearch({query:futureQuery})
-      updateHistory ? this.$_pushSearchHistory('SolrWayback', futureQuery, this.searchAppliedFacets, this.solrSettings) : null
+      updateHistory ? this.$_pushSearchHistory('Search', futureQuery, this.searchAppliedFacets, this.solrSettings) : null
     },
     // Check if there has been any changes to the query
     queryHasChanged(query) {

--- a/src/js/src/router/index.js
+++ b/src/js/src/router/index.js
@@ -5,10 +5,14 @@ import SolrWayback from '../views/SolrWayback.vue'
 Vue.use(VueRouter)
 
 const routes = [
-
   {
-    path: '/:query?',
+    path: '/',
     name: 'SolrWayback',
+    component: SolrWayback,
+  },
+  {
+    path: '/search/:query?',
+    name: 'Search',
     component: SolrWayback,
   },
   {

--- a/src/js/src/views/SolrWayback.vue
+++ b/src/js/src/views/SolrWayback.vue
@@ -74,7 +74,7 @@ export default {
     }
   },
   beforeRouteUpdate (to, from, next) {
-    //console.log('route changed!',to.query, from.query)
+    console.log('route changed!',to.query, from.query)
     // Check if any of our params have changed. Could be refactored into a nice functon.
     if(this.checkForChangesBetweenRouteQueries(to, from)) {
       //console.log('we doing a route search')

--- a/src/js/src/views/SolrWayback.vue
+++ b/src/js/src/views/SolrWayback.vue
@@ -74,7 +74,7 @@ export default {
     }
   },
   beforeRouteUpdate (to, from, next) {
-    console.log('route changed!',to.query, from.query)
+    //console.log('route changed!',to.query, from.query)
     // Check if any of our params have changed. Could be refactored into a nice functon.
     if(this.checkForChangesBetweenRouteQueries(to, from)) {
       //console.log('we doing a route search')

--- a/src/main/webapp/WEB-INF/rewrite.config
+++ b/src/main/webapp/WEB-INF/rewrite.config
@@ -6,4 +6,5 @@ RewriteCond %{REQUEST_URI} !^/solrwayback/services/.*
 RewriteRule ^. /solrwayback_index_page.html [L]
 RewriteRule ^.calendar*$ /solrwayback_index_page.html [L]
 RewriteRule ^.pageharvestdata*$ /solrwayback_index_page.html [L]
+RewriteRule ^.search*$ /solrwayback_index_page.html [L]
 


### PR DESCRIPTION
This works on localhost:8080 now.

Added a /search route that allows params - and all search routes now lead to /search/:query.

'/' allows no querys anymore, and only serves as the main page. When you search you go to /search afterwards.

Small change to not display the query in the search result anymore - as requested by PO.

I've done some rigorous testing - but feel free to give it a whirl too.