### PR TITLE
Soback 107: Add gzip support for WARC export

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/export/StreamingSolrWarcExportBufferedInputStream.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/export/StreamingSolrWarcExportBufferedInputStream.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Locale;
 
 import dk.kb.netarchivesuite.solrwayback.solr.SolrGenericStreaming;
+import dk.kb.netarchivesuite.solrwayback.util.StreamBridge;
+import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.slf4j.Logger;
@@ -19,6 +21,7 @@ import dk.kb.netarchivesuite.solrwayback.parsers.ArcHeader2WarcHeader;
 import dk.kb.netarchivesuite.solrwayback.parsers.ArcParserFileResolver;
 import dk.kb.netarchivesuite.solrwayback.parsers.WarcParser;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
+import sun.nio.ch.IOUtil;
 
 public class StreamingSolrWarcExportBufferedInputStream extends InputStream{
 
@@ -26,10 +29,23 @@ public class StreamingSolrWarcExportBufferedInputStream extends InputStream{
 
   private final SolrGenericStreaming solrClient;
   private final int maxRecords;
+  private final boolean gzip;
   private final List<InputStream> entryStreams = new ArrayList<>(); // Ideally a FIFO buffer, but not worth the hassle
   private int docsWarcRead;
   private int docsArcRead;
 
+  /**
+   * Create a stream with WARC-content from the records referenced by the solrClient.
+   * The parts of the stream is lazy loaded and has no practical limit on sizes.
+   * @param solrClient delivers Solr documents specifying the records to stream.
+   * @param maxRecords the maximum number of records to deliver.
+   * @param gzip if true, the WARC-records will be gzipped. If false, they will be delivered as-is.
+   */
+  public StreamingSolrWarcExportBufferedInputStream(SolrGenericStreaming solrClient, int maxRecords, boolean gzip) {
+    this.solrClient = solrClient;
+    this.maxRecords = maxRecords;
+    this.gzip = gzip;
+  }
 
   @Override
   public int read() throws IOException {
@@ -73,11 +89,6 @@ public class StreamingSolrWarcExportBufferedInputStream extends InputStream{
     return totalRead == 0 ? -1 : totalRead; // -1 signals EOS
   }
 
-  public StreamingSolrWarcExportBufferedInputStream(SolrGenericStreaming solrClient, int maxRecords) {
-    this.solrClient = solrClient;
-    this.maxRecords = maxRecords;
-  }
-
   private void loadMore() {
     try {
       if (docsWarcRead > maxRecords) { //Stop loading more
@@ -95,13 +106,29 @@ public class StreamingSolrWarcExportBufferedInputStream extends InputStream{
         String source_file_path = (String) doc.getFieldValue("source_file_path");
         long offset = (Long) doc.getFieldValue("source_file_offset");
 
-        ArcEntry warcEntry = addHeadersReturnEntry(source_file_path, offset);
-        if (warcEntry == null) {
+        EntryAndHeaders entryAndHeaders = getWARCEntryAndHeaderStream(source_file_path, offset);
+        if (entryAndHeaders == null) {
           log.warn(String.format(Locale.ROOT, "Unable to resolve (W)ARC entry %s#%d for %s",
                                  source_file_path, offset, doc.getFieldValue("id")));
           continue;
         }
 
+        if (gzip) {
+          entryStreams.add(StreamBridge.outputToGzipInput(out -> {
+            try {
+              IOUtils.copy(entryAndHeaders.headers, out);
+              if (entryAndHeaders.entry.getBinaryArraySize() > 0) {
+                IOUtils.copy()
+                entryStreams.add(warcEntry.getBinaryLazyLoad());
+              }
+              entryStreams.add(new ByteArrayInputStream("\r\n\r\n".getBytes(WarcParser.WARC_HEADER_ENCODING)) );
+            } catch (IOException e) {
+              throw new RuntimeException(
+                      "IOException writing entry to gzip stream: " + entryAndHeaders.entry.getUrl(), e);
+            }
+
+          }))
+        }
         //Do this for both arc/warc 
         if ( warcEntry.getBinary().length > 0){
           entryStreams.add(warcEntry.getBinaryLazyLoad());
@@ -114,6 +141,74 @@ public class StreamingSolrWarcExportBufferedInputStream extends InputStream{
       e.printStackTrace();
     }
 
+  }
+
+  private EntryAndHeaders getWARCEntryAndHeaderStream(String source_file_path, long offset) {
+    ArcEntry warcEntry;
+    InputStream headers;
+
+    // ARC
+    if (source_file_path.toLowerCase().endsWith(".arc") || source_file_path.toLowerCase().endsWith(".arc.gz")){
+      //log.info("skipping Arc record:"+source_file_path);
+      try{
+        warcEntry = ArcParserFileResolver.getArcEntry(source_file_path, offset);
+      }
+      catch(Exception e){ //This will only happen if warc file is not found etc. Should not happen for real.
+        log.warn("Error loading arc:"+source_file_path,e);
+        return null;
+      }
+
+
+      String warcHeader = ArcHeader2WarcHeader.arcHeader2WarcHeader(warcEntry);
+      // The header is (normally) fairly small, so we hold it in memory
+      try {
+        headers = new ByteArrayInputStream(warcHeader.getBytes(WarcParser.WARC_HEADER_ENCODING));
+      } catch (UnsupportedEncodingException e) {
+        String message = String.format(Locale.ROOT, "UnsupportedEncodingException for fixed charset '%s' while adding " +
+                                                    "headers for %s#%d. This should not happen",
+                                       WarcParser.WARC_HEADER_ENCODING, source_file_path, offset);
+        log.warn(message, e);
+        throw new RuntimeException(message, e);
+      }
+      docsArcRead++;
+    } else {
+      try{
+        warcEntry = ArcParserFileResolver.getArcEntry(source_file_path,offset);
+      }
+      catch(Exception e){ //This will only happen if warc file is not found etc. Should not happen for real.
+        log.warn("Error loading warc:"+source_file_path,e);
+        return null;
+      }
+
+
+      String warc2HeaderEncoding = warcEntry.getContentEncoding();
+      Charset charset = Charset.forName(WarcParser.WARC_HEADER_ENCODING); //Default if none define or illegal charset
+
+      if (warc2HeaderEncoding != null){
+        try{
+          charset = Charset.forName(warc2HeaderEncoding);
+        }
+        catch (Exception e){
+          if (!"binary".equals(warc2HeaderEncoding)){ //This is not a real encoding
+            log.warn("unknown charset:"+warc2HeaderEncoding);
+          }
+        }
+      }
+
+      // The header is (normally) fairly small, so we hold it in memory
+      headers = new ByteArrayInputStream(warcEntry.getHeader().getBytes(charset));
+      docsWarcRead++;
+    }
+    return new EntryAndHeaders(warcEntry, headers);
+  }
+  private static class EntryAndHeaders {
+    public final ArcEntry entry;
+    public final InputStream headers;
+
+    public EntryAndHeaders(ArcEntry entry, InputStream headers) {
+      this.entry = entry;
+      this.headers = headers;
+    }
   }
 
   /**

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -412,7 +412,7 @@ public static String generateDomainResultGraph(@QueryParam("q") String q, @Query
               expandResources, avoidDuplicates, query, filterqueries);
 
       // TODO: Why do we have a max of 1M?
-      return new StreamingSolrWarcExportBufferedInputStream(solr, 1000000); //1M max. results just for now
+      return new StreamingSolrWarcExportBufferedInputStream(solr, 1000000, false); //1M max. results just for now
     }
  
    

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
@@ -2,6 +2,7 @@ package dk.kb.netarchivesuite.solrwayback.parsers;
 
 import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.RandomAccessFile;
 import java.nio.channels.Channels;
@@ -236,7 +237,7 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
   }
   
 
-  public static BufferedInputStream lazyLoadBinary(String arcFilePath, long arcEntryPosition) throws Exception{
+  public static BufferedInputStream lazyLoadBinary(String arcFilePath, long arcEntryPosition) throws Exception {
       ArcEntry arcEntry = new ArcEntry(); // We just throw away the header info anyway 
       
       if (arcFilePath.endsWith(".gz")){ //It is zipped

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/StreamBridge.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/StreamBridge.java
@@ -30,7 +30,7 @@ public class StreamBridge {
     private static final Logger log = LoggerFactory.getLogger(StreamBridge.class);
 
     private static final ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
-        Thread t = new Thread("StreamBridge");
+        Thread t = new Thread(r, "StreamBridge");
         t.setDaemon(true);
         return t;
     });

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/StreamBridge.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/StreamBridge.java
@@ -1,0 +1,91 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.security.auth.login.AccountLockedException;
+import java.io.*;
+import java.util.concurrent.*;
+import java.util.function.Consumer;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Pipes streamed output from a provider to an InputStream.
+ */
+public class StreamBridge {
+    private static final Logger log = LoggerFactory.getLogger(StreamBridge.class);
+
+    private static final ExecutorService executor = Executors.newSingleThreadExecutor(r -> {
+        Thread t = new Thread("StreamBridge");
+        t.setDaemon(true);
+        return t;
+    });
+
+    /**
+     * The provider is responsible for adding content to the provided OutputStream. The added content will be available
+     * in the form of the returned InputStream.
+     *
+     * The provider will be called inside of a Thread and the coupling of the OutputStream and the InputStream will be
+     * buffer-based, so there is low memory overhead, no matter how much content is produced.
+     *
+     * The stream will be automatically closed after the producer has finished processing.
+     *
+     * Important: This method uses a single-threaded executor. Ensure that the returned InputStream is fully depleted
+     * and closed before calling subsequent InputStreams delivered by this method or there will be a deadlock.
+     * @param provider the provider of the bytes to pipe to the returned InputStream.
+     * @return an InputStream which will be populated with data from the provider.
+     */
+    public static InputStream outputToInput(Consumer<OutputStream> provider) throws IOException {
+        PipedOutputStream out = new PipedOutputStream();
+        PipedInputStream in = new PipedInputStream(out);
+        executor.submit(() -> {
+            provider.accept(out);
+            try {
+                out.close();
+            } catch (IOException e) {
+                log.error("IOException closing piped stream", e);
+            }
+        });
+        return in;
+    }
+
+    /**
+     * The provider is responsible for adding content to the provided OutputStream. The added content will be available
+     * in the form of the returned InputStream, which will automatically be gzipped.
+     *
+     * The provider will be called inside of a Thread and the coupling of the OutputStream and the InputStream will be
+     * buffer-based, so there is low memory overhead, no matter how much content is produced.
+     *
+     * The stream will be automatically closed after the producer has finished processing.
+     *
+     * Important: This method uses a single-threaded executor. Ensure that the returned InputStream is fully depleted
+     * and closed before calling subsequent InputStreams delivered by this method or there will be a deadlock.
+     * @param provider the provider of the bytes to pipe to the returned InputStream.
+     * @return an InputStream which will be populated with data from the provider and gzipped.
+     */
+    public static InputStream outputToGzipInput(Consumer<OutputStream> provider) throws IOException {
+        return outputToInput(out -> {
+            try {
+                GZIPOutputStream gzip = new GZIPOutputStream(out);
+                provider.accept(gzip);
+                gzip.close();
+            } catch (IOException e) {
+                throw new RuntimeException("IOException with gzip", e);
+            }
+        });
+    }
+}

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarcStreaming.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarcStreaming.java
@@ -1,25 +1,22 @@
 package dk.kb.netarchivesuite.solrwayback.parsers;
 
 
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.InputStream;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Locale;
-
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
 import dk.kb.netarchivesuite.solrwayback.export.StreamingSolrWarcExportBufferedInputStream;
-import dk.kb.netarchivesuite.solrwayback.solr.SolrGenericStreaming;
-import dk.kb.netarchivesuite.solrwayback.solr.SolrStreamingExportClient;
-import org.apache.commons.io.FileUtils;
-
 import dk.kb.netarchivesuite.solrwayback.facade.Facade;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
+import dk.kb.netarchivesuite.solrwayback.solr.SolrGenericStreaming;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.junit.Test;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Locale;
+import java.util.zip.GZIPInputStream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -43,25 +40,45 @@ public class TestExportWarcStreaming extends UnitTestUtils {
     }
 
     {
-      SolrDocument doc = new SolrDocument();
-      doc.addField("id", "MockedDocument");
-      doc.addField("source_file_path", WARC);
-      doc.addField("source_file_offset", OFFSET);
-
-      SolrDocumentList docs = new SolrDocumentList();
-      docs.setMaxScore(1.0f);
-      docs.setNumFound(1);
-      docs.setStart(System.currentTimeMillis());
-      docs.add(doc);
-
-      SolrGenericStreaming mockedSolr = mock(SolrGenericStreaming.class);
-      when(mockedSolr.nextDocuments()).thenReturn(docs).thenReturn(null); // Return docs on first call, then null
+      SolrGenericStreaming mockedSolr = getMockedSolrStream(WARC, OFFSET);
 
       StreamingSolrWarcExportBufferedInputStream exportStream = new
-              StreamingSolrWarcExportBufferedInputStream(mockedSolr, 1);
+              StreamingSolrWarcExportBufferedInputStream(mockedSolr, 1, false);
 
       byte[] exportedBytes = new byte[EXPECTED_EXPORT_LENGTH];
-      long exported = exportStream.read(exportedBytes);
+      int exported = IOUtils.read(exportStream, exportedBytes);
+      assertEquals("Expected the right number of bytes to be read", EXPECTED_EXPORT_LENGTH, exported);
+      assertEquals("There should be no more content in the export stream", -1, exportStream.read());
+
+      assertBinaryEnding(upFrontBinary, exportedBytes);
+    }
+  }
+
+  // TODO: Add test for multiple entries
+  @Test
+  public void testGzipExport() throws Exception {
+    final String WARC = getFile("compressions_warc/transfer_compression_none.warc.gz").getCanonicalPath();
+    final long OFFSET = 881;
+    final int EXPECTED_CONTENT_LENGTH = 246;
+    final int EXPECTED_EXPORT_LENGTH = 1102;
+
+    byte[] upFrontBinary;
+    {
+      ArcEntry warcEntry = WarcParser.getWarcEntry(WARC, OFFSET, true);
+      upFrontBinary = warcEntry.getBinary();
+      assertEquals("Length for up front load should be as expected", EXPECTED_CONTENT_LENGTH, upFrontBinary.length);
+    }
+
+    {
+      SolrGenericStreaming mockedSolr = getMockedSolrStream(WARC, OFFSET);
+
+      StreamingSolrWarcExportBufferedInputStream exportStream = new
+              StreamingSolrWarcExportBufferedInputStream(mockedSolr, 1, true);
+      GZIPInputStream gis = new GZIPInputStream(exportStream);
+
+      byte[] exportedBytes = new byte[EXPECTED_EXPORT_LENGTH];
+
+      int exported = IOUtils.read(gis, exportedBytes);
       assertEquals("Expected the right number of bytes to be read", EXPECTED_EXPORT_LENGTH, exported);
       assertEquals("There should be no more content in the export stream", -1, exportStream.read());
 
@@ -128,5 +145,23 @@ public class TestExportWarcStreaming extends UnitTestUtils {
     }
     
   }
-  
+
+  private SolrGenericStreaming getMockedSolrStream(String WARC, long OFFSET) throws Exception {
+    SolrDocument doc = new SolrDocument();
+    doc.addField("id", "MockedDocument");
+    doc.addField("source_file_path", WARC);
+    doc.addField("source_file_offset", OFFSET);
+
+    SolrDocumentList docs = new SolrDocumentList();
+    docs.setMaxScore(1.0f);
+    docs.setNumFound(1);
+    docs.setStart(System.currentTimeMillis());
+    docs.add(doc);
+
+    SolrGenericStreaming mockedSolr = mock(SolrGenericStreaming.class);
+    when(mockedSolr.nextDocuments()).thenReturn(docs).thenReturn(null); // Return docs on first call, then null
+    return mockedSolr;
+  }
+
+
 }


### PR DESCRIPTION
This pull request makes it optional if exported WARC records should be as-is or gzipped.