### PR TITLE
WARCs over HTTP

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcFileLocationResolverInterface.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcFileLocationResolverInterface.java
@@ -1,5 +1,6 @@
 package dk.kb.netarchivesuite.solrwayback.interfaces;
 
+import java.util.Map;
 import java.util.function.Supplier;
 
 public interface ArcFileLocationResolverInterface {
@@ -22,7 +23,7 @@ public interface ArcFileLocationResolverInterface {
    */
   ArcSource resolveArcFileLocation(String source_file_path);
 
-  void setParameters(String parameter);
+  void setParameters(Map<String, String> parameters);
   void initialize();
 
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcHTTPResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcHTTPResolver.java
@@ -1,0 +1,121 @@
+package dk.kb.netarchivesuite.solrwayback.interfaces;
+
+import dk.kb.netarchivesuite.solrwayback.util.SkippingHTTPInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Adjusts the given input using regexp/pattern and expects the result to be a {@code HTTP} or {@code HTTPS} URL.
+ * This implementation supports efficient skips, if the server has HTTP Range Request support for type {@code bytes}
+ *
+ * To activate it, set this in solrwayback.properties:
+ *   {@code warc.file.resolver.class=ArcHTTPResolver}
+ *   {@code warc.file.resolver.parameters.path.regexp=<regexp for the input>}
+ *   {@code warc.file.resolver.parameters.path.replacement=<replacement definition for the regexp result>}
+ *   {@code warc.file.resolver.parameters.readfallback=<true if servers without HTTP Range Request support are acceptable>}
+ * The regexp and the pattern defaults to {@code .*} and {@code $0} respectively (the identity).
+ *
+ * Sample config for requesting the WARCs from a remote server by stripping the path and using the filename only:
+ *   {@code warc.file.resolver.parameters.path.regexp=.*([^/]*)}
+ *   {@code warc.file.resolver.parameters.path.replacement=http://example.com/warcstore/$1}
+ *   {@code warc.file.resolver.parameters.readfallback=false}
+ *
+ * This resolver class will be activated by the InitialContextLoader.
+ *
+ * Note: In order for HTTP(S) to be efficient as a delivery mechanism for WARC content, the server must support
+ * HTTP range requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
+ * It is not recommended to set readfallback to true as this will result is excessive overhead, unless the
+ * backing WARC files are tiny (a few megabytes), if the server does not support range requests.
+ */
+public class ArcHTTPResolver implements ArcFileLocationResolverInterface {
+    private static final Logger log = LoggerFactory.getLogger(ArcHTTPResolver.class);
+
+    public static final String REGEXP_KEY = "path.regexp";
+    public static final String REGEXP_DEFAULT = ".*";
+    public static final String REPLACEMENT_KEY = "path.replacement";
+    public static final String REPLACEMENT_DEFAULT = "$0";
+    public static final String READ_FALLBACK_KEY = "readfallback";
+    public static final boolean READ_FALLBACK_DEFAULT = false;
+
+    private Pattern regexp = Pattern.compile(".*"); // Match everything
+    private String replacement = "$1";                    // The full match
+    private boolean readFallback = false;
+
+    public ArcHTTPResolver() { }
+
+    @Override
+    public void setParameters(Map<String, String> parameters) {
+        setPathPattern(parameters.getOrDefault(REGEXP_KEY, REGEXP_DEFAULT));
+        setPathReplacement(parameters.getOrDefault(REPLACEMENT_KEY, REPLACEMENT_DEFAULT));
+        setReadFallback(Boolean.parseBoolean(parameters.getOrDefault(READ_FALLBACK_KEY, Boolean.toString(READ_FALLBACK_DEFAULT))));
+    }
+
+    public void setPathPattern(String inputPattern) {
+        this.regexp = Pattern.compile(inputPattern);
+    }
+
+    public void setPathReplacement(String replacement) {
+        this.replacement = replacement;
+    }
+
+    public void setReadFallback(boolean readFallback) {
+        this.readFallback = readFallback;
+    }
+
+    @Override
+    public void initialize() {
+        log.info("Initialized " + this);
+    }
+  
+    @Override
+    public ArcSource resolveArcFileLocation(String source_file_path) {
+        Matcher m = regexp.matcher(source_file_path);
+        if (!m.matches()) {
+            throw new IllegalArgumentException("Unable to match '" + source_file_path + "'");
+        }
+        String rewritten = m.replaceFirst(replacement);
+        if (!rewritten.startsWith("http")) {
+            throw new IllegalArgumentException(
+                    "The source '" + rewritten + "' derived from '" + source_file_path + "' is not a HTTP URL");
+        }
+        return makeHTTPSource(rewritten);
+    }
+
+    /**
+     * Parse the given urlString to an URL and deliver the content as a {@link SkippingHTTPInputStream}.
+     * @param urlString the URL to retrieve the content for.
+     * @return an InputStream for the resource that supports efficient skipping.
+     */
+    private ArcSource makeHTTPSource(String urlString) {
+        final URL url;
+        try {
+            url = new URL(urlString);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Unable to construct URL from '" + urlString + "'", e);
+        }
+
+        return new ArcSource(urlString, () -> {
+            try {
+                return new SkippingHTTPInputStream(url, readFallback);
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to open stream for '" + urlString + "'", e);
+            }
+        });
+    }
+
+    @Override
+    public String toString() {
+        return "ArcHTTPResolver(" +
+               "regexp=" + regexp +
+               ", replacement='" + replacement + '\'' +
+               ", readFallback=" + readFallback +
+               ')';
+    }
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/FileMovedMappingResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/FileMovedMappingResolver.java
@@ -2,8 +2,10 @@ package dk.kb.netarchivesuite.solrwayback.interfaces;
 
 import java.io.*;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 
+import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,9 +45,13 @@ public class FileMovedMappingResolver implements ArcFileLocationResolverInterfac
     }    
     
     @Override
-    public void setParameters(String parameter) {
-      log.info("Initializing file mapping parameter:"+parameter);
-      mappingFile=parameter;      
+    public void setParameters(Map<String, String> parameters) {
+        setMappingFile(parameters.get(PropertiesLoader.WARC_FILE_RESOLVER_UNQUALIFIED));
+        log.info("Initializing file mapping parameter: " + mappingFile);
+    }
+
+    public void setMappingFile(String mappingFile) {
+        this.mappingFile = mappingFile;
     }
 
     @Override

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/IdentityArcFileResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/IdentityArcFileResolver.java
@@ -1,8 +1,7 @@
 package dk.kb.netarchivesuite.solrwayback.interfaces;
 
 
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
+import java.util.Map;
 
 public class IdentityArcFileResolver implements ArcFileLocationResolverInterface {
   /*
@@ -14,7 +13,7 @@ public class IdentityArcFileResolver implements ArcFileLocationResolverInterface
     return ArcSource.fromFile(source_file_path);
   }
   @Override
-  public void setParameters(String parameters) {
+  public void setParameters(Map<String, String> parameters) {
     //Does not use parameters
   }
   

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/InputStreamUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/InputStreamUtils.java
@@ -51,11 +51,12 @@ public class InputStreamUtils {
      * {@link InputStream#skip} to allow for efficient skipping.
      * @param input stream to skip.
      * @param toSkip the number of bytes to skip.
+     * @return the number of bytes skipped. This will always be equal to toSkip as everything else raises an Exception.
      * @throws IOException              if there is a problem reading the file.
      * @throws IllegalArgumentException if toSkip is negative.
      * @throws EOFException             if the number of bytes skipped was incorrect.
      */
-    public static void skipFully(final InputStream input, final long toSkip) throws IOException {
+    public static long skipFully(final InputStream input, final long toSkip) throws IOException {
         if (toSkip < 0) {
             throw new IllegalArgumentException("Bytes to skip must not be negative: " + toSkip);
         }
@@ -63,6 +64,7 @@ public class InputStreamUtils {
         if (skipped != toSkip) {
             throw new EOFException("Bytes to skip: " + toSkip + " actual: " + skipped);
         }
+        return toSkip;
     }
 
     /**

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SkippingHTTPInputStream.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SkippingHTTPInputStream.java
@@ -100,6 +100,7 @@ public class SkippingHTTPInputStream extends InputStream {
 
         URLConnection urlCon = createURLConnection(startOffset);
         inner = urlCon.getInputStream();
+        position = startOffset;
         return startOffset;
     }
 
@@ -123,6 +124,13 @@ public class SkippingHTTPInputStream extends InputStream {
             urlCon.setRequestProperty("Range", "bytes=" + startOffset + "-");
         }
         return urlCon;
+    }
+
+    /**
+     * @return the position in the resource, measured in bytes.
+     */
+    public long getPosition() {
+        return position;
     }
 
     @Override

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SkippingHTTPInputStream.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SkippingHTTPInputStream.java
@@ -1,0 +1,228 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * HTTP InputStream with the special feature that {@link InputStream#skip(long)} uses HTTP Range Request to perform
+ * efficient skipping.
+ */
+public class SkippingHTTPInputStream extends InputStream {
+    private static final Logger log = LoggerFactory.getLogger(SkippingHTTPInputStream.class);
+
+    // Skips smaller than this are handled by reads instead of creating a new connection
+    private static final long TRIVIAL_SKIP = 8192;
+
+    private final boolean fallbackToRead;
+    private final URL url;
+
+    private final boolean supportsRangeRequests;
+    private long position = 0;
+    private InputStream inner;
+
+    /**
+     * Construct an InputStream for the given url, with the special feature that calling {@link InputStream#skip(long)}
+     * will use HTTP Range Request to perform efficient skipping. If the server does not support Range Requests, calls
+     * to skip will fail.
+     * @param url a HTTP or HTTPS URL.
+     * @return an InputStream for HTTP-URLs with efficient skipping.
+     * @throws java.io.IOException if the stream could not be constructed.
+     * @see "https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests"
+     */
+    public SkippingHTTPInputStream(URL url) throws IOException {
+        this(url, false);
+    }
+    /**
+     * Construct an InputStream for the given url, with the special feature that calling {@link InputStream#skip(long)}
+     * will use HTTP Range Request to perform efficient skipping.
+     * @param url a HTTP or HTTPS URL.
+     * @param fallbackToRead if true, the implementation will use {@link InputStream#read} if the server does not
+     *                       support Range Requests. If false, calls to {@link InputStream#skip(long)} will fail.
+     * @return an InputStream for HTTP-URLs with efficient skipping.
+     * @throws java.io.IOException if the stream could not be constructed.
+     * @see "https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests"
+     */
+    public SkippingHTTPInputStream(URL url, boolean fallbackToRead) throws IOException {
+        this.url = url;
+        this.fallbackToRead = fallbackToRead;
+        supportsRangeRequests = supportsRangeRequests(url);
+        log.debug("Created " + this);
+    }
+
+    /**
+     * @param url a HTTP or HTTPS URL.
+     * @return true if the server supports HTTP Range Requests.
+     */
+    public static boolean supportsRangeRequests(URL url) throws IOException {
+        URLConnection urlCon = url.openConnection();
+        // There is no explicit close() for URLConnection. Hopefully getHeaderFields closes after itself
+        Map<String, List<String>> map = urlCon.getHeaderFields();
+        List<String> acceptRanges = map.get("Accept-Ranges");
+        return acceptRanges != null && acceptRanges.contains("bytes");
+    }
+
+    /**
+     * Connect to the url given in the constructor, using a Range Request if {@code startOffset != 0}.
+     * @param startOffset start position in the data.
+     * @return startOffset.
+     * @throws IOException if the connection at the given offset could not be established.
+     */
+    long connect(long startOffset) throws IOException {
+        if (inner != null) {
+            try {
+                inner.close();
+            } catch (IOException e) {
+                log.warn("IOException closing existing inner as preparation for Range Request to pos " + startOffset);
+            }
+        }
+
+        URLConnection urlCon = createURLConnection(startOffset);
+        inner = urlCon.getInputStream();
+        return startOffset;
+    }
+
+    /**
+     * Create a URLConnection where the available inputStream starts at startOffset.
+     * @param startOffset start position in the data.
+     * @return a URLConnection where the available inputStream starts at startOffset.
+     * @throws IOException if the connection at the given offset could not be established.
+     */
+    URLConnection createURLConnection(long startOffset) throws IOException {
+        URLConnection urlCon = url.openConnection();
+        urlCon.setRequestProperty("User-Agent", "Java Client; SolrWayback");
+        urlCon.setRequestProperty("Accept", "*/*");
+        urlCon.setRequestProperty("Connection", "close");
+        if (startOffset > 0) {
+            if (!supportsRangeRequests) {
+                throw new IOException("connect(startOffset=" + startOffset + ") called for server that does not " +
+                                      "support HTTP Range Requests: " + url);
+            }
+            // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Range
+            urlCon.setRequestProperty("Range", "bytes=" + startOffset + "-");
+        }
+        return urlCon;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        if (n < 0) {
+            throw new IllegalArgumentException("Cannot skip a negative amount: " + n);
+        }
+        if (n == 0) {
+            return 0;
+        }
+
+        if (n < TRIVIAL_SKIP || (!supportsRangeRequests && fallbackToRead)) {
+            // Skip by delegating to the standard HTTP/HTTPS-InputStream which uses read for skips
+            return skipByDelegation(n);
+        };
+
+        if (!supportsRangeRequests) {
+            throw new IOException("Skip of " + n + " bytes requested but the server does not support " +
+                                  "HTTP Range Requests and fallbackToRead == false: " + url);
+        }
+
+        // Skip by creating a new connection
+        long newPos = connect(position + n);
+        if (newPos - position != n) {
+            throw new IOException(String.format(
+                    Locale.ROOT,
+                    "Unable to (re)connect and skip %d bytes from %d to %d. Only skipped %d bytes to %d: %s",
+                    n, position, position + n, newPos - position, newPos, url));
+        }
+        position = newPos;
+        return n;
+    }
+
+    /**
+     * Delegates skipping to inner, which typically means reading instead of skipping.
+     */
+    long skipByDelegation(long n) throws IOException {
+        if (inner == null) {
+            connect(0);
+        }
+
+        long skipped = inner.skip(n); // Note that skip does not guarantee skipping n, only <= n
+        if (skipped != n) {
+            log.debug(String.format(
+                    Locale.ROOT, "Unable to delegate-skip %d bytes from %d to %d. Only skipped %d bytes to %d: %s",
+                    n, position, position + n, skipped, position + skipped, url));
+        }
+        position += skipped;
+        return n;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (inner == null) {
+            connect(0);
+        }
+        int b = inner.read();
+        if (b != -1) {
+            ++position;
+        }
+        return b;
+    }
+
+    // No need to override
+    // public int read(byte[] b) throws IOException
+    // as it calls read(byte[] b, int off, int len)
+
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (inner == null) {
+            connect(0);
+        }
+        int read = inner.read(b, off, len);
+        position += read;
+        return read;
+    }
+
+    @Override
+    public int available() throws IOException {
+        if (inner == null) {
+            connect(0);
+        }
+        return inner.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (inner != null) {
+            inner.close();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "SkippingHTTPInputStream(" +
+               "url=" + url +
+               ", fallbackToRead=" + fallbackToRead +
+               ", supportsRangeRequests=" + supportsRangeRequests +
+               ", position=" + position +
+               ')';
+    }
+}

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcHTTPResolverTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcHTTPResolverTest.java
@@ -1,0 +1,58 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.interfaces;
+
+import dk.kb.netarchivesuite.solrwayback.util.SkippingHTTPInputStreamTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Piggy backs on {@link dk.kb.netarchivesuite.solrwayback.util.SkippingHTTPInputStreamTest}.
+ */
+public class ArcHTTPResolverTest {
+    public static final String ADAMS_FILE = "foo/18068_Adams_Illustrated_Panorama_of_History_1878_size_104345x11288.tif";
+
+    @Test
+    public void testSkip() throws IOException {
+        Map<String, String> skipParams = new HashMap<>();
+        skipParams.put(ArcHTTPResolver.REGEXP_KEY, ".*/([^/]*)");
+        skipParams.put(ArcHTTPResolver.REPLACEMENT_KEY, "https://labs.statsbiblioteket.dk/anskuelse/adams_history/$1");
+        skipParams.put(ArcHTTPResolver.READ_FALLBACK_KEY, "false");
+        ArcHTTPResolver resolver = new ArcHTTPResolver();
+        resolver.setParameters(skipParams);
+        resolver.initialize();
+
+        ArcSource source = resolver.resolveArcFileLocation(ADAMS_FILE);
+
+        // Base verify of skip
+        try (InputStream is = source.get()) {
+            SkippingHTTPInputStreamTest.assertContent(is, "Adams_take1");
+        }
+
+        // Verify that multiple calls to get works as intended
+        try (InputStream is = source.get()) {
+            SkippingHTTPInputStreamTest.assertContent(is, "Adams_take2");
+        }
+
+    }
+
+
+}

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/FileMovedMappingResolverTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/FileMovedMappingResolverTest.java
@@ -3,7 +3,6 @@ package dk.kb.netarchivesuite.solrwayback.interfaces;
 import static org.junit.Assert.assertEquals;
 
 import java.io.File;
-
 import org.junit.Test;
 
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
@@ -15,7 +14,7 @@ public class FileMovedMappingResolverTest extends UnitTestUtils {
     File file = getFile("src/test/resources/arc_resolvers/FileMovedMappingTest.txt");
 
     FileMovedMappingResolver resolver = new FileMovedMappingResolver();
-    resolver.setParameters(file.getCanonicalPath());
+    resolver.setMappingFile(file.getCanonicalPath());
     resolver.initialize();
 
     //Some warc-files not defined in the moved list

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/util/SkippingHTTPInputStreamTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/util/SkippingHTTPInputStreamTest.java
@@ -1,0 +1,75 @@
+package dk.kb.netarchivesuite.solrwayback.util;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+public class SkippingHTTPInputStreamTest {
+
+    // Supports range requests and should be fairly permanent. 3.5 GigaBytes
+    public static final String ADAMS =
+            "https://labs.statsbiblioteket.dk/anskuelse/adams_history/18068_Adams_Illustrated_Panorama_of_History_1878_size_104345x11288.tif";
+    public static final int BYTE_870 = 111;
+    public static final int BYTE_33638 = 238;
+
+    @Test
+    public void testRangeSupport() throws IOException {
+        System.out.println(SkippingHTTPInputStream.supportsRangeRequests(new URL("https://www.kb.dk/")));
+    }
+
+    @Test
+    public void testBaseline() throws IOException {
+        try (InputStream is = getAdamsURL().openStream()) {
+            assertContent(is, "Skipping");
+        }
+    }
+
+    @Test
+    public void testSkipper() throws IOException {
+        try (InputStream is = new SkippingHTTPInputStream(getAdamsURL())) {
+            assertContent(is, "Skipping");
+        }
+    }
+
+    public static void assertContent(InputStream is, String designation) throws IOException {
+        byte[] BUFFER = new byte[1024];
+        assertEquals("Reading buffer of size " + BUFFER.length + " should fill the buffer",
+                     BUFFER.length, is.read(BUFFER));
+        assertEquals("Reading 1KB directly with '" + designation + "' should yield the expected byte at pos 870",
+                     BYTE_870, 0xFF & BUFFER[870]);
+
+        InputStreamUtils.skipFully(is, 31*1024);
+        assertEquals("Reading buffer of size " + BUFFER.length + " should fill the buffer",
+                     BUFFER.length, is.read(BUFFER));
+        assertEquals("Skipping 32KB more with ' " + designation + "' should yield the expected byte at pos 33638 (32KB + 870)",
+                     BYTE_33638, 0xFF & BUFFER[870]);
+    }
+
+    private URL getAdamsURL() {
+        try {
+            return new URL(ADAMS);
+        } catch (MalformedURLException e) {
+            throw new RuntimeException("Malformed URL '" + ADAMS + "'", e);
+        }
+    }
+
+}


### PR DESCRIPTION
@anjackson needs support for WARCs over HTTP and some digging around for a HTTP InputStream implementation with efficient skipping (using [HTTP Range Requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests)) did not give any results.

This pull request adds an implementation of efficient HTTP skip; the `ArcHTTPResolver`. Skips are handled by closing the existing HTTP connection and opening a new one at `<current position> + <skip>`.