### PR TITLE
Make the property location configurable

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
@@ -47,16 +48,19 @@ public class PropertiesLoader {
     public static void initProperties(String propertyFile) {
         try {
 
-            log.info("Initializing solrwayback-properties");
+            log.info("Initializing solrwayback-properties using property file '" + propertyFile + "'");
             String user_home=System.getProperty("user.home");
-                        
-            File f = new File(user_home,propertyFile);
-             if (!f.exists()) {
+
+            File f = new File(propertyFile);
+            if (!f.exists()) { // Fallback to looking in the user home folder
+                f = new File(user_home, propertyFile);
+            }
+            if (!f.exists()) {
                log.info("Could not find contextroot specific propertyfile:"+propertyFile +". Using default:"+DEFAULT_PROPERTY_FILE);
-               propertyFile=DEFAULT_PROPERTY_FILE;                                 
-             }                        
+                f = new File(user_home, DEFAULT_PROPERTY_FILE);
+             }
             log.info("Load backend-properties: Using user.home folder:" + user_home +" and propertyFile:"+propertyFile);
-            InputStreamReader isr = new InputStreamReader(new FileInputStream(new File(user_home,propertyFile)), "ISO-8859-1");
+            InputStreamReader isr = new InputStreamReader(new FileInputStream(f), StandardCharsets.ISO_8859_1);
 
             serviceProperties = new Properties();
             serviceProperties.load(isr);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
@@ -3,6 +3,7 @@ package dk.kb.netarchivesuite.solrwayback.properties;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.time.YearMonth;
 import java.util.Arrays;
 import java.util.List;
@@ -84,18 +85,21 @@ public class PropertiesLoaderWeb {
     public static void initProperties(String propertyFile) {
         try {
 
-            log.info("Initializing solrwaybackweb-properties");
+            log.info("Initializing solrwaybackweb-properties using property file '" + propertyFile + "'");
             String user_home=System.getProperty("user.home");
 
-            File f = new File(user_home,propertyFile);
+            File f = new File(propertyFile);
+            if (!f.exists()) { // Fallback to looking in the user home folder
+                f = new File(user_home, propertyFile);
+            }
             if (!f.exists()) {
                 log.info("Could not find contextroot specific propertyfile:"+propertyFile +". Using default:"+DEFAULT_PROPERTY_WEB_FILE);
-                propertyFile=DEFAULT_PROPERTY_WEB_FILE;                                 
-            }                        
+                f = new File(user_home, DEFAULT_PROPERTY_WEB_FILE);
+            }
             log.info("Load web-properties: Using user.home folder:" + user_home +" and propertyFile:"+propertyFile);
 
 
-            InputStreamReader isr = new InputStreamReader(new FileInputStream(new File(user_home,propertyFile)), "ISO-8859-1");
+            InputStreamReader isr = new InputStreamReader(new FileInputStream(f), StandardCharsets.ISO_8859_1);
 
             serviceProperties = new Properties();
             serviceProperties.load(isr);

--- a/src/main/webapp/META-INF/context.xml
+++ b/src/main/webapp/META-INF/context.xml
@@ -1,4 +1,16 @@
 <Context override="true" docBase="solrwayback.war">
     <Valve className="org.apache.catalina.valves.rewrite.RewriteValve"/>
 
+<!-- Set the property locations explicitly if they are not at the default location (user home) -->
+<!--
+    <Environment name="solrwayback-config"
+        value="/home/foobar/services/solrwayback.specialcollection.properties"
+        type="java.lang.String"
+        override="false"/>
+    <Environment name="solrwaybackweb-config"
+        value="/home/foobar/services/solrwaybackweb.specialcollection.properties"
+        type="java.lang.String"
+        override="false"/>
+    -->
+
 </Context>


### PR DESCRIPTION
This pull request makes it possible to state the location of the property files in the web app context descriptor. If not specified, the behaviour is to look in the user's home folder, thus maintaining backwards compatibility.

The file `webapp/META-INF/context.xml` has been updated with a commented-out section demonstrating how to specify the locations.