### PR TITLE
Fixed error where encoding was done when it shouldn't be.

### DIFF
--- a/src/js/src/mixins/SearchUtils.js
+++ b/src/js/src/mixins/SearchUtils.js
@@ -72,7 +72,7 @@ export default {
       this.updatePreNormalizedQuery(null)
       this.clearResults()
       !pagnation ? this.clearFacets() : null
-      this.updateQuery(encodeURIComponent(futureQuery))
+      this.updateQuery(futureQuery)
     },
     // Disect the query for URL searching
     DisectQueryForNewUrlSearch(futureQuery) {


### PR DESCRIPTION
This was wrongfully added again - possibly because of a mixup with what branches was merged into master first and last - Removing this encoding *should* make all well again.