### PR TITLE
Soback 60 select all in cvs export

### DIFF
--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -272,6 +272,19 @@ margin: 1em 0 0 0;
   text-decoration:none;
 }
 
+.exportContent .exportSelectAll {
+	float: right;
+	background-color: transparent;
+	border: 0px;
+	color: var(--main-highlight-color);
+	cursor: pointer;
+	border-bottom: 2px solid var(--main-highlight-color);
+}
+
+.exportContent .nonSelectedExportHeadline {
+  display:inline-block;
+}
+
 .pagingContainer button:disabled {
   color: rgba(30,30,30,0.5);
 	border: 2px solid rgba(30,30,30,0.5);

--- a/src/js/src/components/SearchResults/SearchResultExport.vue
+++ b/src/js/src/components/SearchResults/SearchResultExport.vue
@@ -99,18 +99,18 @@ export default {
   methods: {
     exportToWARC() {
      return this.searchAppliedFacets ? 
-       this.returnExportUrl() + 'warc?query=' + this.query + this.searchAppliedFacets :
+       this.returnExportUrl() + 'warc?query=' + this.query + this.searchAppliedFacets.join('') :
        this.returnExportUrl() + 'warc?query=' + this.query
     },
     exportToExtendedWARC() {
       return this.searchAppliedFacets ? 
-      this.returnExportUrl() + 'warcExpanded?query=' + this.query + this.searchAppliedFacets :
+      this.returnExportUrl() + 'warcExpanded?query=' + this.query + this.searchAppliedFacets.join('') :
       this.returnExportUrl() + 'warcExpanded?query=' + this.query
     },
     exportToCSV() {
       let fields = this.selectedArray.join(',')
       return this.searchAppliedFacets ? 
-      this.returnExportUrl() + 'csv?query=' + this.query + this.searchAppliedFacets + '&fields=' + fields :
+      this.returnExportUrl() + 'csv?query=' + this.query + this.searchAppliedFacets.join('') + '&fields=' + fields :
       this.returnExportUrl() + 'csv?query=' + this.query + '&fields=' + fields
     },
     returnExportUrl() {

--- a/src/js/src/components/SearchResults/SearchResultExport.vue
+++ b/src/js/src/components/SearchResults/SearchResultExport.vue
@@ -49,7 +49,11 @@
           </div>
         </div>
         <div class="exportContent">
-          <h2>Non selected</h2>
+          <h2 class="nonSelectedExportHeadline">
+            Non selected
+          </h2> <button class="exportSelectAll" @click="selectAllFields()">
+            Select all
+          </button>
           <div v-for="(item, index) in nonSelectedArray" :key="'nonSelected' + index" class="fieldItem">
             {{ item }}  <div class="fieldItem actions">
               <button class="select" @click="toggleItemInArrays(selectedArray, nonSelectedArray, item, index,'nonSelectedArray')">
@@ -114,6 +118,14 @@ export default {
     },
     toggleCsvExportOptions() {
       this.csvExportOpen = !this.csvExportOpen
+      if(this.csvExportOpen === false) {
+        this.selectedArray = this.getSplitFieldsSelected(this.configs.exportOptions.csvFields)
+        this.nonSelectedArray = this.getSplitFieldsNotSelected(this.configs.exportOptions.csvFields)
+      }
+    },
+    selectAllFields() {
+      this.selectedArray = this.configs.exportOptions.csvFields.replace(/ /g, '').split(',')
+      this.nonSelectedArray = []
     },
     getSplitFieldsSelected(fields) {
       return fields.replace(/ /g, '').split(',').slice(0,9)


### PR DESCRIPTION
Added and styled button to select all fields
Made so the fields reset if window is closed
Fixed minor bug that caused downloads of sets found with facets to be empty - the facets weren't put together right after converting them from string to array.