### PR TITLE
Refactor normalization

### DIFF
--- a/docker/solrwayback.properties
+++ b/docker/solrwayback.properties
@@ -27,9 +27,6 @@ warc.file.resolver.parameters.path.regexp=(.*/)?([^/]*)$
 warc.file.resolver.parameters.path.replacement=${WARC_SERVER_PREFIX}$2
 warc.file.resolver.parameters.readfallback=false
 
-#Optional. Set to true if the index was build with warc-indexer 3.0.0 and not 3.0.1+. ( or if you upgrade from solrwayback release 3.1).
-#warcindexer.urlnormaliser.legacy=true
-
 #Collection name. This is the name shown when exporting a page to PID-XML.
 pid.collection.name=${COLLECTION_NAME}
 
@@ -49,10 +46,16 @@ screenshot.temp.imagedir=/tmp/
 #Timeout in seconds. Optional, 10 seconds is default. 
 screenshot.preview.timeout=10
 
+
+#The possible values for url.normaliser are: normal, legacy and minimal.
+# Only change the normaliser type if you know what you are doing.
+# Only use minimal if the solr index was build in warc-indexer earlier that 3.0. All SolrWayback bundles have warc-indexer later than this. (Playback quality is drastically reduced)
+# Use Legacy for 3.0-3.1 versions of the warc-indexer.
+# Use normal for all warc-indexers version 3.2.0+
+url.normaliser=legacy
+
 # Optional list of Solr-params. Format is key1=value1;key2=value2,...
 #solr.search.params=facet.limit=2;rows=3
 # Add some default values for properties so basic search behaviour is as expected.
 solr.search.params=f.url_norm.qf=url;defType=edismax;pf=text;qf=text
 
-# Use mimimal URL normalisation:
-url.normaliser=minimal

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -333,19 +333,20 @@ public class Facade {
         URL uri = new URL(url);
         String hostName = uri.getHost();
         String hostNameEncoded = IDN.toASCII(hostName);
-
+        
         String path = uri.getPath();
         if ("".equals(path)) {
             path = "/";
         }
         String urlQueryPath = uri.getQuery();
+        String urlPunied = null;
         if (urlQueryPath == null) {
-            urlQueryPath = "";
+             urlPunied = "http://" + hostNameEncoded + path;
         }
-
-        String urlPunied = "http://" + hostNameEncoded + path +"?"+ urlQueryPath;
-        String urlPuniedAndNormalized = Normalisation.canonicaliseURL(urlPunied);
-
+        else {
+            urlPunied = "http://" + hostNameEncoded + path +"?"+ urlQueryPath;            
+        }
+        String urlPuniedAndNormalized = Normalisation.canonicaliseURL(urlPunied);       
         return urlPuniedAndNormalized;
     }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/Normalisation.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/Normalisation.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 public class Normalisation {
  
    private static final Logger log = LoggerFactory.getLogger(Normalisation.class);
-   private enum NormaliseType {NORMAL,LEGACY,MINIMAL};
+  public enum NormaliseType {NORMAL,LEGACY,MINIMAL};
    
    static private NormaliseType type = NormaliseType.NORMAL;
    
@@ -94,4 +94,10 @@ public class Normalisation {
     public static NormaliseType getType() {
         return type;
     }
+
+    public static void setType(NormaliseType type) {
+        Normalisation.type = type;
+    }
+    
+    
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/Normalisation.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/Normalisation.java
@@ -8,9 +8,7 @@ import org.slf4j.LoggerFactory;
  * 
  * This class will delegate to the Normalisation class defined in solrWayback.properties 
  * Always use NORMAL unless you using very old versions of WARC-Indexer
- * 
- * This class needs some refactoring into an abstract class instead of the switches!
- * 
+ *  
  * @author teg
  *
  */
@@ -95,6 +93,7 @@ public class Normalisation {
         return type;
     }
 
+    // Only called from unittests
     public static void setType(NormaliseType type) {
         Normalisation.type = type;
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/NormalisationAbstract.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/NormalisationAbstract.java
@@ -1,0 +1,146 @@
+package dk.kb.netarchivesuite.solrwayback.normalise;
+
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.util.regex.Pattern;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class NormalisationAbstract {
+
+    private static Log log = LogFactory.getLog( NormalisationAbstract.class );
+    
+    private static Charset UTF8_CHARSET = Charset.forName("UTF-8");
+    protected static Pattern DOMAIN_ONLY = Pattern.compile("https?://[^/]+");
+    private final static byte[] HEX = "0123456789abcdef".getBytes(UTF8_CHARSET); // Assuming lowercase
+    
+    
+    // Requires valid %-escapes (as produced by fixEscapeErrorsAndUnescapeHighOrderUTF8) and UTF-8 bytes
+    protected static String escapeUTF8(final byte[] utf8, boolean escapeHighOrder, boolean normaliseLowOrder) {
+        ByteArrayOutputStream sb = new ByteArrayOutputStream(utf8.length*2);
+        int i = 0;
+        boolean paramSection = false; // Affects handling of space and plus
+        while (i < utf8.length) {
+            int c = 0xFF & utf8[i];
+            paramSection |= c == '?';
+            if (paramSection && c == ' ') { // In parameters, space becomes plus
+                sb.write(0xFF & '+');
+            } else if (c == '%') {
+                int codePoint = Integer.parseInt("" + (char) utf8[i + 1] + (char) utf8[i + 2], 16);
+                if (paramSection && codePoint == ' ') { // In parameters, space becomes plus
+                    sb.write(0xFF & '+');
+                } else if (mustEscape(codePoint) || keepEscape(codePoint) || !normaliseLowOrder) { // Pass on unmodified
+                    hexEscape(codePoint, sb);
+                } else { // Normalise to ASCII
+                    sb.write(0xFF & codePoint);
+                }
+                i += 2;
+            } else if ((0b10000000 & c) == 0) { // ASCII
+                if (mustEscape(c)) {
+                    hexEscape(c, sb);
+                } else {
+                    sb.write(0xFF & c);
+                }
+            } else if ((0b11000000 & c) == 0b10000000) { // Non-first UTF-8 byte as first byte
+                hexEscape(c, sb);
+            } else if ((0b11100000 & c) == 0b11000000) { // 2 byte UTF-8
+                if (i >= utf8.length-1 || (0b11000000 & utf8[i+1]) != 0b10000000) { // No byte or wrong byte follows
+                    hexEscape(c, sb);
+                } else if (escapeHighOrder) {
+                    hexEscape(0xff & utf8[i++], sb);
+                    hexEscape(0xff & utf8[i], sb);
+                } else {
+                    sb.write(utf8[i++]);
+                    sb.write(utf8[i]);
+                }
+            } else if ((0b11110000 & utf8[i]) == 0b11100000) { // 3 byte UTF-8
+                if (i >= utf8.length-2 || (0b11000000 & utf8[i+1]) != 0b10000000 ||
+                    (0b11000000 & utf8[i+2]) != 0b10000000) { // Too few or wrong bytes follows
+                    hexEscape(c, sb);
+                } else {
+                    hexEscape(0xff & utf8[i++], sb);
+                    hexEscape(0xff & utf8[i++], sb);
+                    hexEscape(0xff & utf8[i], sb);
+                }
+            } else if ((0b11111000 & utf8[i]) == 0b11110000) { // 4 byte UTF-8
+                if (i >= utf8.length-3 || (0b11000000 & utf8[i+1]) != 0b10000000 || // Too few or wrong bytes follows
+                    (0b11000000 & utf8[i+2]) != 0b10000000 || (0b11000000 & utf8[i+3]) != 0b10000000) {
+                    hexEscape(c, sb);
+                } else {
+                    hexEscape(0xff & utf8[i++], sb);
+                    hexEscape(0xff & utf8[i++], sb);
+                    hexEscape(0xff & utf8[i++], sb);
+                    hexEscape(0xff & utf8[i], sb);
+                }
+            } else {  // Illegal first byte for UTF-8
+                hexEscape(c, sb);
+                log.debug("Sanity check: Unexpected code path encountered.: The input byte-array did not translate" +
+                          " to supported UTF-8 with invalid first-byte for UTF-8 codepoint '0b" +
+                          Integer.toBinaryString(c) + "'. Writing escape code for byte " + c);
+            }
+            i++;
+        }
+        try {
+            return sb.toString("utf-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalStateException("Internal error: UTF-8 must be supported by the JVM", e);
+        }
+    }
+    
+ // Normalisation to UTF-8 form
+   protected static byte[] fixEscapeErrorsAndUnescapeHighOrderUTF8(final String url) {
+        ByteArrayOutputStream sb = new ByteArrayOutputStream(url.length()*2);
+        final byte[] utf8 = url.getBytes(UTF8_CHARSET);
+        int i = 0;
+        while (i < utf8.length) {
+            int c = utf8[i];
+            if (c == '%') {
+                if (i < utf8.length-2 && isHex(utf8[i+1]) && isHex(utf8[i+2])) {
+                    int u = Integer.parseInt("" + (char)utf8[i+1] + (char)utf8[i+2], 16);
+                    if ((0b10000000 & u) == 0) { // ASCII, so don't touch!
+                        sb.write('%'); sb.write(utf8[i+1]); sb.write(utf8[i+2]);
+                    } else { // UTF-8, so write raw byte
+                        sb.write(0xFF & u);
+                    }
+                    i += 3;
+                } else { // Faulty, so fix by escaping percent
+                    sb.write('%'); sb.write('2'); sb.write('5');
+                    i++;
+                }
+                // https://en.wikipedia.org/wiki/UTF-8
+            } else { // Not part of escape, just pass the byte
+                sb.write(0xff & utf8[i++]);
+            }
+        }
+        return sb.toByteArray();
+    }
+
+    
+
+   private static boolean isHex(byte b) {
+       return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F');
+   }
+   
+    private static void hexEscape(int codePoint, ByteArrayOutputStream sb) {
+        sb.write('%');
+        sb.write(HEX[codePoint >> 4]);
+        sb.write(HEX[codePoint & 0xF]);
+    }
+    
+    // Some low-order characters must always be escaped
+    // TODO: Consider adding all unwise characters from https://www.ietf.org/rfc/rfc2396.txt : {|}\^[]`
+    private static boolean mustEscape(int codePoint) {
+        return codePoint == ' ' || codePoint == '%' || codePoint == '\\';
+    }
+
+    // If the codePoint is already escaped, keep the escaping
+    private static boolean keepEscape(int codePoint) {
+        return codePoint == '#';
+    }
+    
+    
+}
+
+

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/NormalisationLegacy.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/NormalisationLegacy.java
@@ -2,16 +2,10 @@ package dk.kb.netarchivesuite.solrwayback.normalise;
 
 import org.apache.commons.logging.LogFactory;
 import org.archive.wayback.util.url.AggressiveUrlCanonicalizer;
-
-import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
-
 import org.apache.commons.httpclient.URIException;
 import org.apache.commons.logging.Log;
 
-import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -21,12 +15,14 @@ import java.util.regex.Pattern;
  * TODO: It seems that https://github.com/iipc/urlcanon is a much better base for normalisation.
  * That should be incorporated here instead of the AggressiveUrlCanonicalizer and the custom code.
  */
-public class NormalisationLegacy {
+public class NormalisationLegacy extends NormalisationAbstract{
     private static Log log = LogFactory.getLog( NormalisationLegacy.class );
 
-    private static Charset UTF8_CHARSET = Charset.forName("UTF-8");
     private static AggressiveUrlCanonicalizer canon = new AggressiveUrlCanonicalizer();
+   
+    private static Pattern WWW_PREFIX = Pattern.compile("([a-z]+://)(?:www[0-9]*|ww2|ww)[.](.+)");
 
+    
    
     public static String canonicaliseHost(String host) throws URIException {
         return canon.urlStringToKey(host.trim()).replace("/", "");
@@ -108,130 +104,8 @@ public class NormalisationLegacy {
 
         return url;
     }
-    private static Pattern DOMAIN_ONLY = Pattern.compile("https?://[^/]+");
-    private static Pattern WWW_PREFIX = Pattern.compile("([a-z]+://)(?:www[0-9]*|ww2|ww)[.](.+)");
-
-    // Normalisation to UTF-8 form
-    private static byte[] fixEscapeErrorsAndUnescapeHighOrderUTF8(final String url) {
-        ByteArrayOutputStream sb = new ByteArrayOutputStream(url.length()*2);
-        final byte[] utf8 = url.getBytes(UTF8_CHARSET);
-        int i = 0;
-        while (i < utf8.length) {
-            int c = utf8[i];
-            if (c == '%') {
-                if (i < utf8.length-2 && isHex(utf8[i+1]) && isHex(utf8[i+2])) {
-                    int u = Integer.parseInt("" + (char)utf8[i+1] + (char)utf8[i+2], 16);
-                    if ((0b10000000 & u) == 0) { // ASCII, so don't touch!
-                        sb.write('%'); sb.write(utf8[i+1]); sb.write(utf8[i+2]);
-                    } else { // UTF-8, so write raw byte
-                        sb.write(0xFF & u);
-                    }
-                    i += 3;
-                } else { // Faulty, so fix by escaping percent
-                    sb.write('%'); sb.write('2'); sb.write('5');
-                    i++;
-                }
-                // https://en.wikipedia.org/wiki/UTF-8
-            } else { // Not part of escape, just pass the byte
-                sb.write(0xff & utf8[i++]);
-            }
-        }
-        return sb.toByteArray();
-    }
-
-    // Requires valid %-escapes (as produced by fixEscapeErrorsAndUnescapeHighOrderUTF8) and UTF-8 bytes
-    private static String escapeUTF8(final byte[] utf8, boolean escapeHighOrder, boolean normaliseLowOrder) {
-        ByteArrayOutputStream sb = new ByteArrayOutputStream(utf8.length*2);
-        int i = 0;
-        boolean paramSection = false; // Affects handling of space and plus
-        while (i < utf8.length) {
-            int c = 0xFF & utf8[i];
-            paramSection |= c == '?';
-            if (paramSection && c == ' ') { // In parameters, space becomes plus
-                sb.write(0xFF & '+');
-            } else if (c == '%') {
-                int codePoint = Integer.parseInt("" + (char) utf8[i + 1] + (char) utf8[i + 2], 16);
-                if (paramSection && codePoint == ' ') { // In parameters, space becomes plus
-                    sb.write(0xFF & '+');
-                } else if (mustEscape(codePoint) || keepEscape(codePoint) || !normaliseLowOrder) { // Pass on unmodified
-                    hexEscape(codePoint, sb);
-                } else { // Normalise to ASCII
-                    sb.write(0xFF & codePoint);
-                }
-                i += 2;
-            } else if ((0b10000000 & c) == 0) { // ASCII
-                if (mustEscape(c)) {
-                    hexEscape(c, sb);
-                } else {
-                    sb.write(0xFF & c);
-                }
-            } else if ((0b11000000 & c) == 0b10000000) { // Non-first UTF-8 byte as first byte
-                hexEscape(c, sb);
-            } else if ((0b11100000 & c) == 0b11000000) { // 2 byte UTF-8
-                if (i >= utf8.length-1 || (0b11000000 & utf8[i+1]) != 0b10000000) { // No byte or wrong byte follows
-                    hexEscape(c, sb);
-                } else if (escapeHighOrder) {
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i], sb);
-                } else {
-                    sb.write(utf8[i++]);
-                    sb.write(utf8[i]);
-                }
-            } else if ((0b11110000 & utf8[i]) == 0b11100000) { // 3 byte UTF-8
-                if (i >= utf8.length-2 || (0b11000000 & utf8[i+1]) != 0b10000000 ||
-                    (0b11000000 & utf8[i+2]) != 0b10000000) { // Too few or wrong bytes follows
-                    hexEscape(c, sb);
-                } else {
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i], sb);
-                }
-            } else if ((0b11111000 & utf8[i]) == 0b11110000) { // 4 byte UTF-8
-                if (i >= utf8.length-3 || (0b11000000 & utf8[i+1]) != 0b10000000 || // Too few or wrong bytes follows
-                    (0b11000000 & utf8[i+2]) != 0b10000000 || (0b11000000 & utf8[i+3]) != 0b10000000) {
-                    hexEscape(c, sb);
-                } else {
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i], sb);
-                }
-            } else {  // Illegal first byte for UTF-8
-                hexEscape(c, sb);
-                log.debug("Sanity check: Unexpected code path encountered.: The input byte-array did not translate" +
-                          " to supported UTF-8 with invalid first-byte for UTF-8 codepoint '0b" +
-                          Integer.toBinaryString(c) + "'. Writing escape code for byte " + c);
-            }
-            i++;
-        }
-        try {
-            return sb.toString("utf-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException("Internal error: UTF-8 must be supported by the JVM", e);
-        }
-    }
-
-    private static void hexEscape(int codePoint, ByteArrayOutputStream sb) {
-        sb.write('%');
-        sb.write(HEX[codePoint >> 4]);
-        sb.write(HEX[codePoint & 0xF]);
-    }
-    private final static byte[] HEX = "0123456789abcdef".getBytes(UTF8_CHARSET); // Assuming lowercase
-
-    // Some low-order characters must always be escaped
-    // TODO: Consider adding all unwise characters from https://www.ietf.org/rfc/rfc2396.txt : {|}\^[]`
-    private static boolean mustEscape(int codePoint) {
-        return codePoint == ' ' || codePoint == '%' || codePoint == '\\';
-    }
-
-    // If the codePoint is already escaped, keep the escaping
-    private static boolean keepEscape(int codePoint) {
-        return codePoint == '#';
-    }
-
-    private static boolean isHex(byte b) {
-        return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F');
-    }
+  
+  
 
 
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/NormalisationStandard.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/NormalisationStandard.java
@@ -2,15 +2,9 @@ package dk.kb.netarchivesuite.solrwayback.normalise;
 
 import org.apache.commons.logging.LogFactory;
 import org.archive.wayback.util.url.AggressiveUrlCanonicalizer;
-
-import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
-
 import org.apache.commons.logging.Log;
 
-import java.io.ByteArrayOutputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.regex.Pattern;
 
 /**
@@ -19,10 +13,9 @@ import java.util.regex.Pattern;
  * TODO: It seems that https://github.com/iipc/urlcanon is a much better base for normalisation.
  * That should be incorporated here instead of the AggressiveUrlCanonicalizer and the custom code.
  */
-public class NormalisationStandard {
+public class NormalisationStandard extends NormalisationAbstract{
     private static Log log = LogFactory.getLog(NormalisationStandard.class );
-
-    private static Charset UTF8_CHARSET = Charset.forName("UTF-8");
+    
     private static AggressiveUrlCanonicalizer canon = new AggressiveUrlCanonicalizer();
 
     
@@ -72,6 +65,7 @@ public class NormalisationStandard {
         }
 
         // Create temporary url with %-fixing and high-order characters represented directly
+                          
         byte[] urlBytes = fixEscapeErrorsAndUnescapeHighOrderUTF8(url);
         // Normalise
 
@@ -83,128 +77,10 @@ public class NormalisationStandard {
 
         return url;
     }
-    private static Pattern DOMAIN_ONLY = Pattern.compile("https?://[^/]+");
 
-    // Normalisation to UTF-8 form
-    private static byte[] fixEscapeErrorsAndUnescapeHighOrderUTF8(final String url) {
-        ByteArrayOutputStream sb = new ByteArrayOutputStream(url.length()*2);
-        final byte[] utf8 = url.getBytes(UTF8_CHARSET);
-        int i = 0;
-        while (i < utf8.length) {
-            int c = utf8[i];
-            if (c == '%') {
-                if (i < utf8.length-2 && isHex(utf8[i+1]) && isHex(utf8[i+2])) {
-                    int u = Integer.parseInt("" + (char)utf8[i+1] + (char)utf8[i+2], 16);
-                    if ((0b10000000 & u) == 0) { // ASCII, so don't touch!
-                        sb.write('%'); sb.write(utf8[i+1]); sb.write(utf8[i+2]);
-                    } else { // UTF-8, so write raw byte
-                        sb.write(0xFF & u);
-                    }
-                    i += 3;
-                } else { // Faulty, so fix by escaping percent
-                    sb.write('%'); sb.write('2'); sb.write('5');
-                    i++;
-                }
-                // https://en.wikipedia.org/wiki/UTF-8
-            } else { // Not part of escape, just pass the byte
-                sb.write(0xff & utf8[i++]);
-            }
-        }
-        return sb.toByteArray();
-    }
 
-    // Requires valid %-escapes (as produced by fixEscapeErrorsAndUnescapeHighOrderUTF8) and UTF-8 bytes
-    private static String escapeUTF8(final byte[] utf8, boolean escapeHighOrder, boolean normaliseLowOrder) {
-        ByteArrayOutputStream sb = new ByteArrayOutputStream(utf8.length*2);
-        int i = 0;
-        boolean paramSection = false; // Affects handling of space and plus
-        while (i < utf8.length) {
-            int c = 0xFF & utf8[i];
-            paramSection |= c == '?';
-            if (paramSection && c == ' ') { // In parameters, space becomes plus
-                sb.write(0xFF & '+');
-            } else if (c == '%') {
-                int codePoint = Integer.parseInt("" + (char) utf8[i + 1] + (char) utf8[i + 2], 16);
-                if (paramSection && codePoint == ' ') { // In parameters, space becomes plus
-                    sb.write(0xFF & '+');
-                } else if (mustEscape(codePoint) || keepEscape(codePoint) || !normaliseLowOrder) { // Pass on unmodified
-                    hexEscape(codePoint, sb);
-                } else { // Normalise to ASCII
-                    sb.write(0xFF & codePoint);
-                }
-                i += 2;
-            } else if ((0b10000000 & c) == 0) { // ASCII
-                if (mustEscape(c)) {
-                    hexEscape(c, sb);
-                } else {
-                    sb.write(0xFF & c);
-                }
-            } else if ((0b11000000 & c) == 0b10000000) { // Non-first UTF-8 byte as first byte
-                hexEscape(c, sb);
-            } else if ((0b11100000 & c) == 0b11000000) { // 2 byte UTF-8
-                if (i >= utf8.length-1 || (0b11000000 & utf8[i+1]) != 0b10000000) { // No byte or wrong byte follows
-                    hexEscape(c, sb);
-                } else if (escapeHighOrder) {
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i], sb);
-                } else {
-                    sb.write(utf8[i++]);
-                    sb.write(utf8[i]);
-                }
-            } else if ((0b11110000 & utf8[i]) == 0b11100000) { // 3 byte UTF-8
-                if (i >= utf8.length-2 || (0b11000000 & utf8[i+1]) != 0b10000000 ||
-                    (0b11000000 & utf8[i+2]) != 0b10000000) { // Too few or wrong bytes follows
-                    hexEscape(c, sb);
-                } else {
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i], sb);
-                }
-            } else if ((0b11111000 & utf8[i]) == 0b11110000) { // 4 byte UTF-8
-                if (i >= utf8.length-3 || (0b11000000 & utf8[i+1]) != 0b10000000 || // Too few or wrong bytes follows
-                    (0b11000000 & utf8[i+2]) != 0b10000000 || (0b11000000 & utf8[i+3]) != 0b10000000) {
-                    hexEscape(c, sb);
-                } else {
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i++], sb);
-                    hexEscape(0xff & utf8[i], sb);
-                }
-            } else {  // Illegal first byte for UTF-8
-                hexEscape(c, sb);
-                log.debug("Sanity check: Unexpected code path encountered.: The input byte-array did not translate" +
-                          " to supported UTF-8 with invalid first-byte for UTF-8 codepoint '0b" +
-                          Integer.toBinaryString(c) + "'. Writing escape code for byte " + c);
-            }
-            i++;
-        }
-        try {
-            return sb.toString("utf-8");
-        } catch (UnsupportedEncodingException e) {
-            throw new IllegalStateException("Internal error: UTF-8 must be supported by the JVM", e);
-        }
-    }
+  
 
-    private static void hexEscape(int codePoint, ByteArrayOutputStream sb) {
-        sb.write('%');
-        sb.write(HEX[codePoint >> 4]);
-        sb.write(HEX[codePoint & 0xF]);
-    }
-    private final static byte[] HEX = "0123456789abcdef".getBytes(UTF8_CHARSET); // Assuming lowercase
-
-    // Some low-order characters must always be escaped
-    private static boolean mustEscape(int codePoint) {
-        return codePoint == ' ' || codePoint == '%';
-    }
-
-    // If the codePoint is already escaped, keep the escaping
-    private static boolean keepEscape(int codePoint) {
-        return codePoint == '#';
-    }
-
-    private static boolean isHex(byte b) {
-        return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F');
-    }
     
     public static String resolveRelative(String url, String relative, boolean normalise) throws IllegalArgumentException {
       try {

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/NormalisationStandard.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/normalise/NormalisationStandard.java
@@ -5,6 +5,7 @@ import org.archive.wayback.util.url.AggressiveUrlCanonicalizer;
 import org.apache.commons.logging.Log;
 
 import java.net.URL;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -17,7 +18,7 @@ public class NormalisationStandard extends NormalisationAbstract{
     private static Log log = LogFactory.getLog(NormalisationStandard.class );
     
     private static AggressiveUrlCanonicalizer canon = new AggressiveUrlCanonicalizer();
-
+    private static Pattern WWW_PREFIX = Pattern.compile("([a-z]+://)(?:www[0-9]*|ww2|ww)[.](.+)");
     
 
     /**
@@ -53,6 +54,14 @@ public class NormalisationStandard extends NormalisationAbstract{
         // Protocol: https → http
         url = url.startsWith("https://") ? "http://" + url.substring(8) : url;
 
+     // www. prefix
+        if (createUnambiguous) {
+            Matcher wwwMatcher = WWW_PREFIX.matcher(url);
+            if (wwwMatcher.matches()) {
+                url = wwwMatcher.group(1) + wwwMatcher.group(2);
+            }
+        }
+        
         // TODO: Consider if this should only be done if createUnambiguous == true
         // Trailing slashes: http://example.com/foo/ → http://example.com/foo
         while (url.endsWith("/")) { // Trailing slash affects the URL semantics

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/normalize/PunyEncodeAndNormaliseTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/normalize/PunyEncodeAndNormaliseTest.java
@@ -41,6 +41,11 @@ public class PunyEncodeAndNormaliseTest extends UnitTestUtils {
         urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
         assertEquals("http://xn--plser-vua.dk/pølseguf.html?pølse=medister", urlPunyNorm);
         
+        
+        url="http://www.pølser.dk/pølseguf.html?pølse=Medister"; //normal normaliser removes www
+        urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+        assertEquals("http://xn--plser-vua.dk/pølseguf.html?pølse=medister", urlPunyNorm);
+        
     
     }
    }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/normalize/PunyEncodeAndNormaliseTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/normalize/PunyEncodeAndNormaliseTest.java
@@ -19,14 +19,11 @@ import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
 
 public class PunyEncodeAndNormaliseTest extends UnitTestUtils {
 
-    @Before
-    public void setNormalisation() throws IOException {     
-        Normalisation.setType(NormaliseType.NORMAL);
-    }
 
     @Test
     public void testPunyEncodingAndNormalize() throws Exception {
         
+        Normalisation.setType(NormaliseType.NORMAL);
         String url="http://www.test.dk/ABC.cfm?value=27";        
         String urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
         assertEquals("http://test.dk/abc.cfm?value=27", urlPunyNorm);
@@ -46,6 +43,30 @@ public class PunyEncodeAndNormaliseTest extends UnitTestUtils {
         urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
         assertEquals("http://xn--plser-vua.dk/pølseguf.html?pølse=medister", urlPunyNorm);
         
+        url="http://www.pølser.dk/"; //normal normaliser removes www 
+        urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+        assertEquals("http://xn--plser-vua.dk/", urlPunyNorm);
+
+        
     
     }
+    @Test
+    public void testPunyEncodingAndNormalizeWithLegacy() throws Exception {             
+        Normalisation.setType(NormaliseType.LEGACY);
+       
+        String url="http://www.pølser.dk"; //normal should NOT remove www. 
+        String urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+        assertEquals("http://www.xn--plser-vua.dk/", urlPunyNorm);
+
+         url="http://www.pølser.dk/"; //normal should NOT remove www. 
+         urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+         assertEquals("http://www.xn--plser-vua.dk/", urlPunyNorm);
+        
+         url="http://www.pølser.dk/pølseguf.html?pølse=ostepølse"; //legacy should remove www 
+         urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+         assertEquals("http://xn--plser-vua.dk/pølseguf.html?pølse=ostepølse", urlPunyNorm);
+         
+    }
+    
+    
    }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/normalize/PunyEncodeAndNormaliseTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/normalize/PunyEncodeAndNormaliseTest.java
@@ -7,6 +7,7 @@ import java.io.File;
 import java.io.IOException;
 
 import dk.kb.netarchivesuite.solrwayback.normalise.Normalisation;
+import dk.kb.netarchivesuite.solrwayback.normalise.Normalisation.NormaliseType;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,10 +20,8 @@ import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
 public class PunyEncodeAndNormaliseTest extends UnitTestUtils {
 
     @Before
-    public void invalidateProperties() throws IOException {
-        // Ensures that the normaliser has a known setting
-        PropertiesLoader.initProperties(UnitTestUtils.getFile("properties/solrwayback.properties").getPath());
-        Normalisation.setTypeFromConfig();
+    public void setNormalisation() throws IOException {     
+        Normalisation.setType(NormaliseType.NORMAL);
     }
 
     @Test

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/util/URLAbsoluterTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/util/URLAbsoluterTest.java
@@ -1,7 +1,9 @@
 package dk.kb.netarchivesuite.solrwayback.util;
 
+
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
 import dk.kb.netarchivesuite.solrwayback.normalise.Normalisation;
+import dk.kb.netarchivesuite.solrwayback.normalise.Normalisation.NormaliseType;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,6 +36,22 @@ public class URLAbsoluterTest {
         PropertiesLoader.WAYBACK_BASEURL = "http://localhost:0000/solrwayback/";
     }
 
+    @Test
+    public void testTemp() {
+        String url ="http://www.example.com";
+        Normalisation.setType(NormaliseType.NORMAL);
+        String urlNorm1 = Normalisation.canonicaliseURL(url);
+        System.out.println(Normalisation.getType());
+        System.out.println(urlNorm1);
+        Normalisation.setType(NormaliseType.LEGACY);
+        String urlNorm2 = Normalisation.canonicaliseURL(url);
+        System.out.println(Normalisation.getType());
+        System.out.println(urlNorm2);
+        
+    }
+
+    
+    
     @Test
     public void testSimple() {
         URLAbsoluter absoluter = new URLAbsoluter("http://example.com", true);

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/util/URLAbsoluterTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/util/URLAbsoluterTest.java
@@ -47,7 +47,7 @@ public class URLAbsoluterTest {
         String urlDomainOnly ="http://www.example.com"; //www will be kept and a slash added to end
         String urlDomainOnlyNorm= Normalisation.canonicaliseURL(urlDomainOnly );
         assertEquals("http://www.example.com/", urlDomainOnlyNorm);        
-        String urlDomainWithPath ="http://www.example.com/index.html"; //www be removed
+        String urlDomainWithPath ="http://www.example.com/index.html"; //www must be removed
         String urlDomainWithPathNorm= Normalisation.canonicaliseURL(urlDomainWithPath );                
         assertEquals("http://example.com/index.html", urlDomainWithPathNorm);
         

--- a/src/test/resources/properties/solrwayback.properties
+++ b/src/test/resources/properties/solrwayback.properties
@@ -36,11 +36,13 @@ warc.file.resolver.class=dk.kb.netarchivesuite.solrwayback.interfaces.IdentityAr
 #Collection name. This is the name shown when exporting a page to PID-XML.
 pid.collection.name=netarkivet.dk
 
+
 #The possible values for url.normaliser are: normal, legacy and minimal.
-# Use minimal if using warc-indexer before 3.0 (Playback quality is drastically reduced).
-# Minimal also require the following solr params added: solr.search.params: f.url_norm.qf=url 
-# Legacy is recommended  on all 3.0-3.2 versions of the warc-indexer. 
-url.normaliser=legacy
+# Only change the normaliser type if you know what you are doing.
+# Only use minimal if the solr index was build in warc-indexer earlier that 3.0. All SolrWayback bundles have warc-indexer later than this. (Playback quality is drastically reduced)
+# Use Legacy for 3.0-3.1 versions of the warc-indexer.
+# Use normal for all warc-indexers version 3.2.0+
+url.normaliser=normal
 
 # Optional list of Solr-params. Format is key1=value1;key2=value2,...
 #solr.search.params=f.url_norm.qf=url


### PR DESCRIPTION
This PR fixes some bugs with normalisation. Both in unittest but also in the application.

The bug fixes normalisation in case normaliser is legacy and the domain is a domain without part.
Legacy normalizer
"http://www.test.dk/" -> "http://www.test.dk/"  (this was the bug)
"http://www.test.dk/index.html" -> "http://test.dk/index.html"  (here  www is removed.)

The bug was also fixed in the url-search method that both punyencodes and normalise the url
