### PR TITLE
Soback 124 links on facets and documents

### DIFF
--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -94,6 +94,11 @@
   cursor: pointer;
 }
 
+.SingleEntryAllData .td.clickAble a {
+  text-decoration: none;
+  color:black;
+}
+
 .SingleEntryAllData .td.clickAble:hover, .gephiQueryContainer td:hover { 
   background-color:var(--secondary-highlight-color)
 }
@@ -423,6 +428,16 @@ margin-left:40px;
 	text-overflow: ellipsis;
   cursor: pointer;
   text-transform: lowercase;
+}
+
+.facetItem a {
+  text-decoration: none;
+  color:black;
+}
+
+.facetItem a:hover {
+  text-decoration: none;
+  color:var(--main-highlight-color);
 }
 
 .facetItem:before {

--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -12,7 +12,9 @@
         <div v-for="(facet, facetIndex) in facetCategory[1]"
              :key="facetIndex"
              :class="facetIndex % 2 === 0 ? 'facetItem' : 'facetCount'">
-          <a v-if="facetIndex % 2 === 0" :href="getFacetSelectionLink(facetCategory, facet)"> {{ facet || 'Unknown' }}</a>
+          <router-link v-if="facetIndex % 2 === 0" :to="{ path: getFacetSelectionLink(facetCategory, facet) }">
+            {{ facet || 'Unknown' }}
+          </router-link>
           <span v-else>{{ "(" + facet.toLocaleString("en") + ")" }}</span>
         </div>
       </div>

--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -11,9 +11,9 @@
         </div> 
         <div v-for="(facet, facetIndex) in facetCategory[1]"
              :key="facetIndex"
-             :class="facetIndex % 2 === 0 ? 'facetItem' : 'facetCount'"
-             @click="facetIndex % 2 === 0 ? applyFacet(facetCategory[0], facet) : null">
-          {{ facetIndex % 2 === 0 ? facet || "Unknown" : "(" + facet.toLocaleString("en") + ")" }}
+             :class="facetIndex % 2 === 0 ? 'facetItem' : 'facetCount'">
+          <a v-if="facetIndex % 2 === 0" :href="getFacetSelectionLink(facetCategory, facet)"> {{ facet || 'Unknown' }}</a>
+          <span v-else>{{ "(" + facet.toLocaleString("en") + ")" }}</span>
         </div>
       </div>
     </div>
@@ -43,11 +43,10 @@ export default {
       updateSolrSettingOffset:'updateSolrSettingOffset',
       addToSearchAppliedFacets:'addToSearchAppliedFacets',
     }),
-    applyFacet(facetCategory, facet) {
-      let newFacet = '&fq=' + facetCategory + ':"' + facet + '"'
-      this.updateSolrSettingOffset(0)
-      this.addToSearchAppliedFacets(newFacet)
-      this.$_pushSearchHistory('Search', this.query, this.searchAppliedFacets, this.solrSettings)
+    getFacetSelectionLink(facetCategory, facet) {
+      const newFacet = encodeURIComponent('&fq=' + facetCategory[0] + ':"' + facet + '"')
+      console.log(newFacet)
+      return `/search?query=${encodeURIComponent(this.query)}&offset=0&grouping=${this.solrSettings.grouping}&imgSearch=${this.solrSettings.imgSearch}&urlSearch=${this.solrSettings.urlSearch}&facets=${encodeURIComponent(this.searchAppliedFacets.join(''))}${newFacet}`
     },
     checkForFacets(facets) {
     //we test if the variable exists first - can cause problems if it's not set yet.

--- a/src/js/src/components/searchSingleItemComponents/SearchSingleItemAllData.vue
+++ b/src/js/src/components/searchSingleItemComponents/SearchSingleItemAllData.vue
@@ -26,9 +26,9 @@
                class="td content clickAble">
             <span v-for="(singleLine, newIndex) in singleObject[1]"
                   :key="newIndex"
-                  :class="determinePlaceAndVisiblity(index, newIndex)"
-                  @click="singleObject[0] !== 'content' ? searchFromAllValues(singleObject[0], singleLine) : null">
-              {{ singleLine }} <br>
+                  :class="determinePlaceAndVisiblity(index, newIndex)">
+              <a v-if="singleObject[0] !== 'content'" :href="createLinkToValueSearch(singleObject[0], singleLine)"> {{ singleLine }}</a>
+              <br>
             </span>
             <button v-if="singleObject[1].length > arrayShownLimit"
                     :key="index + '-button' "
@@ -38,10 +38,12 @@
             </button>
           </div>
           <div v-if="singleObject[1].constructor !== Array" 
-               :class="singleObject[0] === 'content' ? 'td content' : 'td content clickAble'" 
-               @click="singleObject[0] === 'content' ? null : searchFromAllValues(singleObject[0], singleObject[1])">
-            <span :class="singleObject[0] === 'content' ? '' : 'singleEntry'">
-              {{ singleObject[0] === 'content' ? displayContentValue(singleObject[1]) : singleObject[1] }}
+               :class="singleObject[0] === 'content' ? 'td content' : 'td content clickAble'">
+            <a v-if="singleObject[0] !== 'content'" :href="createLinkToValueSearch(singleObject[0], singleObject[1])" class="singleEntry">
+              {{ singleObject[1] }}
+            </a>
+            <span v-if="singleObject[0] === 'content'">
+              {{ displayContentValue(singleObject[1]) }}
             </span>
           </div>
           <button v-if="singleObject[0] === 'content' && singleObject[1].length > contentShownLength" 
@@ -147,6 +149,9 @@ export default {
       this.updateSolrSettingUrlSearch(false)
       this.emptySearchAppliedFacets()
       this.$_pushSearchHistory('Search', searchString, this.searchAppliedFacets, this.solrSettings)
+    },
+    createLinkToValueSearch(attribute, value) {
+      return `/search?query=${attribute}:${encodeURIComponent(value)}&offset=0&grouping=${this.solrSettings.grouping}&imgSearch=false&urlSearch=false&facets=${this.searchAppliedFacets.join('')}`
     },
     toggleShownData(index) {
       index === this.currentDataShown ? this.currentDataShown = null : this.currentDataShown = index

--- a/src/js/src/components/searchSingleItemComponents/SearchSingleItemAllData.vue
+++ b/src/js/src/components/searchSingleItemComponents/SearchSingleItemAllData.vue
@@ -26,11 +26,13 @@
                class="td content clickAble">
             <span v-for="(singleLine, newIndex) in singleObject[1]"
                   :key="newIndex"
+                  
                   :class="determinePlaceAndVisiblity(index, newIndex)">
-              <a v-if="singleObject[0] !== 'content'" :href="createLinkToValueSearch(singleObject[0], singleLine)"> {{ singleLine }}</a>
+              <router-link v-if="singleObject[0] !== 'content'" :to="{ path: createLinkToValueSearch(singleObject[0], singleLine) }"> {{ singleLine }} </router-link>
               <br>
             </span>
-            <button v-if="singleObject[1].length > arrayShownLimit"
+            <button v-if="
+                      single-object-1-length> arrayShownLimit"
                     :key="index + '-button' "
                     class="attributeButton"
                     @click="toggleShownData(index)">
@@ -39,9 +41,9 @@
           </div>
           <div v-if="singleObject[1].constructor !== Array" 
                :class="singleObject[0] === 'content' ? 'td content' : 'td content clickAble'">
-            <a v-if="singleObject[0] !== 'content'" :href="createLinkToValueSearch(singleObject[0], singleObject[1])" class="singleEntry">
+            <router-link v-if="singleObject[0] !== 'content'" :to="{ path: createLinkToValueSearch(singleObject[0], singleObject[1]) }" class="singleEntry">
               {{ singleObject[1] }}
-            </a>
+            </router-link>
             <span v-if="singleObject[0] === 'content'">
               {{ displayContentValue(singleObject[1]) }}
             </span>

--- a/src/js/src/components/searchSingleItemComponents/SearchSingleItemAllData.vue
+++ b/src/js/src/components/searchSingleItemComponents/SearchSingleItemAllData.vue
@@ -31,8 +31,7 @@
               <router-link v-if="singleObject[0] !== 'content'" :to="{ path: createLinkToValueSearch(singleObject[0], singleLine) }"> {{ singleLine }} </router-link>
               <br>
             </span>
-            <button v-if="
-                      single-object-1-length> arrayShownLimit"
+            <button v-if="singleObject[1].length > arrayShownLimit"
                     :key="index + '-button' "
                     class="attributeButton"
                     @click="toggleShownData(index)">

--- a/src/js/src/components/searchSingleItemComponents/SearchSingleItemAllData.vue
+++ b/src/js/src/components/searchSingleItemComponents/SearchSingleItemAllData.vue
@@ -151,7 +151,7 @@ export default {
       this.$_pushSearchHistory('Search', searchString, this.searchAppliedFacets, this.solrSettings)
     },
     createLinkToValueSearch(attribute, value) {
-      return `/search?query=${attribute}:${encodeURIComponent(value)}&offset=0&grouping=${this.solrSettings.grouping}&imgSearch=false&urlSearch=false&facets=${this.searchAppliedFacets.join('')}`
+      return `/search?query=${attribute}:"${encodeURIComponent(value)}"&offset=0&grouping=${this.solrSettings.grouping}&imgSearch=false&urlSearch=false&facets=${encodeURIComponent(this.searchAppliedFacets.join(''))}`
     },
     toggleShownData(index) {
       index === this.currentDataShown ? this.currentDataShown = null : this.currentDataShown = index

--- a/src/js/src/mixins/SearchUtils.js
+++ b/src/js/src/mixins/SearchUtils.js
@@ -72,7 +72,7 @@ export default {
       this.updatePreNormalizedQuery(null)
       this.clearResults()
       !pagnation ? this.clearFacets() : null
-      this.updateQuery(encodeURIComponent(futureQuery))
+      this.updateQuery(futureQuery)
     },
     // Disect the query for URL searching
     DisectQueryForNewUrlSearch(futureQuery) {


### PR DESCRIPTION
Links in document expanded fields and facets are now router-links, meaning you can open them in a different tab, and even see the URL.

@thomasegense for test of functionality

@jorntx for codereview