### PR TITLE
start year for visualizations is now configurable in Tomcat properties

### DIFF
--- a/src/js/src/components/ngrams/chartsCore/chartConfigs/chartOptionsCore.js
+++ b/src/js/src/components/ngrams/chartsCore/chartConfigs/chartOptionsCore.js
@@ -1,5 +1,6 @@
 import Config from '../../netarchive/configs'
 import SearchHelper from '../../searchHelper'
+import APP_CONFIGS from '../../../../configs'
 
 /**
  * Here we keep all the specific logic and options
@@ -13,7 +14,7 @@ export default {
   */
   getChartLabels: () => {
     let labels = []
-    let start = Config.START_YEAR
+    let start = APP_CONFIGS.visualizations.ngram.startYear
     const end = Config.END_YEAR
       while (start < end) {
         labels.push(start)

--- a/src/js/src/components/ngrams/netarchive/configs.js
+++ b/src/js/src/components/ngrams/netarchive/configs.js
@@ -1,7 +1,6 @@
 import APP_CONFIGS from '../../../configs'
 export default {
   SERVICE_URL : 'services/search/',
-  START_YEAR : '1998',
   END_YEAR: '2021',
   BASE_SEARCH_URL: () => {
       let searchPrefix = window.location.pathname.split('/')[1] === 'search' ? '' : 'search'

--- a/src/js/src/configs/index.js
+++ b/src/js/src/configs/index.js
@@ -8,6 +8,13 @@ export default {
     csvAllowed:false,
     csvFields:''
   },
+
+  visualizations:{
+    ngram:{
+      startYear:''
+    }
+  },
+
   leaflet: {
     attribution:'',
     source:'',

--- a/src/js/src/main.js
+++ b/src/js/src/main.js
@@ -20,7 +20,8 @@ Axios.get('services/frontend/properties/solrwaybackweb/')
         configs.leaflet.source = response.data['leaflet.source']
         configs.leaflet.map.latitude = response.data['maps.latitude']
         configs.leaflet.map.longitude = response.data['maps.longitude']
-        configs.leaflet.map.radius = response.data['maps.radius']        
+        configs.leaflet.map.radius = response.data['maps.radius']
+        configs.visualizations.ngram.startYear = response.data['archive.start.year']       
         initializeVue()
     })
     .catch(error => initializeVue())

--- a/src/js/src/services/RequestService.js
+++ b/src/js/src/services/RequestService.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 import dataTransformationHelper from './dataTransformationHelper'
-import NgramConfig from '../components/ngrams/netarchive/configs'
+import APP_CONFIGS from '../configs'
 
 export const requestService = {
   fireSearchRequest,
@@ -190,7 +190,7 @@ function getDomainStatistics(domain) {
 }
 
 function getNgramNetarchive(query){
-  const url = `services/frontend/smurf/text/?q=${encodeURIComponent(query)}&startyear=${NgramConfig.START_YEAR}`
+  const url = `services/frontend/smurf/text/?q=${encodeURIComponent(query)}&startyear=${APP_CONFIGS.visualizations.ngram.startYear}`
   return axios.get(url).then(response => {
     return response.data
   }).catch(error => {


### PR DESCRIPTION
Made start year configurable from server properties.

@jesperlauridsen not much to it but in a future release we have to look at how we handle properties. They are somewhat scattered throughout the project, have inconsistent naming and the serverside properties are loaded into the project in a clumsy way.

I will make a jira for this.