### PR TITLE
Soback 129 linebreak in query textarea

### DIFF
--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -14,7 +14,7 @@
                   ? decideActiveClassesForQueryBox()
                   : ''"
                 :placeholder="solrSettings.urlSearch ? 'Enter search url' : 'Enter search term'"
-                @keydown.enter.prevent="launchNewSearch()"
+                @keydown.enter="checkKeyPresses()"
                 @input="getSizeOfTextArea()" />
       <button type="button" class="searchGuidelinesButton" @click.prevent="openSelectedModal('guidelines')">
         ?
@@ -134,6 +134,8 @@ export default {
         //If this is resulted by a backbutton going to the first time the user landed on the page, we want a clean slate.
         this.resetSearchState()
       }
+      document.getElementById('query').value = this.futureQuery
+      this.getSizeOfTextArea()
   },
   
   methods: {
@@ -152,10 +154,12 @@ export default {
       updateCurrentModal:'updateCurrentModal'
     }),
     getSizeOfTextArea() {
-      console.log('we resize')
       let textarea = document.getElementById('query')
       textarea.style.height = '1px'
       textarea.style.height = (textarea.scrollHeight) + 'px'
+    },
+    checkKeyPresses() {
+      !event.shiftKey ? (event.preventDefault(),this.launchNewSearch()) : null
     },
     selectSearchMethod(selected) {
       if(selected === 'imgSearch') {

--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -7,7 +7,7 @@
       </transition>
       <textarea id="query"
                 ref="query"
-                v-model="futureQuery"
+                v-model="decodedFutureQuery"
                 type="text"
                 rows="1"
                 autofocus
@@ -98,6 +98,9 @@ export default {
     }
   },
   computed: {
+    decodedFutureQuery: function() {
+      return decodeURIComponent(this.futureQuery)
+    },
     ...mapState({
       query: state => state.Search.query,
       preNormalizedQuery: state => state.Search.preNormalizedQuery,

--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -7,7 +7,7 @@
       </transition>
       <textarea id="query"
                 ref="query"
-                v-model="decodedFutureQuery"
+                v-model="futureQuery"
                 type="text"
                 rows="1"
                 autofocus
@@ -98,9 +98,6 @@ export default {
     }
   },
   computed: {
-    decodedFutureQuery: function() {
-      return decodeURIComponent(this.futureQuery)
-    },
     ...mapState({
       query: state => state.Search.query,
       preNormalizedQuery: state => state.Search.preNormalizedQuery,
@@ -114,7 +111,7 @@ export default {
   },
   watch: {
     query: function (val) {
-      this.futureQuery  = val
+      this.futureQuery  = decodeURIComponent(val)
     },
   },
   mounted () {

--- a/src/js/src/components/SearchBox.vue
+++ b/src/js/src/components/SearchBox.vue
@@ -6,6 +6,7 @@
         <span v-if="solrSettings.urlSearch" class="urlSearchHelper">URL:</span>
       </transition>
       <textarea id="query"
+                ref="query"
                 v-model="futureQuery"
                 type="text"
                 rows="1"
@@ -135,7 +136,7 @@ export default {
         //If this is resulted by a backbutton going to the first time the user landed on the page, we want a clean slate.
         this.resetSearchState()
       }
-      document.getElementById('query').value = this.futureQuery
+      this.$refs.query.value = this.futureQuery
       this.$_getSizeOfTextArea('query')
   },
   
@@ -179,8 +180,7 @@ export default {
       this.preNormalizeQuery = null
       this.resetSearchState()
       //Make sure the query textarea is returned to its original size, regardless of what it was before.
-      let textarea = document.getElementById('query')
-      textarea.style.height = '1px'
+      this.$refs.query.style.height = '1px'
     },
     decideActiveClassesForQueryBox() {
       const isPrefixUrlNorm = this.futureQuery.substring(0,8) === 'url_norm'

--- a/src/js/src/components/ToolboxComponents/GephiExport.vue
+++ b/src/js/src/components/ToolboxComponents/GephiExport.vue
@@ -7,6 +7,7 @@
       <div class="gephiQueryContainer">
         <h3>Query</h3>
         <textarea id="gephiQuery"
+                  ref="gephiQuery"
                   v-model="query"
                   type="text"
                   rows="1"

--- a/src/js/src/mixins/SearchUtils.js
+++ b/src/js/src/mixins/SearchUtils.js
@@ -72,7 +72,7 @@ export default {
       this.updatePreNormalizedQuery(null)
       this.clearResults()
       !pagnation ? this.clearFacets() : null
-      this.updateQuery(encodeURIComponent(futureQuery))
+      this.updateQuery(futureQuery)
     },
     // Disect the query for URL searching
     DisectQueryForNewUrlSearch(futureQuery) {

--- a/src/js/src/mixins/SearchUtils.js
+++ b/src/js/src/mixins/SearchUtils.js
@@ -23,6 +23,7 @@ export default {
       requestSearch:'requestSearch',
       requestImageSearch:'requestImageSearch',
       requestUrlSearch:'requestUrlSearch',
+      requestNormalizedFacets:'requestNormalizedFacets',
       requestFacets:'requestFacets'
 
     }),
@@ -45,7 +46,7 @@ export default {
       this.updatePreNormalizedQuery(futureQuery)
       if(this.$_validateUrlSearchPrefix(this.DisectQueryForNewUrlSearch(futureQuery))) {
         this.requestUrlSearch({query:this.DisectQueryForNewUrlSearch(futureQuery), facets:this.searchAppliedFacets, options:this.solrSettings})
-        this.requestFacets({query:'url_norm:"' + this.DisectQueryForNewUrlSearch(futureQuery) + '"', facets:this.searchAppliedFacets, options:this.solrSettings})
+        this.requestNormalizedFacets({query:this.DisectQueryForNewUrlSearch(futureQuery), facets:this.searchAppliedFacets, options:this.solrSettings})
         updateHistory ? this.$_pushSearchHistory('Search', this.DisectQueryForNewUrlSearch(futureQuery), this.searchAppliedFacets, this.solrSettings) : null
       }
       else {
@@ -98,7 +99,7 @@ export default {
         this.deliverUrlSearchRequest(futureQuery , updateHistory)
       }
       else {
-        this.deliverSearchRequest(encodeURIComponent(futureQuery), updateHistory, pagnation)
+        this.deliverSearchRequest(futureQuery, updateHistory, pagnation)
       }
     }
   }

--- a/src/js/src/mixins/SearchUtils.js
+++ b/src/js/src/mixins/SearchUtils.js
@@ -71,7 +71,7 @@ export default {
       this.updatePreNormalizedQuery(null)
       this.clearResults()
       !pagnation ? this.clearFacets() : null
-      this.updateQuery(futureQuery)
+      //this.updateQuery(futureQuery)
     },
     // Disect the query for URL searching
     DisectQueryForNewUrlSearch(futureQuery) {

--- a/src/js/src/mixins/SearchUtils.js
+++ b/src/js/src/mixins/SearchUtils.js
@@ -71,7 +71,7 @@ export default {
       this.updatePreNormalizedQuery(null)
       this.clearResults()
       !pagnation ? this.clearFacets() : null
-      //this.updateQuery(futureQuery)
+      this.updateQuery(encodeURIComponent(futureQuery))
     },
     // Disect the query for URL searching
     DisectQueryForNewUrlSearch(futureQuery) {
@@ -98,7 +98,7 @@ export default {
         this.deliverUrlSearchRequest(futureQuery , updateHistory)
       }
       else {
-        this.deliverSearchRequest(futureQuery, updateHistory, pagnation)
+        this.deliverSearchRequest(encodeURIComponent(futureQuery), updateHistory, pagnation)
       }
     }
   }

--- a/src/js/src/mixins/SearchboxUtils.js
+++ b/src/js/src/mixins/SearchboxUtils.js
@@ -1,9 +1,8 @@
 export default {
   methods: {
     $_getSizeOfTextArea(id) {
-      let textarea = document.getElementById(id)
-      textarea.style.height = '1px'
-      textarea.style.height = textarea.scrollHeight + 'px'
+      this.$refs[id].style.height = '1px'
+      this.$refs[id].style.height = this.$refs[id].scrollHeight + 'px'
     },
   }
 }

--- a/src/js/src/services/RequestService.js
+++ b/src/js/src/services/RequestService.js
@@ -68,7 +68,7 @@ function fireImageSearchRequest(query) {
 function fireFacetRequest (query, facets, options) {
   let optionString = '&start=' + options.offset + '&grouping=' + options.grouping
   // Split url and move to config
-  const url = 'services/frontend/solr/search/facets/' + `?query=${query + facets.join('') + optionString}`
+  const url = 'services/frontend/solr/search/facets/' + `?query=${encodeURIComponent(query) + facets.join('') + optionString}`
   return axios.get(
     url).then(response => {
     //console.log('facets', response.data.facet_counts)

--- a/src/js/src/services/RequestService.js
+++ b/src/js/src/services/RequestService.js
@@ -26,7 +26,7 @@ export const requestService = {
 function fireSearchRequest (query, facets, options) {
   let optionString = '&start=' + options.offset + '&grouping=' + options.grouping
   // Split url and move to config
-  const url = 'services/frontend/solr/search/results/' + `?query=${query + facets.join('') + optionString}`
+  const url = 'services/frontend/solr/search/results/' + `?query=${encodeURIComponent(query) + facets.join('') + optionString}`
   return axios.get(
     url, {
       transformResponse: [


### PR DESCRIPTION
So, this should make it possible to make linebreaks by pressing SHIFT+Enter in the search-field, and search *should* work when you do so. This is gonna need some rigorous testing to make sure nothing is broken. As far as I've seen, it works as it's supposed to.  You should now be able to:

use linebreaks (by SHIFT+Enter)
Search with said query
And c/p the URL into a new browserwindow and still get the linebreaks + results when you open a new site with the URL.
And the textarea should have a size accordingly to the content of the query the whole time.

@tokee for rigorous testing
@jorntx for code review