### PR TITLE
Jsoup and apache compress bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
-            <version>1.20</version>
+            <version>1.21</version>
             <!-- Used to get a reliable decompression of multi-part gzip stream in test -->
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.12.1</version>
+            <version>1.14.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterTest.java
@@ -8,8 +8,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -136,13 +138,30 @@ public class HtmlParserUrlRewriterTest {
                 RewriteTestHelper.createOXResolver(expectedNotFound >= 0));
 
         assertEquals("The result should be as expected for test '" + testPrefix + "'",
-                     expected, rewritten.getReplaced().replaceAll(" +\n", "\n"));
+                     normalise(expected), normalise(rewritten.getReplaced()));
         assertEquals("The number of replaced links should be as expected",
                      expectedReplaced, rewritten.getNumberOfLinksReplaced());
         if (expectedNotFound >= 0) {
             assertEquals("The number of not found links should be as expected",
                          expectedNotFound, rewritten.getNumberOfLinksNotFound());
         }
+    }
+
+    /**
+     * @param text multiline text.
+     * @return the text where leading and trailing spaces has been removed from all lines and empty lines
+     * has been removed.
+     */
+    private String normalise(String text) {
+        return Arrays.stream(
+                text.replace("> <!--", ">\n<!--") // JSoup won't put comments on their own lines
+                        .replace("</style> <a", "</style>\n<a") // JSoup strangeness with lines starting with <a...>
+                        .replace("</a> <a", "</a>\n<a")
+                        .replace("--> <a", "-->\n<a")
+                        .split("\n"))
+                .map(String::trim)
+                .filter(line -> !line.isEmpty())
+                .collect(Collectors.joining("\n"));
     }
 
     private void assertCount(String testPrefix, int expectedReplaced) throws Exception {

--- a/src/test/resources/example_rewrite/css.html
+++ b/src/test/resources/example_rewrite/css.html
@@ -11,6 +11,7 @@
 <style type="text/css" media="screen">@import "//www.dr.dk/drdkGlobal/spot/spotGlobal_o4.css";</style>
 <style type="text/css" media="screen">@import "/design/www/global/css/globalPrint_o5.css";</style>
 <style type="text/css" media="screen">@import url(http://en.statsbiblioteket.dk/portal_css/SB%20Theme/resourceplonetheme.sbtheme.stylesheetsmain-cachekey-7e976fa2b125f18f45a257c2d1882e00_o6.css);</style>
+<!-- Note: In 1.14.2, JSoup changes from preserving the first class attribut to preserving the last, so "button" is removed -->
 <a class="toplink" href="test" class="button" style="background:url(img/homeico_o7.png) no-repeat ; width:90px; margin:0px 0px 0px 16px;">kimse.rovfisk.dk  </a>
 <a class="toplink" href="/katte/">katte / </a><br /><br />
 <table cellspacing="8"><tr><td></td><td class="itemw"><a href="/katte/?browse=DSC00175.JPG"><img class="lo" src="/cache/katte/DSC00175_o8.JPG" /></a></td>

--- a/src/test/resources/example_rewrite/css_expected.html
+++ b/src/test/resources/example_rewrite/css_expected.html
@@ -11,7 +11,8 @@
   <style type="text/css" media="screen">@import "http://localhost:0000/solrwayback/services/downloadRaw?source_file_path=somesourcefile&offset=4";</style>
   <style type="text/css" media="screen">@import "http://localhost:0000/solrwayback/services/downloadRaw?source_file_path=somesourcefile&offset=5";</style>
   <style type="text/css" media="screen">@import url(http://localhost:0000/solrwayback/services/downloadRaw?source_file_path=somesourcefile&offset=6);</style>
-  <a class="button" href="http://localhost:0000/solrwayback/services/web/20200430130700/http://example.com/somefolder/test" style="background:url(http://localhost:0000/solrwayback/services/downloadRaw?source_file_path=somesourcefile&amp;offset=7) no-repeat ; width:90px; margin:0px 0px 0px 16px;">kimse.rovfisk.dk </a>
+  <!-- Note: In 1.14.2, JSoup changes from preserving the first class attribut to preserving the last, so "button" is removed -->
+  <a class="toplink" href="http://localhost:0000/solrwayback/services/web/20200430130700/http://example.com/somefolder/test" style="background:url(http://localhost:0000/solrwayback/services/downloadRaw?source_file_path=somesourcefile&amp;offset=7) no-repeat ; width:90px; margin:0px 0px 0px 16px;">kimse.rovfisk.dk </a>
   <a class="toplink" href="http://localhost:0000/solrwayback/services/web/20200430130700/http://example.com/katte/">katte / </a>
   <br>
   <br>


### PR DESCRIPTION
Bumps Jsoup and apache commons compress to latest versions due to Dependabot alerts. This includes adjusting unit tests for slightly changed output from JSoup (indents and newlines). This was done by making the unit tests trim each line, remove empty lines and ecplicitly compensating for JSoup tendency to collapse multiple lines to a single line in some cases.