### PR TITLE
Soback 114 load more facets on demand

### DIFF
--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -420,13 +420,18 @@ margin-left:40px;
 
 .facetCategory .moreFacets {
 	margin-top: 10px;
-	display: inline-block;
+  display: inline-block;
+  margin-left: 15px;
 }
 
 .facetCategory .moreFacets .facetArrow {
   color: var(--main-highlight-color);
   font-weight:bold;
   text-align: center;
+}
+
+.facetCategory .moreFacets .facetArrow.up {
+  margin-top: -10px;
 }
 
 .facetCategory .moreFacets .moreFacetText {
@@ -666,7 +671,11 @@ margin-left:40px;
   transition: all 300ms linear 0s;
 }
 
-.images .column .columnImageContainer .loader, .previewImageContainer .loader {
+.facets .extraFacetsloading {
+  margin-left:15px !important;
+}
+
+.images .column .columnImageContainer .loader, .previewImageContainer .loader, .facets .extraFacetsloading {
   content: '';
 	position: relative;
 	width: 30px;

--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -437,6 +437,14 @@ margin-left:40px;
 .facetCategory .moreFacets .moreFacetText {
   cursor: pointer;
   color:var(--main-highlight-color);
+  background-color: transparent;
+  border:0px;
+  font-size: 100%;
+}
+
+.facetCategory .moreFacets .moreFacetText:disabled {
+  cursor: default;
+  color:var(--seethrough-black);
 }
 
 .facetItem {

--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -413,6 +413,22 @@ margin-left:40px;
   margin-bottom: 20px;
 }
 
+.facetCategory .moreFacets {
+	margin-top: 10px;
+	display: inline-block;
+}
+
+.facetCategory .moreFacets .facetArrow {
+  color: var(--main-highlight-color);
+  font-weight:bold;
+  text-align: center;
+}
+
+.facetCategory .moreFacets .moreFacetText {
+  cursor: pointer;
+  color:var(--main-highlight-color);
+}
+
 .facetItem {
   float: left;
   margin-right: 5px;

--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -16,7 +16,8 @@
           {{ facetIndex % 2 === 0 ? facet || "Unknown" : "(" + facet.toLocaleString("en") + ")" }}
         </div>
         <div v-show="extraFacetsLoading" class="extraFacetsloading" />
-        <div v-if="facetCategory[1].length >= 20 && !extraFacetsLoading" class="moreFacets">
+        <!-- here we're excluding the crawl_year facets, because OP don't want a show more on those -->
+        <div v-if="facetCategory[1].length >= 20 && !extraFacetsLoading && facetCategory[0] !== 'crawl_year'" class="moreFacets">
           <div v-if="facetCategory[1].length > 20" class="facetArrow up">
             ︿
           </div>
@@ -76,7 +77,6 @@ export default {
     },
     requestAdditionalFacets(facetArea) {
       this.extraFacetsLoading = true
-      console.log(this.query, this.facets)
       let structuredQuery = this.query + this.searchAppliedFacets.join('')
       requestService.getAddonFacets(facetArea, this.query).then(result => (this.constructNewFacets(result, facetArea), this.extraFacetsLoading = false), error => (console.log('No additional facets found.'),this.extraFacetsLoading = false))
     },
@@ -87,7 +87,6 @@ export default {
       this.addSpecificRequestedFacets(facets)
     },
     constructNewFacets(result, facetArea) {
-      console.log(result)
       let facets = JSON.parse(JSON.stringify(this.facets))
       facets['facet_fields'][facetArea] = result.facet_counts.facet_fields[facetArea]
       this.addSpecificRequestedFacets(facets)

--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -15,15 +15,15 @@
              @click="facetIndex % 2 === 0 ? applyFacet(facetCategory[0], facet) : null">
           {{ facetIndex % 2 === 0 ? facet || "Unknown" : "(" + facet.toLocaleString("en") + ")" }}
         </div>
-        <div v-show="extraFacetsLoading" class="extraFacetsloading" />
+        <div v-show="extraFacetLoading === facetCategory[0]" class="extraFacetsloading" />
         <!-- here we're excluding the crawl_year facets, because OP don't want a show more on those -->
-        <div v-if="facetCategory[1].length >= 20 && !extraFacetsLoading && facetCategory[0] !== 'crawl_year'" class="moreFacets">
+        <div v-if="facetCategory[1].length >= 20 && facetCategory[0] !== 'crawl_year'" class="moreFacets">
           <div v-if="facetCategory[1].length > 20" class="facetArrow up">
             ︿
           </div>
-          <div class="moreFacetText" @click="determineFacetAction(facetCategory[0], facetCategory[1].length)">
+          <button :disabled="!!extraFacetLoading" class="moreFacetText" @click="determineFacetAction(facetCategory[0], facetCategory[1].length)">
             {{ determineText(facetCategory[0], facetCategory[1].length) }} 
-          </div>
+          </button>
           <div v-if="facetCategory[1].length === 20" class="facetArrow down">
             ﹀
           </div>
@@ -43,19 +43,15 @@ import { requestService } from '../services/RequestService'
 export default {
   name: 'SearchFacetOptions',
   mixins: [HistoryRoutingUtils],
-  data () {
-    return {  
-      extraFacetsLoading:false
-    }
-  },
   computed: {
     ...mapState({
       searchAppliedFacets: state => state.Search.searchAppliedFacets,
       facets: state => state.Search.facets,
       query: state => state.Search.query,
       solrSettings: state => state.Search.solrSettings,
+      loading: state => state.Search.loading,
       facetLoading: state => state.Search.facetLoading,
-      loading: state => state.Search.loading
+      extraFacetLoading: state => state.Search.extraFacetLoading
     }),
   },
   methods: {
@@ -77,9 +73,8 @@ export default {
       return length <= 20 ? 'more ' + facet + 's' : 'less ' + facet + 's'
     },
     requestAdditionalFacets(facetArea) {
-      this.extraFacetsLoading = true
       let structuredQuery = this.query + this.searchAppliedFacets.join('')
-      this.addSpecificRequestedFacets({facet:facetArea, query:structuredQuery}).then(this.extraFacetsLoading = false)
+      this.addSpecificRequestedFacets({facet:facetArea, query:structuredQuery})
     },
     applyFacet(facetCategory, facet) {
       let newFacet = '&fq=' + facetCategory + ':"' + facet + '"'

--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -15,9 +15,15 @@
              @click="facetIndex % 2 === 0 ? applyFacet(facetCategory[0], facet) : null">
           {{ facetIndex % 2 === 0 ? facet || "Unknown" : "(" + facet.toLocaleString("en") + ")" }}
         </div>
-        <div v-if="facetCategory[1].length >= 20">
-          <div @click="determineFacetAction(facetCategory[0], facetCategory[1].length)">
-            {{ determineText(facetCategory[0], facetCategory[1].length) }}
+        <div v-if="facetCategory[1].length >= 20" class="moreFacets">
+          <div v-if="facetCategory[1].length > 20" class="facetArrow">
+            ︿
+          </div>
+          <div class="moreFacetText" @click="determineFacetAction(facetCategory[0], facetCategory[1].length)">
+            {{ determineText(facetCategory[0], facetCategory[1].length) }} 
+          </div>
+          <div v-if="facetCategory[1].length === 20" class="facetArrow">
+            ﹀
           </div>
         </div>
       </div>
@@ -44,9 +50,6 @@ export default {
       facetLoading: state => state.Search.facetLoading,
       loading: state => state.Search.loading
     }),
-    shownEntities(facet) {
-      return facet
-    },
   },
   methods: {
     ...mapActions('Search', {
@@ -55,15 +58,11 @@ export default {
       addSpecificRequestedFacets:'addSpecificRequestedFacets'
     }),
     determineFacetAction(facet, length) {
-      console.log(length)
       if(length === 20) {
         this.requestAdditionalFacets(facet)
       }
       else if(length > 20) {
-
-      }
-      else {
-
+        this.removeAdditionalFacets(facet)
       }
     },
     determineText(facet, length) {
@@ -72,9 +71,13 @@ export default {
     requestAdditionalFacets(facetArea) {
       console.log(this.query, this.facets)
       let structuredQuery = this.query + this.searchAppliedFacets.join('')
-      let obj = {...this.facets}
       requestService.getAddonFacets(facetArea, this.query).then(result => this.constructNewFacets(result, facetArea), error => console.log('No additional facets found.'))
-      this.addSpecificRequestedFacets(obj)
+    },
+    removeAdditionalFacets(facetArea) {
+      let structuredQuery = this.query + this.searchAppliedFacets.join('')
+      let facets = JSON.parse(JSON.stringify(this.facets))
+      facets['facet_fields'][facetArea] = facets['facet_fields'][facetArea].splice(0,20)
+      this.addSpecificRequestedFacets(facets)
     },
     constructNewFacets(result, facetArea) {
       console.log(result)

--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -15,14 +15,15 @@
              @click="facetIndex % 2 === 0 ? applyFacet(facetCategory[0], facet) : null">
           {{ facetIndex % 2 === 0 ? facet || "Unknown" : "(" + facet.toLocaleString("en") + ")" }}
         </div>
-        <div v-if="facetCategory[1].length >= 20" class="moreFacets">
-          <div v-if="facetCategory[1].length > 20" class="facetArrow">
+        <div v-show="extraFacetsLoading" class="extraFacetsloading" />
+        <div v-if="facetCategory[1].length >= 20 && !extraFacetsLoading" class="moreFacets">
+          <div v-if="facetCategory[1].length > 20" class="facetArrow up">
             ︿
           </div>
           <div class="moreFacetText" @click="determineFacetAction(facetCategory[0], facetCategory[1].length)">
             {{ determineText(facetCategory[0], facetCategory[1].length) }} 
           </div>
-          <div v-if="facetCategory[1].length === 20" class="facetArrow">
+          <div v-if="facetCategory[1].length === 20" class="facetArrow down">
             ﹀
           </div>
         </div>
@@ -41,6 +42,11 @@ import { requestService } from '../services/RequestService'
 export default {
   name: 'SearchFacetOptions',
   mixins: [HistoryRoutingUtils],
+  data () {
+    return {  
+      extraFacetsLoading:false
+    }
+  },
   computed: {
     ...mapState({
       searchAppliedFacets: state => state.Search.searchAppliedFacets,
@@ -69,9 +75,10 @@ export default {
       return length <= 20 ? 'more ' + facet + 's' : 'less ' + facet + 's'
     },
     requestAdditionalFacets(facetArea) {
+      this.extraFacetsLoading = true
       console.log(this.query, this.facets)
       let structuredQuery = this.query + this.searchAppliedFacets.join('')
-      requestService.getAddonFacets(facetArea, this.query).then(result => this.constructNewFacets(result, facetArea), error => console.log('No additional facets found.'))
+      requestService.getAddonFacets(facetArea, this.query).then(result => (this.constructNewFacets(result, facetArea), this.extraFacetsLoading = false), error => (console.log('No additional facets found.'),this.extraFacetsLoading = false))
     },
     removeAdditionalFacets(facetArea) {
       let structuredQuery = this.query + this.searchAppliedFacets.join('')

--- a/src/js/src/components/SearchFacetOptions.vue
+++ b/src/js/src/components/SearchFacetOptions.vue
@@ -62,14 +62,15 @@ export default {
     ...mapActions('Search', {
       updateSolrSettingOffset:'updateSolrSettingOffset',
       addToSearchAppliedFacets:'addToSearchAppliedFacets',
-      addSpecificRequestedFacets:'addSpecificRequestedFacets'
+      addSpecificRequestedFacets:'addSpecificRequestedFacets',
+      setFacetToInitialAmount:'setFacetToInitialAmount'
     }),
     determineFacetAction(facet, length) {
       if(length === 20) {
         this.requestAdditionalFacets(facet)
       }
       else if(length > 20) {
-        this.removeAdditionalFacets(facet)
+        this.setFacetToInitialAmount(facet)
       }
     },
     determineText(facet, length) {
@@ -78,18 +79,7 @@ export default {
     requestAdditionalFacets(facetArea) {
       this.extraFacetsLoading = true
       let structuredQuery = this.query + this.searchAppliedFacets.join('')
-      requestService.getAddonFacets(facetArea, this.query).then(result => (this.constructNewFacets(result, facetArea), this.extraFacetsLoading = false), error => (console.log('No additional facets found.'),this.extraFacetsLoading = false))
-    },
-    removeAdditionalFacets(facetArea) {
-      let structuredQuery = this.query + this.searchAppliedFacets.join('')
-      let facets = JSON.parse(JSON.stringify(this.facets))
-      facets['facet_fields'][facetArea] = facets['facet_fields'][facetArea].splice(0,20)
-      this.addSpecificRequestedFacets(facets)
-    },
-    constructNewFacets(result, facetArea) {
-      let facets = JSON.parse(JSON.stringify(this.facets))
-      facets['facet_fields'][facetArea] = result.facet_counts.facet_fields[facetArea]
-      this.addSpecificRequestedFacets(facets)
+      this.addSpecificRequestedFacets({facet:facetArea, query:structuredQuery}).then(this.extraFacetsLoading = false)
     },
     applyFacet(facetCategory, facet) {
       let newFacet = '&fq=' + facetCategory + ':"' + facet + '"'

--- a/src/js/src/services/RequestService.js
+++ b/src/js/src/services/RequestService.js
@@ -20,7 +20,8 @@ export const requestService = {
   fireGeoImageSearchRequest,
   getPWID,
   getWarcHeader,
-  getLinkGraph
+  getLinkGraph,
+  getAddonFacets
 }
 
 function fireSearchRequest (query, facets, options) {
@@ -243,6 +244,16 @@ function getWarcHeader(sourceFilePath, offset) {
 
 function getLinkGraph(domain, facetLimit, ingoing, dateStart, dateEnd) {
   const url = `services/frontend/tools/linkgraph/?domain=${domain}&facetLimit=${facetLimit}&ingoing=${ingoing}&dateStart=${dateStart}&dateEnd=${dateEnd}`
+  return axios.get(
+    url).then(response => {
+    return response.data
+  }).catch(error => {
+    return Promise.reject(error)
+  })
+}
+
+function getAddonFacets(domain, query) {
+  const url = `services/frontend/solr/search/facets/loadmore/?facetfield=${domain}&grouping=false&query=${ encodeURIComponent(query)}`
   return axios.get(
     url).then(response => {
     return response.data

--- a/src/js/src/services/RequestService.js
+++ b/src/js/src/services/RequestService.js
@@ -21,7 +21,7 @@ export const requestService = {
   getPWID,
   getWarcHeader,
   getLinkGraph,
-  getAddonFacets
+  getMoreFacets
 }
 
 function fireSearchRequest (query, facets, options) {
@@ -252,7 +252,7 @@ function getLinkGraph(domain, facetLimit, ingoing, dateStart, dateEnd) {
   })
 }
 
-function getAddonFacets(domain, query) {
+function getMoreFacets(domain, query) {
   const url = `services/frontend/solr/search/facets/loadmore/?facetfield=${domain}&grouping=false&query=${encodeURIComponent(query)}`
   return axios.get(
     url).then(response => {

--- a/src/js/src/services/RequestService.js
+++ b/src/js/src/services/RequestService.js
@@ -253,7 +253,7 @@ function getLinkGraph(domain, facetLimit, ingoing, dateStart, dateEnd) {
 }
 
 function getAddonFacets(domain, query) {
-  const url = `services/frontend/solr/search/facets/loadmore/?facetfield=${domain}&grouping=false&query=${ encodeURIComponent(query)}`
+  const url = `services/frontend/solr/search/facets/loadmore/?facetfield=${domain}&grouping=false&query=${encodeURIComponent(query)}`
   return axios.get(
     url).then(response => {
     return response.data

--- a/src/js/src/store/modules/search.store.js
+++ b/src/js/src/store/modules/search.store.js
@@ -230,7 +230,6 @@ const mutations = {
     state.facetLoading = status
   },
   setExtraFacetLoadingStatus(state, status) {
-    console.log('setting ', status)
     state.extraFacetLoading = status
   },
   clearResultsSuccess(state) {

--- a/src/js/src/store/modules/search.store.js
+++ b/src/js/src/store/modules/search.store.js
@@ -16,6 +16,7 @@ const initialState = () => ({
   },
   loading:false,
   facetLoading:false,
+  extraFacetLoading:false
 })
 
 const state = initialState()
@@ -26,6 +27,9 @@ const actions = {
   },
   setFacetLoadingStatus( {commit}, param) {
     commit('setFacetLoadingStatus', param)
+  },
+  setExtraFacetLoadingStatus( {commit}, param) {
+    commit('setExtraFacetLoadingStatus', param)
   },
   updateQuery ( {commit}, param) {
     commit('updateQuerySuccess', param)
@@ -55,6 +59,7 @@ const actions = {
     commit('emptySearchAppliedFacetsSuccess')
   },
   addSpecificRequestedFacets ( {commit}, params ) {
+    commit('setExtraFacetLoadingStatus', params.facet)
     requestService
       .getMoreFacets(params.facet, params.query)
       .then(result => commit('loadMorefacetsRequestSuccess', {result:result, selectedFacet:params.facet}), error =>
@@ -141,11 +146,14 @@ const mutations = {
     let newFacets = JSON.parse(JSON.stringify(state.facets))
     newFacets['facet_fields'][param.selectedFacet] = param.result.facet_counts.facet_fields[param.selectedFacet]
     state.facets = newFacets
+    state.extraFacetLoading = false
   },
   setFacetsToInitialAmountSuccess(state, facetArea) {
     let newFacets = JSON.parse(JSON.stringify(state.facets))
     newFacets['facet_fields'][facetArea] = newFacets['facet_fields'][facetArea].splice(0,20)
     state.facets = newFacets
+    state.extraFacetLoading = false
+
   },
   loadMorefacetsRequestError() {
     this.dispatch('Notifier/setNotification', {
@@ -155,6 +163,8 @@ const mutations = {
       type: 'error',
       timeout: false
     })
+    state.extraFacetLoading = false
+
   },
   facetRequestSuccess(state, result) {
       state.facets = result
@@ -218,6 +228,10 @@ const mutations = {
   },
   setFacetLoadingStatus(state, status) {
     state.facetLoading = status
+  },
+  setExtraFacetLoadingStatus(state, status) {
+    console.log('setting ', status)
+    state.extraFacetLoading = status
   },
   clearResultsSuccess(state) {
     state.results = {}

--- a/src/js/src/store/modules/search.store.js
+++ b/src/js/src/store/modules/search.store.js
@@ -54,6 +54,9 @@ const actions = {
   emptySearchAppliedFacets ({commit}) {
     commit('emptySearchAppliedFacetsSuccess')
   },
+  addSpecificRequestedFacets ( {commit}, param ) {
+    commit('facetRequestSuccess', param)
+  },
   clearResults ( {commit} ) {
     commit('clearResultsSuccess')
   },

--- a/src/js/src/store/modules/search.store.js
+++ b/src/js/src/store/modules/search.store.js
@@ -54,8 +54,14 @@ const actions = {
   emptySearchAppliedFacets ({commit}) {
     commit('emptySearchAppliedFacetsSuccess')
   },
-  addSpecificRequestedFacets ( {commit}, param ) {
-    commit('facetRequestSuccess', param)
+  addSpecificRequestedFacets ( {commit}, params ) {
+    requestService
+      .getMoreFacets(params.facet, params.query)
+      .then(result => commit('loadMorefacetsRequestSuccess', {result:result, selectedFacet:params.facet}), error =>
+        commit('loadMorefacetsRequestError', error))
+  },
+  setFacetToInitialAmount ( {commit}, param) {
+    commit('setFacetsToInitialAmountSuccess', param)
   },
   clearResults ( {commit} ) {
     commit('clearResultsSuccess')
@@ -130,6 +136,25 @@ const mutations = {
   },
   emptySearchAppliedFacetsSuccess(state) {
     state.searchAppliedFacets = []
+  },
+  loadMorefacetsRequestSuccess(state, param) {
+    let newFacets = JSON.parse(JSON.stringify(state.facets))
+    newFacets['facet_fields'][param.selectedFacet] = param.result.facet_counts.facet_fields[param.selectedFacet]
+    state.facets = newFacets
+  },
+  setFacetsToInitialAmountSuccess(state, facetArea) {
+    let newFacets = JSON.parse(JSON.stringify(state.facets))
+    newFacets['facet_fields'][facetArea] = newFacets['facet_fields'][facetArea].splice(0,20)
+    state.facets = newFacets
+  },
+  loadMorefacetsRequestError() {
+    this.dispatch('Notifier/setNotification', {
+      title: 'We are so sorry!',
+      text: 'Something went wrong when fetching more facets - please try again',
+      srvMessage: 'Facets not found.',
+      type: 'error',
+      timeout: false
+    })
   },
   facetRequestSuccess(state, result) {
       state.facets = result

--- a/src/js/vue.config.js
+++ b/src/js/vue.config.js
@@ -137,6 +137,11 @@ module.exports = {
         pathRewrite: { '^/services/export/linkgraph/': '' },
         changeOrigin: true
       },
+      'services/frontend/solr/search/facets/loadmore/' : {
+        target: 'http://localhost:8080/solrwayback/services/frontend/solr/search/facets/loadmore/',
+        pathRewrite: { '^/services/frontend/solr/search/facets/loadmore/': '' },
+        changeOrigin: true
+      }
     }
   },
   publicPath: process.env.NODE_ENV === 'production'


### PR DESCRIPTION
Added facet loadmore function
Styled it a little bit so it doesn't look too horrible
Added a loading spinner while it gathers the info

I've kept it somewhat simple. Because of the way we've designed the store (and added the facets to the store), we don't have a nice way to keep a history of loaded facets. So if you load them, hide then again and decide you want to see them again, we make a new call. It shouldn't be a big deal, since it has to be done manually on 2 seperate button clicks.

Need some rigorous testing on a larger system (I simply don't have enough data to make fancy query and get enough facets back to see if something breaks with a fancy query (AND/OR, linebreak and the likes.) I hope @thomasegense can be helpful with testing this

As usual, @jorntx for code review.