### PR TITLE
Proper reads

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
@@ -1,6 +1,7 @@
 package dk.kb.netarchivesuite.solrwayback.parsers;
 
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +32,7 @@ public class ArcWarcFileParserAbstract {
       byte[] bytes = new byte[(int) binarySize];
 
       // we are not using IOUtils.readFully as we'd rather return non-complete data than nothing
-      int read = is.read(bytes);
+      int read = IOUtils.read(is, bytes);
       if (read == -1) {
           log.warn("Attempted to load binary for {}#{} but got EOF immediately",
                    arcEntry.getArcSource().getSource(), arcEntry.getOffset());

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/DelayedInputStream.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/DelayedInputStream.java
@@ -87,48 +87,48 @@ public class DelayedInputStream extends InputStream {
     @Override
     public int read(byte[] b) throws IOException {
         ensureStream();
-        return inner.read(b);    // TODO: Implement this
+        return inner.read(b);
     }
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
         ensureStream();
-        return inner.read(b, off, len);    // TODO: Implement this
+        return inner.read(b, off, len);
     }
 
     @Override
     public long skip(long n) throws IOException {
         ensureStream();
-        return inner.skip(n);    // TODO: Implement this
+        return inner.skip(n);
     }
 
     @Override
     public int available() throws IOException {
         ensureStream();
-        return inner.available();    // TODO: Implement this
+        return inner.available();
     }
 
     @Override
     public void close() throws IOException {
         ensureStream();
-        inner.close();    // TODO: Implement this
+        inner.close();
     }
 
     @Override
     public synchronized void mark(int readlimit) {
         ensureStream();
-        inner.mark(readlimit);    // TODO: Implement this
+        inner.mark(readlimit);
     }
 
     @Override
     public synchronized void reset() throws IOException {
         ensureStream();
-        inner.reset();    // TODO: Implement this
+        inner.reset();
     }
 
     @Override
     public boolean markSupported() {
         ensureStream();
-        return inner.markSupported();    // TODO: Implement this
+        return inner.markSupported();
     }
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
@@ -6,10 +6,12 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,23 +34,10 @@ public class FileUtil {
             if (!Files.exists(path)) {
                 throw new FileNotFoundException("Unable to locate '" + resource + "'");
             }
-            
             url = path.toUri().toURL();
         }
-        try (InputStream in = url.openStream();
-                
-                ByteArrayOutputStream out = new ByteArrayOutputStream(1024);) {
-            byte[] buffer = new byte[1024];
-            int len = in.read(buffer);
-            while (len != -1) {
-                out.write(buffer, 0, len);
-                len = in.read(buffer);
-            }
-            return out.toString("utf-8");
-        }
+        return IOUtils.toString(url, StandardCharsets.UTF_8);
     }
-    
-    
     
     /**
      * 

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/UnitTestUtils.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/UnitTestUtils.java
@@ -1,5 +1,7 @@
 package dk.kb.netarchivesuite.solrwayback;
 
+import org.apache.commons.io.IOUtils;
+
 import java.io.*;
 import java.net.URL;
 import java.nio.charset.Charset;
@@ -35,7 +37,7 @@ public class UnitTestUtils {
         }
         InputStream in = new FileInputStream(source);
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
-        pipe(in, bos);
+        IOUtils.copy(in, bos);
         in.close();
         return bos.toString("utf-8");
     }
@@ -49,13 +51,5 @@ public class UnitTestUtils {
         out.close();
     }
 
-    private static void pipe(InputStream in, OutputStream out) throws IOException {
-        byte[] buffer = new byte[1024];
-        int read;
-        while ((read = in.read(buffer)) != -1) {
-            out.write(buffer, 0, read);
-        }
-        out.flush();
-    }
 
 }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriteTestHelper.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriteTestHelper.java
@@ -16,6 +16,7 @@ package dk.kb.netarchivesuite.solrwayback.parsers;
 
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDocShort;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.logging.Log;
 
@@ -24,6 +25,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -112,16 +114,6 @@ public class RewriteTestHelper {
             }
             url = path.toUri().toURL();
         }
-
-        try (InputStream in = url.openStream();
-             ByteArrayOutputStream out = new ByteArrayOutputStream(1024);) {
-            byte[] buffer = new byte[1024];
-            int len = in.read(buffer);
-            while (len != -1) {
-                out.write(buffer, 0, len);
-                len = in.read(buffer);
-            }
-            return out.toString("utf-8");
-        }
+        return IOUtils.toString(url, StandardCharsets.UTF_8);
     }
 }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcGzParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcGzParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import java.io.BufferedInputStream;
 import java.io.File;
+
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
@@ -53,7 +55,7 @@ public class ArcGzParserTest extends UnitTestUtils {
         try (BufferedInputStream buf = arcEntry.getBinaryLazyLoad()) {
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",
-                         newBinary.length, buf.read(newBinary));
+                         newBinary.length, IOUtils.read(buf, newBinary));
             assertEquals(orgBinary.length, newBinary.length); //Same length
             assertArrayEquals(orgBinary, newBinary); //Same binary
             assertEquals("There should be no more content in the lazy loaded stream", -1, buf.read());

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
@@ -9,6 +9,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
@@ -56,7 +57,7 @@ public class ArcParserTest extends UnitTestUtils{
         try (BufferedInputStream buf = arcEntry.getBinaryLazyLoad()) {
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",
-                         newBinary.length, buf.read(newBinary));
+                         newBinary.length, IOUtils.read(buf, newBinary));
             assertEquals(orgBinary.length, newBinary.length); //Same length
             assertArrayEquals(orgBinary, newBinary); //Same binary
             assertEquals("There should be no more content in the lazy loaded stream", -1, buf.read());

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
@@ -8,6 +8,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
@@ -55,7 +56,7 @@ public class WarcGzParserTest  extends UnitTestUtils{
 
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",
-                         newBinary.length, buf.read(newBinary));
+                         newBinary.length, IOUtils.read(buf, newBinary));
             assertEquals(orgBinary.length, newBinary.length); //Same length
             assertArrayEquals(orgBinary, newBinary); //Same binary
             assertEquals("There should be no more content in the lazy loaded stream", -1, buf.read());

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcParserTest.java
@@ -6,6 +6,7 @@ import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.File;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
@@ -64,7 +65,7 @@ public class WarcParserTest extends UnitTestUtils{
         try (BufferedInputStream buf = arcEntry.getBinaryLazyLoad()) {
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",
-                         newBinary.length, buf.read(newBinary));
+                         newBinary.length, IOUtils.read(buf, newBinary));
             assertEquals(orgBinary.length, newBinary.length); //Same length
             assertArrayEquals(orgBinary, newBinary); //Same binary
             assertEquals("There should be no more content in the lazy loaded stream", -1, buf.read());

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/util/SkippingHTTPInputStreamTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/util/SkippingHTTPInputStreamTest.java
@@ -58,7 +58,6 @@ public class SkippingHTTPInputStreamTest {
 //                     BUFFER.length, is.read(BUFFER));
         assertEquals("Reading 1KB directly with '" + designation + "' should yield the expected byte at pos 870",
                      BYTE_870, 0xFF & BUFFER[870]);
-
         InputStreamUtils.skipFully(is, 31*1024);
         IOUtils.readFully(is, BUFFER);
 //        assertEquals("Reading buffer of size " + BUFFER.length + " should fill the buffer",


### PR DESCRIPTION
Switches to Apache IOUtils' "read until the data are fetched or EOF" implementations where it makes sense. This should ensure that WARC content fetched over HTTP will be fully delivered.

This closes #213 