### PR TITLE
Stream warc content

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/export/StreamingSolrWarcExportBufferedInputStream.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/export/StreamingSolrWarcExportBufferedInputStream.java
@@ -239,7 +239,7 @@ public class StreamingSolrWarcExportBufferedInputStream extends InputStream{
    * were encountered.
    */
   private InputStream getWARCEntryStream(EntryAndHeaders entryAndHeaders) {
-    final String id = entryAndHeaders.entry.getSourceFilePath() + "#" + entryAndHeaders.entry.getOffset();
+    final String id = entryAndHeaders.entry.getArcSource() + "#" + entryAndHeaders.entry.getOffset();
     try {
       // Retrieve the payload to local cache (heap or storage, depending on size)
       StatusInputStream payload = entryAndHeaders.entry.getBinaryArraySize() > 0 ?

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcFileLocationResolverInterface.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcFileLocationResolverInterface.java
@@ -1,23 +1,28 @@
 package dk.kb.netarchivesuite.solrwayback.interfaces;
 
+import java.util.function.Supplier;
+
 public interface ArcFileLocationResolverInterface {
 
-  /*
-   * This method must return the new file location path from the original source_file_path
-   * It is only required if the path has been changed since indexing. This can be the case if
-   * it was index on another computer and the file-path is different compared to where solrwayback is running. 
+  /**
+   * Returns a {@link Supplier} that delivers an InputStream for the given (WARC) source file.
+   * The supplier can be called multiple times, each time delivering an InputStream positioned at the beginning of
+   * the source file.
+   * It is the responsibility of the caller to close the InputStream after use.
+   *
+   * This level of indirection allows for handling of moved files, WARCs delivered over HTTP or similar.
    * A simple situation is just a string manipulation of the url, a more complicated situation can be
    * using a lookup service give the filename.  
    *  
-   * Implementing classes must have the default constructor
-   * Parameters are given by setParameters method
+   * Implementing classes must have the default constructor.
+   * Parameters are given by setParameters method.
    *     
-   *@param source_file_path is the complete file path when the arc file was indexed. example : /mountA/0211/filedir/12345.warc.gz
-   *@return the new path : ie /mountB/12345.warc.gz   
+   * @param source_file_path is the complete file path when the arc file was indexed. example : /mountA/0211/filedir/12345.warc.gz
+   * @return a Supplier that delivers an InputStream for the (w)arc file, positioned at the beginning.
    */
-  String resolveArcFileLocation(String source_file_path);
+  ArcSource resolveArcFileLocation(String source_file_path);
 
   void setParameters(String parameter);
   void initialize();
-  
+
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcSource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcSource.java
@@ -1,0 +1,69 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.interfaces;
+
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Supplier;
+
+/**
+ * Encapsulates a supplier of data from a WARC- or ARC, independent of storage system.
+ */
+public class ArcSource implements Supplier<InputStream> {
+    private final String source;
+    private final Supplier<InputStream> supplier;
+
+    /**
+     * @param source the source (URL, file path or similar) of the ArcData.
+     * @return a Supplier that delivers an InputStream for the (w)arc file, positioned at the beginning.
+     */
+    public ArcSource(String source, Supplier<InputStream> supplier) {
+        this.source = source;
+        this.supplier = supplier;
+    }
+
+    /**
+     * @return the source of the data. Used for guessing the type of the source (warc/warc.gz/arc/arc.gz) by
+     * looking at the last part of the String.
+     */
+    public String getSource() {
+        return source;
+    }
+
+    @Override
+    public InputStream get() {
+        return supplier.get();
+    }
+
+    /**
+     * @param file a file on the local file system.
+     * @return an ArcSource for the given file.
+     */
+    public static ArcSource fromFile(String file) {
+        return new ArcSource(file, () -> {
+            try {
+                return new FileInputStream(file);
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to create FileInputStream for '" + file + "'", e);
+            }
+        });
+    }
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcSource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcSource.java
@@ -66,4 +66,9 @@ public class ArcSource implements Supplier<InputStream> {
             }
         });
     }
+
+    @Override
+    public String toString() {
+        return "ArcSource(" + "source='" + source + '\'' + ')';
+    }
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/FileMovedMappingResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/FileMovedMappingResolver.java
@@ -1,13 +1,12 @@
 package dk.kb.netarchivesuite.solrwayback.interfaces;
 
+import java.io.*;
 import java.util.HashMap;
 import java.util.stream.Stream;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
@@ -73,18 +72,12 @@ public class FileMovedMappingResolver implements ArcFileLocationResolverInterfac
       //If the filename is not found in the mapping, return the input back.
     
     @Override
-    public String resolveArcFileLocation(String source_file_path){
+    public ArcSource resolveArcFileLocation(String source_file_path){
         String fileName = new File(source_file_path).getName();
-        String value=FILE_MAP.get(fileName);
-        if(value == null) {
-       // log.info("File location not moved:"+source_file_path);
-          return source_file_path; //Use original location
-        }
-        
-       // log.info("File location moved:"+source_file_path +" ->" + value+"/"+fileName);
-        return value+"/"+fileName;
+        String value = FILE_MAP.get(fileName);
+
+        String finalPath = value == null ? source_file_path : value + "/" + fileName;
+
+        return ArcSource.fromFile(finalPath);
       }
-
-
-      
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/IdentityArcFileResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/IdentityArcFileResolver.java
@@ -1,14 +1,17 @@
 package dk.kb.netarchivesuite.solrwayback.interfaces;
 
 
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+
 public class IdentityArcFileResolver implements ArcFileLocationResolverInterface {
   /*
    * This implementation just returns the same file location as output. Can be used if path to the arc-files is the same as 
    * the index field: source_file_path
    */    
   @Override
-  public String resolveArcFileLocation(String source_file_path) {        
-    return source_file_path;
+  public ArcSource resolveArcFileLocation(String source_file_path) {
+    return ArcSource.fromFile(source_file_path);
   }
   @Override
   public void setParameters(String parameters) {

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcFileParserFactory.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcFileParserFactory.java
@@ -1,6 +1,9 @@
 package dk.kb.netarchivesuite.solrwayback.parsers;
 
+import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
+
+import java.util.Locale;
 
 public class ArcFileParserFactory {
 
@@ -11,25 +14,26 @@ public class ArcFileParserFactory {
    * @param offset offset in the warc file
    * @param loadBinary will load the byte[] with the content. Do mot use for video/audio etc. Use the InputStream method for this
    */  
-    public static ArcEntry getArcEntry(String file_path, long offset, boolean loadBinary) throws Exception{
+    public static ArcEntry getArcEntry(ArcSource arcSource, long offset, boolean loadBinary) throws Exception{
         
-        if (file_path == null ){           
-            throw new IllegalArgumentException("file_path is null");        
+        if (arcSource == null ){
+            throw new IllegalArgumentException("No arcSupplier provided");
         }
 
         ArcEntry arcEntry = null; 
-       String fileLowerCase=file_path.toLowerCase(); 
-        
-        
-        if (fileLowerCase.endsWith(".warc")  || fileLowerCase.endsWith(".warc.gz") ) {
-            arcEntry = WarcParser.getWarcEntry(file_path, offset, loadBinary);     
+        String sourceLowercase = arcSource.getSource().toLowerCase(Locale.ROOT);
+
+
+        if (sourceLowercase.endsWith(".warc")  || sourceLowercase.endsWith(".warc.gz") ) {
+            arcEntry = WarcParser.getWarcEntry(arcSource, offset, loadBinary);
         }
                         
-        else if (fileLowerCase.endsWith(".arc") || fileLowerCase.endsWith("arc.gz")){
-            arcEntry = ArcParser.getArcEntry(file_path, offset,loadBinary);                     
+        else if (sourceLowercase.endsWith(".arc") || sourceLowercase.endsWith("arc.gz")){
+            arcEntry = ArcParser.getArcEntry(arcSource, offset,loadBinary);
         }
         else{
-            throw new IllegalArgumentException("File not arc or warc:"+file_path);
+            throw new IllegalArgumentException(
+                    "Expected (W)ARC source not arc or warc: '"+ arcSource.getSource() + "'");
         }
 
         return arcEntry;

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 import java.util.zip.GZIPInputStream;
 
 import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
+import dk.kb.netarchivesuite.solrwayback.util.InputStreamUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.slf4j.Logger;
@@ -48,7 +49,7 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
       arcEntry.setOffset(arcEntryPosition);
 
       try (InputStream is = arcSource.get()) {
-          IOUtils.skipFully(is, arcEntryPosition);
+          InputStreamUtils.skipFully(is, arcEntryPosition);
 
           try (BufferedInputStream bis = new BufferedInputStream(is)) {
               loadArcHeader(bis, arcEntry);
@@ -70,7 +71,7 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
     arcEntry.setOffset(arcEntryPosition);
 
     try (InputStream is = arcSource.get()) {
-        IOUtils.skipFully(is, arcEntryPosition);
+        InputStreamUtils.skipFully(is, arcEntryPosition);
 
         // log.info("file is zipped:"+arcFilePath);
         try (GZIPInputStream stream = new GZIPInputStream(is);
@@ -144,7 +145,7 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
       ArcEntry arcEntry = new ArcEntry(); // We just throw away the header info anyway 
 
       InputStream is = arcSource.get();
-      IOUtils.skipFully(is, arcEntryPosition);
+      InputStreamUtils.skipFully(is, arcEntryPosition);
 
       if (arcSource.getSource().toLowerCase(Locale.ROOT).endsWith(".gz")){ //It is zipped
           // log.info("file is zipped:"+arcFilePath);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
@@ -55,7 +55,7 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
 
               //log.debug("Arc entry : totalsize:"+totalSize +" headersize:"+headerSize+" binary size:"+binarySize);
               if (loadBinary) {
-                  loadBinary(is, arcEntry);
+                  loadBinary(bis, arcEntry);
               }
           }
           return arcEntry;
@@ -155,12 +155,12 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
           BoundedInputStream maxStream = new BoundedInputStream(bis, arcEntry.getBinaryArraySize());
           return new BufferedInputStream(maxStream); // It's a mess to use nested BufferedInputStreams...
           
-        } else {
-            BufferedInputStream  bis = new BufferedInputStream(is);
-            loadArcHeader(bis, arcEntry);
-            BoundedInputStream maxStream = new BoundedInputStream(is, arcEntry.getBinaryArraySize());
-            return new BufferedInputStream(maxStream);
-        }
+      } else {
+          BufferedInputStream  bis = new BufferedInputStream(is);
+          loadArcHeader(bis, arcEntry);
+          BoundedInputStream maxStream = new BoundedInputStream(bis, arcEntry.getBinaryArraySize());
+          return new BufferedInputStream(maxStream);
+      }
       
   }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
@@ -1,13 +1,11 @@
 package dk.kb.netarchivesuite.solrwayback.parsers;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.RandomAccessFile;
-import java.nio.channels.Channels;
+import java.io.*;
+import java.util.Locale;
 import java.util.zip.GZIPInputStream;
 
+import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,116 +32,71 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
    *MicrosoftOfficeWebServer: 5.0_Pub
    *X-Powered-By: ASP.NET
    */
-  public static ArcEntry getArcEntry(String arcFilePath, long arcEntryPosition, boolean loadBinary) throws Exception {
-    RandomAccessFile raf= null ;
-    try{
-
-      if (arcFilePath.endsWith(".gz")){ //It is zipped
-        return getArcEntryZipped(arcFilePath, arcEntryPosition, loadBinary);                       
-      }
-      else {
-          return getArcEntryNotZipped(arcFilePath, arcEntryPosition, loadBinary);
+  public static ArcEntry getArcEntry(ArcSource arcSource, long arcEntryPosition, boolean loadBinary) throws Exception {
+      if (arcSource.getSource().toLowerCase(Locale.ROOT).endsWith(".gz")){ //It is zipped
+        return getArcEntryZipped(arcSource, arcEntryPosition, loadBinary);
+      } else {
+          return getArcEntryNotZipped(arcSource, arcEntryPosition, loadBinary);
       }      
-    }
-    catch(Exception e){
-      throw e;
-    }
-    finally{
-      if (raf!= null){
-        raf.close();
-      }
-    }
   }
 
   
-  public static ArcEntry getArcEntryNotZipped(String arcFilePath, long arcEntryPosition, boolean loadBinary) throws Exception {
-      RandomAccessFile raf= null ;
+  public static ArcEntry getArcEntryNotZipped(ArcSource arcSource, long arcEntryPosition, boolean loadBinary) throws Exception {
       ArcEntry arcEntry = new ArcEntry();
       arcEntry.setFormat(ArcEntry.FORMAT.ARC);
-      arcEntry.setSourceFilePath(arcFilePath);
+      arcEntry.setSource(arcSource);
       arcEntry.setOffset(arcEntryPosition);
-      
-      try{        
-      
-        raf = new RandomAccessFile(new File(arcFilePath), "r");
-        raf.seek(arcEntryPosition);
 
-        loadArcHeaderNotZipped(raf, arcEntry);
-        
-        long binarySize=arcEntry.getBinaryArraySize();
-        
-        if (loadBinary) {        
-        //log.debug("Arc entry : totalsize:"+totalSize +" headersize:"+headerSize+" binary size:"+binarySize);            
-          byte[] bytes = new byte[(int) binarySize];
-          raf.read(bytes);
-          arcEntry.setBinary(bytes);
-        }
-                        
-        return arcEntry;
+      try (InputStream is = arcSource.get()) {
+          IOUtils.skipFully(is, arcEntryPosition);
+
+          try (BufferedInputStream bis = new BufferedInputStream(is)) {
+              loadArcHeader(bis, arcEntry);
+
+              //log.debug("Arc entry : totalsize:"+totalSize +" headersize:"+headerSize+" binary size:"+binarySize);
+              if (loadBinary) {
+                  loadBinary(is, arcEntry);
+              }
+          }
+          return arcEntry;
       }
-      catch(Exception e){
-        throw e;
-      }
-      finally{
-        if (raf!= null){
-          raf.close();
-        }
-      }      
-      
   }
 
-  public static ArcEntry getArcEntryZipped(String arcFilePath, long arcEntryPosition, boolean loadBinary) throws Exception {
+  public static ArcEntry getArcEntryZipped(ArcSource arcSource, long arcEntryPosition, boolean loadBinary) throws Exception {
 
-    
     ArcEntry arcEntry = new ArcEntry();
     arcEntry.setFormat(ArcEntry.FORMAT.ARC);
-    arcEntry.setSourceFilePath(arcFilePath);
+    arcEntry.setSource(arcSource);
     arcEntry.setOffset(arcEntryPosition);
-    
-      try (RandomAccessFile raf = new RandomAccessFile(new File(arcFilePath), "r")){ 
-      
-      raf.seek(arcEntryPosition);          
 
-      // log.info("file is zipped:"+arcFilePath);
-      InputStream is = Channels.newInputStream(raf.getChannel());                           
-      GZIPInputStream stream = new GZIPInputStream(is);             
-      BufferedInputStream  bis= new BufferedInputStream(stream);
+    try (InputStream is = arcSource.get()) {
+        IOUtils.skipFully(is, arcEntryPosition);
 
-      loadArcHeaderZipped(bis, arcEntry);
-      
-      //System.out.println("Arc entry : totalsize:"+totalSize +" binary size:"+binarySize +" firstHeadersize:"+byteCount);          
-      long binarySize = arcEntry.getBinaryArraySize();
-       if (loadBinary) {
-        byte[] chars = new byte[(int)binarySize];           
-        
-        bis.read(chars);
-        arcEntry.setBinary(chars);
-      }      
-      raf.close();
-      bis.close();
-      
-      
-      return arcEntry;
+        // log.info("file is zipped:"+arcFilePath);
+        try (GZIPInputStream stream = new GZIPInputStream(is);
+             BufferedInputStream  bis= new BufferedInputStream(stream)) {
+
+            loadArcHeader(bis, arcEntry);
+
+            //System.out.println("Arc entry : totalsize:"+totalSize +" binary size:"+binarySize +" firstHeadersize:"+byteCount);
+            if (loadBinary) {
+                loadBinary(bis, arcEntry);
+            }
+        }
     }
-    catch(Exception e){
-      throw e;
-    }    
+    return arcEntry;
   }
 
-  
-  
-  
+
   /*
    * Will load the header information into the warcEntry
-   * The  BufferedInputStream will be returned with pointer in start of binary 
    * warcEntry will have binaryArraySize defined
    * 
    */
-  private static void loadArcHeaderZipped( BufferedInputStream bis, ArcEntry arcEntry) throws Exception{
-      
-    StringBuffer headerLinesBuffer = new StringBuffer(); 
+  private static void loadArcHeader(BufferedInputStream bis, ArcEntry arcEntry) throws Exception{
 
- 
+    StringBuffer headerLinesBuffer = new StringBuffer();
+
     String line = readLine(bis); // First line
     headerLinesBuffer.append(line+newLineChar);
 
@@ -186,103 +139,47 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
     arcEntry.setBinaryArraySize(binarySize);      
   }
   
-  /*
-   * Will load the header information into the warcEntry
-   * The  RandomAccessFile will be returned with pointer in start of binary 
-   * warcEntry will have binaryArraySize defined
-   * 
-   */
-  private static void loadArcHeaderNotZipped(RandomAccessFile raf, ArcEntry arcEntry) throws Exception{
-      
-      StringBuffer headerLinesBuffer = new StringBuffer();
-      
-      String line = raf.readLine(); // First line
-      headerLinesBuffer.append(line+newLineChar);
-      
-      if  (!(line.startsWith("http"))) //No version check yet
-      {            
-        throw new IllegalArgumentException("ARC header does not start with http : "+line);
-      }         
 
-      arcEntry.setFileName(getArcLastUrlPart(line));            
-
-      String waybackDate = getWaybackDate(line);                    
-      arcEntry.setCrawlDate(DateUtils.convertWaybackDate2SolrDate(waybackDate));          
-      arcEntry.setWaybackDate(waybackDate);                       
-      arcEntry.setUrl(getArcUrl(line));
-      arcEntry.setIp(getIp(line));
-
-      long afterFirst = raf.getFilePointer();
-
-      String[] split = line.split(" ");
-      int totalSize = Integer.parseInt(split[split.length - 1]);
-      line = raf.readLine(); // second line http+status: HTTP/1.1 302 Found
-      arcEntry.setStatus_code(getStatusCode(line));      
-      while (!"".equals(line)) { // End of header block is an empty line
-      
-        line = raf.readLine();
-        headerLinesBuffer.append(line+newLineChar);
-        populateArcHeader(arcEntry, line);
-      }
-      
-      arcEntry.setHeader(headerLinesBuffer.toString());
-      
-      // Load the binary blog. We are now right after the header. Rest will be the binary
-      long headerSize = raf.getFilePointer() - afterFirst;
-      long binarySize = totalSize - headerSize;
-      arcEntry.setContentLength(binarySize);  //trust the load, not the http-header for arc-files
-
-      arcEntry.setBinaryArraySize(binarySize);
-      
-  }
-  
-
-  public static BufferedInputStream lazyLoadBinary(String arcFilePath, long arcEntryPosition) throws Exception {
+  public static BufferedInputStream lazyLoadBinary(ArcSource arcSource, long arcEntryPosition) throws Exception {
       ArcEntry arcEntry = new ArcEntry(); // We just throw away the header info anyway 
-      
-      if (arcFilePath.endsWith(".gz")){ //It is zipped
-          
-          RandomAccessFile raf = new RandomAccessFile(new File(arcFilePath), "r");
-          raf.seek(arcEntryPosition);          
 
+      InputStream is = arcSource.get();
+      IOUtils.skipFully(is, arcEntryPosition);
+
+      if (arcSource.getSource().toLowerCase(Locale.ROOT).endsWith(".gz")){ //It is zipped
           // log.info("file is zipped:"+arcFilePath);
-          InputStream is = Channels.newInputStream(raf.getChannel());                           
           GZIPInputStream zipStream = new GZIPInputStream(is);
-          BufferedInputStream  bis= new BufferedInputStream(zipStream);
-          loadArcHeaderZipped(bis, arcEntry);
+          BufferedInputStream  bis = new BufferedInputStream(zipStream);
+          loadArcHeader(bis, arcEntry);
           
           BoundedInputStream maxStream = new BoundedInputStream(bis, arcEntry.getBinaryArraySize());
           return new BufferedInputStream(maxStream); // It's a mess to use nested BufferedInputStreams...
           
-        }
-        else {
-            RandomAccessFile raf = new RandomAccessFile(new File(arcFilePath), "r");
-            raf.seek(arcEntryPosition);
-            loadArcHeaderNotZipped(raf, arcEntry);
-            InputStream is = Channels.newInputStream(raf.getChannel());
+        } else {
+            BufferedInputStream  bis = new BufferedInputStream(is);
+            loadArcHeader(bis, arcEntry);
             BoundedInputStream maxStream = new BoundedInputStream(is, arcEntry.getBinaryArraySize());
-            BufferedInputStream bis = new BufferedInputStream(maxStream);
-            return bis;
-        }            
+            return new BufferedInputStream(maxStream);
+        }
       
   }
-  
-  public static String readLine(BufferedInputStream  bis) throws Exception{
-    StringBuffer buf = new StringBuffer();
-    int current = 0; // CRLN || LN
-    while ((current = bis.read()) != '\r' && current != '\n') {             
-      buf.append((char) current);
+
+    public static String readLine(BufferedInputStream bis) throws Exception{
+      StringBuffer buf = new StringBuffer();
+      int current = 0; // CRLN || LN
+      while ((current = bis.read()) != '\r' && current != '\n') {
+        buf.append((char) current);
+      }
+      if (current == '\r') {
+        bis.read(); // line ends with 10 13
+      }
+
+
+      return buf.toString();
+
     }
-    if (current == '\r') {
-      bis.read(); // line ends with 10 13        
-    }
 
-
-    return buf.toString();
-
-  }
-
-  public static LineAndByteCount readLineCount(BufferedInputStream  bis) throws Exception{
+    public static LineAndByteCount readLineCount(BufferedInputStream  bis) throws Exception{
     int count = 0;
     StringBuffer buf = new StringBuffer();
     int current = 0; // CRLN || LN

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParserFileResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParserFileResolver.java
@@ -2,6 +2,7 @@ package dk.kb.netarchivesuite.solrwayback.parsers;
 
 import java.util.HashMap;
 
+import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -22,7 +23,7 @@ import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
  */
 public class ArcParserFileResolver {
 
-  private static HashMap<String, String> cache = new HashMap<String, String>();
+  private static final HashMap<String, ArcSource> cache = new HashMap<>();
 
   private static ArcFileLocationResolverInterface resolver = new IdentityArcFileResolver(); // Default
   private static final Logger log = LoggerFactory.getLogger(ArcFileLocationResolverInterface.class);
@@ -61,20 +62,14 @@ public class ArcParserFileResolver {
     String source_file_path = source_file_path_org.trim();
 
     try {
-      String cached = cache.get(source_file_path);
-      String fileLocation = null;
-      if (cached != null) {
-        fileLocation = cached;
-        // log.info("Using cached arcfile location:"+source_file_path
-        // +"->"+fileLocation);
-      } else {
-        fileLocation = resolver.resolveArcFileLocation(source_file_path);
-        cache.put(source_file_path, fileLocation);
-        // log.debug("Resolved arcfile location:" + source_file_path + "->" +
-        // fileLocation);
+      ArcSource arcSource = cache.get(source_file_path);
+      if (arcSource == null) {
+
+        arcSource = resolver.resolveArcFileLocation(source_file_path);
+        cache.put(source_file_path, arcSource);
       }
 
-      return ArcFileParserFactory.getArcEntry(fileLocation, offset, loadBinary);
+      return ArcFileParserFactory.getArcEntry(arcSource, offset, loadBinary);
 
     } catch (Exception e) {
       // It CAN happen, but crazy unlikely, and not critical at all... (took 10

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
@@ -1,8 +1,15 @@
 package dk.kb.netarchivesuite.solrwayback.parsers;
 
-public class ArcWarcFileParserAbstract {
+import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-  
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ArcWarcFileParserAbstract {
+  private static final Logger log = LoggerFactory.getLogger(ArcWarcFileParserAbstract.class);
+
 
   public static int getStatusCode(String line){//HTTP/1.1 302 Object moved      
     String[] tokens = line.split(" ");
@@ -10,5 +17,22 @@ public class ArcWarcFileParserAbstract {
     return Integer.parseInt(status);     
     
   }
-  
+
+  protected static void loadBinary(InputStream is, ArcEntry arcEntry) throws IOException {
+      long binarySize = arcEntry.getBinaryArraySize();
+
+      if (binarySize > Integer.MAX_VALUE) {
+          String message = "Binary size too large for java byte[]. Size:" + binarySize +
+                           ", source='" + arcEntry.getArcSource().getSource() + "'";
+        log.error(message);
+        throw new IllegalArgumentException(message);
+      }
+
+      byte[] bytes = new byte[(int) binarySize];
+
+      // we are not using IOUtils.readFully as we'd rather return non-complete data than nothing
+      is.read(bytes);
+      arcEntry.setBinary(bytes);
+  }
+
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
@@ -31,7 +31,14 @@ public class ArcWarcFileParserAbstract {
       byte[] bytes = new byte[(int) binarySize];
 
       // we are not using IOUtils.readFully as we'd rather return non-complete data than nothing
-      is.read(bytes);
+      int read = is.read(bytes);
+      if (read == -1) {
+          log.warn("Attempted to load binary for {}#{} but got EOF immediately",
+                   arcEntry.getArcSource().getSource(), arcEntry.getOffset());
+      } else if (read < bytes.length) {
+          log.warn("Incomplete binary for {}#{}: {}/{} bytes read",
+                   arcEntry.getArcSource().getSource(), arcEntry.getOffset(), read, bytes.length);
+      }
       arcEntry.setBinary(bytes);
   }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import java.util.zip.GZIPInputStream;
 
 import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
+import dk.kb.netarchivesuite.solrwayback.util.InputStreamUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.slf4j.Logger;
@@ -66,7 +67,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
     warcEntry.setOffset(warcEntryPosition);
 
     try (InputStream is = arcSource.get()) {
-        IOUtils.skipFully(is, warcEntryPosition);
+        InputStreamUtils.skipFully(is, warcEntryPosition);
 
         try (BufferedInputStream bis = new BufferedInputStream(is)) {
             loadWarcHeader(bis, warcEntry);
@@ -141,7 +142,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
     warcEntry.setOffset(warcEntryPosition);
 
     try (InputStream is = arcSource.get()) {
-        IOUtils.skipFully(is, warcEntryPosition);
+        InputStreamUtils.skipFully(is, warcEntryPosition);
 
         // log.info("file is zipped:"+arcFilePath);
         try (GZIPInputStream stream = new GZIPInputStream(is);
@@ -168,7 +169,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
     ArcEntry arcEntry = new ArcEntry(); // We just throw away the header info anyway 
 
     InputStream is = arcSource.get();
-    IOUtils.skipFully(is, arcEntryPosition);
+    InputStreamUtils.skipFully(is, arcEntryPosition);
 
     if (arcSource.getSource().toLowerCase(Locale.ROOT).endsWith(".gz")){ //It is zipped
       // log.info("file is zipped:"+arcFilePath);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
@@ -3,13 +3,13 @@ package dk.kb.netarchivesuite.solrwayback.parsers;
 import java.io.BufferedInputStream;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.InputStream;
 
-import java.io.RandomAccessFile;
-import java.nio.channels.Channels;
+import java.util.Locale;
 import java.util.zip.GZIPInputStream;
 
+import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,112 +48,37 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
    *Connection: close
    *Content-Length: 7178
    */
-  public static ArcEntry getWarcEntry(String warcFilePath, long warcEntryPosition, boolean loadBinary) throws Exception {
+  public static ArcEntry getWarcEntry(ArcSource arcSource, long warcEntryPosition, boolean loadBinary) throws Exception {
 
-    if (warcFilePath.endsWith(".gz")){ //It is zipped
-      return getWarcEntryZipped(warcFilePath, warcEntryPosition, loadBinary);                       
+    if (arcSource.getSource().toLowerCase(Locale.ROOT).endsWith(".gz")){ //It is zipped
+      return getWarcEntryZipped(arcSource, warcEntryPosition, loadBinary);
     }
     else {
-      return getWarcEntryNotZipped(warcFilePath, warcEntryPosition, loadBinary);
+      return getWarcEntryNotZipped(arcSource, warcEntryPosition, loadBinary);
     }          
   }
 
-  public static ArcEntry getWarcEntryNotZipped(String warcFilePath, long warcEntryPosition,boolean loadBinary) throws Exception {
+  public static ArcEntry getWarcEntryNotZipped(ArcSource arcSource, long warcEntryPosition,boolean loadBinary) throws Exception {
 
     ArcEntry warcEntry = new ArcEntry();
     warcEntry.setFormat(ArcEntry.FORMAT.WARC);
-    warcEntry.setSourceFilePath(warcFilePath);
+    warcEntry.setSource(arcSource);
     warcEntry.setOffset(warcEntryPosition);
 
-    RandomAccessFile raf=null;
-    try {
+    try (InputStream is = arcSource.get()) {
+        IOUtils.skipFully(is, warcEntryPosition);
 
-      raf = new RandomAccessFile(new File(warcFilePath), "r");
-      raf.seek(warcEntryPosition);
+        try (BufferedInputStream bis = new BufferedInputStream(is)) {
+            loadWarcHeader(bis, warcEntry);
 
-      loadWarcHeaderNotZipped(raf, warcEntry);
-
-      long binarySize = warcEntry.getBinaryArraySize();
-
-      if (binarySize > Integer.MAX_VALUE) {             
-        log.error("Binary size too large for java byte[]. Size:"+binarySize);
-        throw new Exception("Binary size too large for java byte[]. Size:"+binarySize);
-      }
-
-      if (loadBinary) {
-        byte[] bytes = new byte[(int) binarySize];
-        raf.read(bytes);            
-        warcEntry.setBinary(bytes);          
-      }
-
-      raf.close();
-      return warcEntry;
-    }
-    catch(Exception e){
-      throw e;
-    }
-    finally {
-      if (raf!= null){
-        raf.close();
-      }
+            //log.debug("Arc entry : totalsize:"+totalSize +" headersize:"+headerSize+" binary size:"+binarySize);
+            if (loadBinary) {
+                loadBinary(is, warcEntry);
+            }
+        }
+        return warcEntry;
     }
   }
-
-
-
-  /*
-   * Will load the header information into the warcEntry
-   * The  RandomAccessFile will be returned with pointer in start of binary 
-   * warcEntry will have binaryArraySize defined
-   * 
-   */
-  private static void loadWarcHeaderNotZipped(RandomAccessFile raf, ArcEntry warcEntry) throws Exception{
-
-    StringBuffer headerLinesBuffer = new StringBuffer();
-    String line = raf.readLine(); // First line
-    headerLinesBuffer.append(line+newLineChar);
-
-    if  (!(line.startsWith("WARC/"))) //No version check yet
-    {            
-      throw new IllegalArgumentException("WARC header is not WARC/'version', instead it is : "+line);
-    }            
-
-    while (!"".equals(line)) { // End of warc first header block is an empty line                
-      line = raf.readLine();                
-      headerLinesBuffer.append(line+newLineChar);
-      populateWarcFirstHeader(warcEntry, line);                
-    }
-
-    if( !(warcEntry.getType() == ArcEntry.TYPE.RESOURCE)){ 
-    
-    long afterFirst = raf.getFilePointer(); //Now we are past the WARC header and back to the ARC standard 
-    line = raf.readLine();  
-    warcEntry.setStatus_code(getStatusCode(line));            
-    headerLinesBuffer.append(line+newLineChar);
-    while (!"".equals(line)) { // End of warc second header block is an empty line
-      line = raf.readLine();                  
-      headerLinesBuffer.append(line+"\r\n");
-      populateWarcSecondHeader(warcEntry, line);
-    }
-
-    warcEntry.setHeader(headerLinesBuffer.toString());
-
-    int totalSize= (int) warcEntry.getWarcEntryContentLength();            
-
-    // Load the binary blog. We are now right after the header. Rest will be the binary
-    long headerSize = raf.getFilePointer() - afterFirst;
-    long binarySize = totalSize - headerSize;
-    warcEntry.setBinaryArraySize(binarySize);
-    }
-    else {
-      warcEntry.setHeader(""); //NONE for resource type
-      warcEntry.setStatus_code(200); //fake it . Warc-indexer does the same
-      warcEntry.setBinaryArraySize((int) warcEntry.getWarcEntryContentLength());
-    }
-
-    //log.debug("Warc entry : totalsize:"+totalSize +" headersize:"+headerSize+" binary size:"+binarySize);
-  }
-
 
   /*
    * Will load the header information into the warcEntry
@@ -161,7 +86,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
    * warcEntry will have binaryArraySize defined
    * 
    */
-  private static void loadWarcHeaderZipped( BufferedInputStream bis, ArcEntry warcEntry) throws Exception{
+  private static void loadWarcHeader(BufferedInputStream bis, ArcEntry warcEntry) throws Exception{
 
     StringBuffer headerLinesBuffer = new StringBuffer();
     String line = readLine(bis); // First line
@@ -208,89 +133,58 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
     warcEntry.setBinaryArraySize(binarySize);
   }
 
-  public static ArcEntry getWarcEntryZipped(String warcFilePath, long warcEntryPosition, boolean loadBinary) throws Exception {
+  public static ArcEntry getWarcEntryZipped(ArcSource arcSource, long warcEntryPosition, boolean loadBinary) throws Exception {
 
     ArcEntry warcEntry = new ArcEntry();
     warcEntry.setFormat(ArcEntry.FORMAT.WARC);
-    warcEntry.setSourceFilePath(warcFilePath);
+    warcEntry.setSource(arcSource);
     warcEntry.setOffset(warcEntryPosition);
 
-    try (RandomAccessFile raf = new RandomAccessFile(new File(warcFilePath), "r")){      
+    try (InputStream is = arcSource.get()) {
+        IOUtils.skipFully(is, warcEntryPosition);
 
+        // log.info("file is zipped:"+arcFilePath);
+        try (GZIPInputStream stream = new GZIPInputStream(is);
+             BufferedInputStream  bis= new BufferedInputStream(stream)) {
 
-      raf.seek(warcEntryPosition);
+            loadWarcHeader(bis, warcEntry);
 
-      //  log.info("file is zipped:"+warcFilePath);
-      InputStream is = Channels.newInputStream(raf.getChannel());                           
-      GZIPInputStream zipStream = new GZIPInputStream(is);             
-
-      BufferedInputStream  bis= new BufferedInputStream(zipStream);
-
-
-      loadWarcHeaderZipped(bis, warcEntry);
-
-      long binarySize = warcEntry.getBinaryArraySize(); 
-
-      if (binarySize > Integer.MAX_VALUE) {
-
-        log.error("Binary size too large for java byte[]. Size:"+binarySize);
-        throw new Exception("Binary size too large for java byte[]. Size:"+binarySize);
-      }
-
-      //System.out.println("Warc entry : totalsize:"+totalSize +" binary size:"+binarySize +" firstHeadersize:"+byteCount);          
-
-      if (loadBinary) {
-        byte[] chars = new byte[(int)binarySize];           
-        bis.read(chars);
-        warcEntry.setBinary(chars);
-
-      }          
-      raf.close();
-      bis.close();
-
-
-
+            //System.out.println("Arc entry : totalsize:"+totalSize +" binary size:"+binarySize +" firstHeadersize:"+byteCount);
+            if (loadBinary) {
+                loadBinary(bis, warcEntry);
+            }
+        }
+    }
+    return warcEntry;
       /*
           System.out.println("-------- binary start");
           System.out.println(new String(chars));
           System.out.println("-------- slut");
        */
-      return warcEntry;
-    }
-    catch(Exception e){
-      throw e;
-    }      
   }
 
 
-  public static BufferedInputStream lazyLoadBinary(String arcFilePath, long arcEntryPosition) throws Exception{
+  public static BufferedInputStream lazyLoadBinary(ArcSource arcSource, long arcEntryPosition) throws Exception{
     ArcEntry arcEntry = new ArcEntry(); // We just throw away the header info anyway 
 
-    if (arcFilePath.endsWith(".gz")){ //It is zipped
+    InputStream is = arcSource.get();
+    IOUtils.skipFully(is, arcEntryPosition);
 
-      RandomAccessFile raf = new RandomAccessFile(new File(arcFilePath), "r");
-      raf.seek(arcEntryPosition);          
-
+    if (arcSource.getSource().toLowerCase(Locale.ROOT).endsWith(".gz")){ //It is zipped
       // log.info("file is zipped:"+arcFilePath);
-      InputStream is = Channels.newInputStream(raf.getChannel());                           
-      GZIPInputStream zipStream = new GZIPInputStream(is);              
+      GZIPInputStream zipStream = new GZIPInputStream(is);
       BufferedInputStream  bis= new BufferedInputStream(zipStream);
-
-      loadWarcHeaderZipped(bis, arcEntry);
+      loadWarcHeader(bis, arcEntry);
 
       BoundedInputStream maxStream = new BoundedInputStream(bis, arcEntry.getBinaryArraySize());
       return new BufferedInputStream(maxStream); // It's a mess to use nested BufferedInputStreams...
 
-    }
-    else {
-      RandomAccessFile raf = new RandomAccessFile(new File(arcFilePath), "r");
-      raf.seek(arcEntryPosition);              
-      loadWarcHeaderNotZipped(raf, arcEntry);
-      InputStream is = Channels.newInputStream(raf.getChannel());
+    } else {
+      BufferedInputStream  bis = new BufferedInputStream(is);
+      loadWarcHeader(bis, arcEntry);
       BoundedInputStream maxStream = new BoundedInputStream(is, arcEntry.getBinaryArraySize());
-      BufferedInputStream bis = new BufferedInputStream(maxStream);
-      return bis;
-    }            
+      return new BufferedInputStream(maxStream);
+    }
 
   }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
@@ -73,7 +73,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
 
             //log.debug("Arc entry : totalsize:"+totalSize +" headersize:"+headerSize+" binary size:"+binarySize);
             if (loadBinary) {
-                loadBinary(is, warcEntry);
+                loadBinary(bis, warcEntry);
             }
         }
         return warcEntry;
@@ -182,7 +182,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
     } else {
       BufferedInputStream  bis = new BufferedInputStream(is);
       loadWarcHeader(bis, arcEntry);
-      BoundedInputStream maxStream = new BoundedInputStream(is, arcEntry.getBinaryArraySize());
+      BoundedInputStream maxStream = new BoundedInputStream(bis, arcEntry.getBinaryArraySize());
       return new BufferedInputStream(maxStream);
     }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/dto/ArcEntry.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/dto/ArcEntry.java
@@ -9,6 +9,7 @@ import java.util.zip.GZIPInputStream;
 
 import javax.xml.bind.annotation.XmlRootElement;
 
+import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
 import org.apache.commons.httpclient.ChunkedInputStream;
 import org.apache.commons.io.IOUtils;
 import org.brotli.dec.BrotliInputStream;
@@ -46,7 +47,7 @@ public class ArcEntry {
   private FORMAT format;
     
   private static final Logger log = LoggerFactory.getLogger(ArcEntry.class);
-  private String sourceFilePath; //full path
+  private ArcSource arcSource;
   private long offset;  
   private boolean hasBeenDecompressed=false;
   private boolean chunked=false;
@@ -70,11 +71,11 @@ public class ArcEntry {
   
   
   
-  public String getSourceFilePath() {
-    return sourceFilePath;
+  public ArcSource getArcSource() {
+    return arcSource;
 }
-public void setSourceFilePath(String sourceFilePath) {
-    this.sourceFilePath = sourceFilePath;
+public void setSource(ArcSource arcSource) {
+    this.arcSource = arcSource;
 }
 public long getOffset() {
     return offset;
@@ -244,16 +245,16 @@ public void setFormat(FORMAT format) {
  */
   public BufferedInputStream getBinaryLazyLoad() throws Exception{
       if (format.equals(FORMAT.ARC)) {
-         return ArcParser.lazyLoadBinary(sourceFilePath, offset);
+         return ArcParser.lazyLoadBinary(arcSource, offset);
      }
       else {
-          return WarcParser.lazyLoadBinary(sourceFilePath, offset);
+          return WarcParser.lazyLoadBinary(arcSource, offset);
       }            
   }
   
   public InputStream getBinaryLazyLoadNoChucking() throws Exception{
       if (format.equals(FORMAT.ARC)) {
-         BufferedInputStream is = ArcParser.lazyLoadBinary(sourceFilePath, offset);              
+         BufferedInputStream is = ArcParser.lazyLoadBinary(arcSource, offset);
          InputStream maybeDechunked = maybeDechunk(is);
          //InputStream maybeUnziped = maybeUnzip(maybeDechunked);
          InputStream maybeBrotliDecoded = maybeBrotliDecode(maybeDechunked);
@@ -261,7 +262,7 @@ public void setFormat(FORMAT format) {
          return maybeBrotliDecoded;
       }
       else {
-           InputStream is = WarcParser.lazyLoadBinary(sourceFilePath, offset);              
+           InputStream is = WarcParser.lazyLoadBinary(arcSource, offset);
            InputStream maybeDechunked = maybeDechunk(is);
            //InputStream maybeUnziped = maybeUnzip(maybeDechunked);
            InputStream maybeBrotliDecoded = maybeBrotliDecode(maybeDechunked);

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/FileMovedMappingResolverTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/FileMovedMappingResolverTest.java
@@ -21,15 +21,15 @@ public class FileMovedMappingResolverTest extends UnitTestUtils {
     //Some warc-files not defined in the moved list
     String warc1="/abc/test/example.warc";
     String warc2="/netarchivemount/warcs/111/example111.warc";
-    assertEquals(warc1, resolver.resolveArcFileLocation(warc1));
-    assertEquals(warc2, resolver.resolveArcFileLocation(warc2));
+    assertEquals(warc1, resolver.resolveArcFileLocation(warc1).getSource());
+    assertEquals(warc2, resolver.resolveArcFileLocation(warc2).getSource());
     
     //These two has been moved
     String warc3="/home/xxx/solrwayback_package_4.2.1/indexing/warcs1/356548-347-20210201093000132-00000-sb-prod-har-001.statsbiblioteket.dk.warc.gz";
     String warc4="/mount/netarchive/test-00000.warc.gz";
 
-    assertEquals(warc3, resolver.resolveArcFileLocation("/home/old/location/356548-347-20210201093000132-00000-sb-prod-har-001.statsbiblioteket.dk.warc.gz"));
-    assertEquals(warc4, resolver.resolveArcFileLocation("/oldlocation/test-00000.warc.gz"));
+    assertEquals(warc3, resolver.resolveArcFileLocation("/home/old/location/356548-347-20210201093000132-00000-sb-prod-har-001.statsbiblioteket.dk.warc.gz").getSource());
+    assertEquals(warc4, resolver.resolveArcFileLocation("/oldlocation/test-00000.warc.gz").getSource());
         
     
     

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportArc.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportArc.java
@@ -8,6 +8,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 
+import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
@@ -26,7 +27,7 @@ public class TestExportArc {
     
 
     
-    ArcEntry arcEntry = ArcParser.getArcEntry(arcFile, offset,true);
+    ArcEntry arcEntry = ArcParser.getArcEntry(ArcSource.fromFile(arcFile), offset, true);
     
     String warcHeader = ArcHeader2WarcHeader.arcHeader2WarcHeader(arcEntry);
     

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarc.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarc.java
@@ -8,6 +8,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 
+import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
@@ -47,7 +48,7 @@ public class TestExportWarc {
       }
       System.out.println(source_file_path);
       System.out.println(offset);
-      ArcEntry warcEntry = WarcParser.getWarcEntry(source_file_path,offset,true);
+      ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(source_file_path), offset, true);
       String warc2HeaderEncoding = warcEntry.getContentEncoding();
       Charset charset = Charset.forName(WarcParser.WARC_HEADER_ENCODING); //Default if none define or illegal charset
  

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarcStreaming.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarcStreaming.java
@@ -4,6 +4,7 @@ package dk.kb.netarchivesuite.solrwayback.parsers;
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
 import dk.kb.netarchivesuite.solrwayback.export.StreamingSolrWarcExportBufferedInputStream;
 import dk.kb.netarchivesuite.solrwayback.facade.Facade;
+import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
 import dk.kb.netarchivesuite.solrwayback.solr.SolrGenericStreaming;
@@ -38,7 +39,7 @@ public class TestExportWarcStreaming extends UnitTestUtils {
 
     byte[] upFrontBinary;
     {
-      ArcEntry warcEntry = WarcParser.getWarcEntry(WARC, OFFSET, true);
+      ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(WARC), OFFSET, true);
       upFrontBinary = warcEntry.getBinary();
       assertEquals("Length for up front load should be as expected", EXPECTED_CONTENT_LENGTH, upFrontBinary.length);
     }
@@ -71,7 +72,7 @@ public class TestExportWarcStreaming extends UnitTestUtils {
 
     byte[] upFrontBinary;
     {
-      ArcEntry warcEntry = WarcParser.getWarcEntry(WARC, OFFSET, true);
+      ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(WARC), OFFSET, true);
       upFrontBinary = warcEntry.getBinary();
       assertEquals("Length for up front load should be as expected", EXPECTED_CONTENT_LENGTH, upFrontBinary.length);
     }
@@ -219,7 +220,7 @@ public class TestExportWarcStreaming extends UnitTestUtils {
     PropertiesLoader.initProperties();
     String source_file_path="/home/teg/workspace/solrwayback/storedanske_export-00000.warc";
     int offset = 515818793;
-    ArcEntry warcEntry = WarcParser.getWarcEntry(source_file_path,offset,true);
+    ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(source_file_path),offset,true);
     
     byte[] bytes = warcEntry.getBinary(); // <--------- The binary
     String fileFromBytes = "image1.jpg";

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
@@ -50,7 +50,9 @@ public class ArcParserTest extends UnitTestUtils{
         
         assertNull(arcEntry.getBinary());
         arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 136767); //Image entry and load binary
-        byte[] orgBinary = arcEntry.getBinary();        
+        byte[] orgBinary = arcEntry.getBinary();
+        assertTrue("The extracted binary size should be > 0 but was " + arcEntry.getBinaryArraySize(),
+                   arcEntry.getBinaryArraySize() > 0);
         try (BufferedInputStream buf = arcEntry.getBinaryLazyLoad()) {
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",


### PR DESCRIPTION
Switch from `RandomAccessFile` to `InputStream` as the source of data in the `ArcParser` and `WarcParser` classes, thereby making it (a lot) easier to add support for HTTP and similar non-file sources by creating a custom implementation of the `ArcFileLocationResolverInterface`.