### PR TITLE
Removed paging and facets when no hits are returned from the respective services.

### DIFF
--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -51,16 +51,12 @@ export default {
     },
     checkForFacets(facets) {
     //we test if the variable exists first - can cause problems if it's not set yet.
-    if(facets) {
       let fate = false
-      Object.keys(facets).forEach(function(item) {
-        facets[item].length !== 0 ? fate = true : null
-      })
-      return fate
-      }
-      else {
-        return false
-      }
+      if(facets) { 
+        Object.keys(facets).forEach(function(item) {
+          facets[item].length !== 0 ? fate = true : null 
+        }) 
+      } return fate
     }
   }
 }

--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -1,8 +1,10 @@
 <template>
   <div class="facets">
-    <h2>Facets</h2>
+    <h2 v-if="checkForFacets(facets.facet_fields)">
+      Facets
+    </h2>
     <div v-if="facetLoading && !loading" class="spinner" />
-    <div v-if="!facetLoading && facets.facet_fields" class="allFacets">
+    <div v-if="!facetLoading && checkForFacets(facets.facet_fields)" class="allFacets">
       <div v-for="(facetCategory, index) in Object.entries(facets.facet_fields)" :key="index" class="facetCategory">
         <div class="facetCategoryName">
           {{ facetCategory[0] }}
@@ -46,6 +48,19 @@ export default {
       this.updateSolrSettingOffset(0)
       this.addToSearchAppliedFacets(newFacet)
       this.$_pushSearchHistory('Search', this.query, this.searchAppliedFacets, this.solrSettings)
+    },
+    checkForFacets(facets) {
+    //we test if the variable exists first - can cause problems if it's not set yet.
+    if(facets) {
+      let fate = false
+      Object.keys(facets).forEach(function(item) {
+        facets[item].length !== 0 ? fate = true : null
+      })
+      return fate
+      }
+      else {
+        return false
+      }
     }
   }
 }

--- a/src/js/src/components/searchResults/PostSearchResults.vue
+++ b/src/js/src/components/searchResults/PostSearchResults.vue
@@ -9,7 +9,7 @@
       <span class="highlightText">{{ results.cardinality.toLocaleString("en") }}</span> unique entries matching query 
       <span class="tonedDownText">(total hits: {{ results.numFound.toLocaleString("en") }})</span>.
     </span>
-    <div class="pagingContainer">
+    <div v-if="results.cardinality !== 0 && results.numFound !== 0" class="pagingContainer">
       <button :disabled="solrSettings.offset < 20" @click="getPreviousResults()">
         Previous 20
       </button>
@@ -24,7 +24,7 @@
                  :result="result"
                  :rank-number="index" />
     </div>
-    <div class="pagingContainer">
+    <div v-if="results.cardinality !== 0 && results.numFound !== 0" class="pagingContainer">
       <button :disabled="solrSettings.offset < 20" @click="getPreviousResults()">
         Previous 20
       </button>


### PR DESCRIPTION
removed paging from post results when no results are returned (numFound/cardinality)

Removed facets when none are returned (check of the facets.facet_fields object. If we ever decide that OTHER facets should be put into play from any of the other arrays, this needs to be updated)

@jorntx for code review
@thomasegense for functionality