### PR TITLE
Fix ngram end year bug

### DIFF
--- a/src/js/src/components/ngrams/netarchive/configs.js
+++ b/src/js/src/components/ngrams/netarchive/configs.js
@@ -1,7 +1,7 @@
 import APP_CONFIGS from '../../../configs'
 export default {
   SERVICE_URL : 'services/search/',
-  END_YEAR: '2021',
+  END_YEAR: new Date().getFullYear().toString(),
   BASE_SEARCH_URL: () => {
       let searchPrefix = window.location.pathname.split('/')[1] === 'search' ? '' : 'search'
       return `${APP_CONFIGS.playbackConfig.solrwaybackBaseURL}${searchPrefix}`

--- a/src/js/src/components/ngrams/netarchive/configs.js
+++ b/src/js/src/components/ngrams/netarchive/configs.js
@@ -1,7 +1,7 @@
 import APP_CONFIGS from '../../../configs'
 export default {
   SERVICE_URL : 'services/search/',
-  END_YEAR: new Date().getFullYear().toString(),
+  END_YEAR: (new Date().getFullYear() + 1).toString(),
   BASE_SEARCH_URL: () => {
       let searchPrefix = window.location.pathname.split('/')[1] === 'search' ? '' : 'search'
       return `${APP_CONFIGS.playbackConfig.solrwaybackBaseURL}${searchPrefix}`


### PR DESCRIPTION
Fixes ngram end year bug by making the end year the current year. For some yet unknown reason we have to +1 the year to make the graph tool work.