### PR TITLE
Cache invalidation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ issues.
 GUI improvement. Use escape-key to close all modal pop-ups. (toolbox, search syntax, full size 
 images)
 
+Cache invalidation based on background checks for index changes.
 
 
 4.3.0

--- a/docker/solrwayback.properties
+++ b/docker/solrwayback.properties
@@ -6,7 +6,7 @@ solr.server=${SOLR_URL}
 #Solr caching. Will be default false if not defined
 solr.server.caching=true
 solr.server.caching.max.entries=10000
-# Max age is set to a year, effectively disabling it, as solr.server.check.interval is used.
+# Max age is set to a year, effectively disabling it, as solr.server.check.interval.seconds is used.
 solr.server.caching.age.seconds=36586400
 
 # Solr availability and index change check interval.
@@ -17,10 +17,10 @@ solr.server.caching.age.seconds=36586400
 # will strain the system. In that case it is recommended to disable active checking and use
 # fixed cache clearing with solr.server.caching.age.seconds instead.
 #
-# Default is 60000 milliseconds (1 minute).
+# Default is 60 seconds
 # Disable by setting to -1
 # If the checking is disabled, consider setting solr.server.caching.age.seconds to something less than a year
-solr.server.check.interval=60000
+solr.server.check.interval.seconds=60
 
 ## Link to this webapp itself. BaseURL for link rewrites must be full url.
 wayback.baseurl=${BASE_URL}

--- a/docker/solrwayback.properties
+++ b/docker/solrwayback.properties
@@ -6,12 +6,17 @@ solr.server=${SOLR_URL}
 #Solr caching. Will be default false if not defined
 solr.server.caching=true
 solr.server.caching.max.entries=10000
-# Max age is set to a year as solr.server.check.interval is used.
+# Max age is set to a year, effectively disabling it, as solr.server.check.interval is used.
 solr.server.caching.age.seconds=36586400
 
 # Solr availability and index change check interval.
-# The check is light if the index has not changes and moderate if the index has been changed
+# The check is light if the index has not changes and moderate if the index has been changed.
 # If an index change is detected, caches will be cleared
+#
+# If the backing index has billions of records and is continuously updated, active checking
+# will strain the system. In that case it is recommended to disable active checking and use
+# fixed cache clearing with solr.server.caching.age.seconds instead.
+#
 # Default is 60000 milliseconds (1 minute).
 # Disable by setting to -1
 # If the checking is disabled, consider setting solr.server.caching.age.seconds to something less than a year

--- a/docker/solrwayback.properties
+++ b/docker/solrwayback.properties
@@ -8,6 +8,13 @@ solr.server.caching=true
 solr.server.caching.max.entries=10000
 solr.server.caching.age.seconds=86400
 
+# Solr availability and index change check interval.
+# The check is light if the index has not changes and moderate if the index has been changed
+# If an index change is detected, caches will be cleared
+# Default i 60000 milliseconds (1 minute).
+# Disable by setting to -1
+solr.server.check.interval=60000
+
 ## Link to this webapp itself. BaseURL for link rewrites must be full url.
 wayback.baseurl=${BASE_URL}
 

--- a/docker/solrwayback.properties
+++ b/docker/solrwayback.properties
@@ -6,20 +6,21 @@ solr.server=${SOLR_URL}
 #Solr caching. Will be default false if not defined
 solr.server.caching=true
 solr.server.caching.max.entries=10000
-# Max age is set to a year, effectively disabling it, as solr.server.check.interval.seconds is used.
-solr.server.caching.age.seconds=36586400
+# Age based cache invalidation is not enabled per default as index watching works better for most cases
+# See the descrition of solr.server.check.interval.seconds below for more details
+#solr.server.caching.age.seconds=86400
 
-# Solr availability and index change check interval.
-# The check is light if the index has not changes and moderate if the index has been changed.
+# Solr availability and index change check interval: Every x seconds a query for new documents is issued.
 # If an index change is detected, caches will be cleared
 #
-# If the backing index has billions of records and is continuously updated, active checking
-# will strain the system. In that case it is recommended to disable active checking and use
-# fixed cache clearing with solr.server.caching.age.seconds instead.
+# The check is light (cached by Solr) if the index has not changed and moderate if the index has been
+# changed. If the backing index has billions of records and is continuously updated, active checking
+# will strain the system. In that case it is recommended to disable active checking and use fixed time
+# cache clearing with solr.server.caching.age.seconds instead.
 #
 # Default is 60 seconds
 # Disable by setting to -1
-# If the checking is disabled, consider setting solr.server.caching.age.seconds to something less than a year
+# If the checking is disabled, consider setting solr.server.caching.age.seconds instead
 solr.server.check.interval.seconds=60
 
 ## Link to this webapp itself. BaseURL for link rewrites must be full url.

--- a/docker/solrwayback.properties
+++ b/docker/solrwayback.properties
@@ -6,13 +6,15 @@ solr.server=${SOLR_URL}
 #Solr caching. Will be default false if not defined
 solr.server.caching=true
 solr.server.caching.max.entries=10000
-solr.server.caching.age.seconds=86400
+# Max age is set to a year as solr.server.check.interval is used.
+solr.server.caching.age.seconds=36586400
 
 # Solr availability and index change check interval.
 # The check is light if the index has not changes and moderate if the index has been changed
 # If an index change is detected, caches will be cleared
-# Default i 60000 milliseconds (1 minute).
+# Default is 60000 milliseconds (1 minute).
 # Disable by setting to -1
+# If the checking is disabled, consider setting solr.server.caching.age.seconds to something less than a year
 solr.server.check.interval=60000
 
 ## Link to this webapp itself. BaseURL for link rewrites must be full url.

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
@@ -67,7 +67,7 @@ public class PropertiesLoader {
     public static boolean SOLR_SERVER_CACHING=false;
     public static boolean WARC_FILES_VERIFY_COLLECTION=false;
     public static int SOLR_SERVER_CACHING_MAX_ENTRIES=1000; //default value
-    public static int SOLR_SERVER_CACHING_AGE_SECONDS=84600; //default value 1 day
+    public static int SOLR_SERVER_CACHING_AGE_SECONDS=36584600; //default value 1 year (effectively disabled)
     /**
      * How often the status (available, unavailable, changed) of the backing Solr is checked.
      *

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
@@ -42,7 +42,7 @@ public class PropertiesLoader {
     private static final String SOLR_SERVER_CACHING_PROPERTY="solr.server.caching";
     private static final String SOLR_SERVER_CACHING_MAX_ENTRIES_PROPERTY="solr.server.caching.max.entries";
     private static final String SOLR_SERVER_CACHING_AGE_SECONDS_PROPERTY="solr.server.caching.age.seconds";
-    public static final String SOLR_SERVER_CHECK_INTERVAL_PROPERTY = "solr.server.check.interval";
+    public static final String SOLR_SERVER_CHECK_INTERVAL_PROPERTY = "solr.server.check.interval.seconds";
 
     private static final String URL_NORMALISER_PROPERTY="url.normaliser";
     

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
@@ -42,6 +42,7 @@ public class PropertiesLoader {
     private static final String SOLR_SERVER_CACHING_PROPERTY="solr.server.caching";
     private static final String SOLR_SERVER_CACHING_MAX_ENTRIES_PROPERTY="solr.server.caching.max.entries";
     private static final String SOLR_SERVER_CACHING_AGE_SECONDS_PROPERTY="solr.server.caching.age.seconds";
+    public static final String SOLR_SERVER_CHECK_INTERVAL_PROPERTY = "solr.server.check.interval";
 
     private static final String URL_NORMALISER_PROPERTY="url.normaliser";
     
@@ -67,6 +68,15 @@ public class PropertiesLoader {
     public static boolean WARC_FILES_VERIFY_COLLECTION=false;
     public static int SOLR_SERVER_CACHING_MAX_ENTRIES=1000; //default value
     public static int SOLR_SERVER_CACHING_AGE_SECONDS=84600; //default value 1 day
+    /**
+     * How often the status (available, unavailable, changed) of the backing Solr is checked.
+     *
+     * Set this to -1 or 0 to disable the running check.
+     *
+     * Used by {@link dk.kb.netarchivesuite.solrwayback.solr.IndexWatcher}
+     * through {@link dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrClient}.
+     */
+    public static int SOLR_SERVER_CHECK_INTERVAL = 60000; //default value every minute
     public static String URL_NORMALISER="normal";
 
     public static int SCREENSHOT_PREVIEW_TIMEOUT = 10;//default
@@ -122,6 +132,9 @@ public class PropertiesLoader {
                 SOLR_SERVER_CACHING_MAX_ENTRIES=Integer.parseInt(serviceProperties.getProperty(SOLR_SERVER_CACHING_MAX_ENTRIES_PROPERTY).trim());
             }
 
+            SOLR_SERVER_CHECK_INTERVAL = Integer.parseInt(serviceProperties.getProperty(
+                    SOLR_SERVER_CHECK_INTERVAL_PROPERTY, Integer.toString(SOLR_SERVER_CHECK_INTERVAL)));
+
             String verifyCollectionString = serviceProperties.getProperty(WARC_FILES_VERIFY_COLLECTION_PROPERTY,"false");            
             WARC_FILES_VERIFY_COLLECTION = Boolean.valueOf(verifyCollectionString);
             
@@ -149,7 +162,8 @@ public class PropertiesLoader {
             log.info("Property:"+ SOLR_SERVER_CACHING_PROPERTY +" = " +  SOLR_SERVER_CACHING);
             log.info("Property:"+ SOLR_SERVER_CACHING_AGE_SECONDS_PROPERTY +" = " +  SOLR_SERVER_CACHING_AGE_SECONDS);
             log.info("Property:"+ SOLR_SERVER_CACHING_MAX_ENTRIES_PROPERTY +" = " +  SOLR_SERVER_CACHING_MAX_ENTRIES);
-            log.info("Property:"+ SOLR_SEARCH_PARAMS_PROPERTY+" loaded map: " +  SOLR_PARAMS_MAP);                        
+            log.info("Property:"+ SOLR_SERVER_CHECK_INTERVAL_PROPERTY +" = " +  SOLR_SERVER_CHECK_INTERVAL);
+            log.info("Property:"+ SOLR_SEARCH_PARAMS_PROPERTY+" loaded map: " +  SOLR_PARAMS_MAP);
         }
         catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
@@ -255,7 +255,7 @@ public class SolrWaybackResourceWeb {
      * NOTE: This does not trigger an active check, so the call is cheap.
      *
      * The availability status is updated internally by {@link dk.kb.netarchivesuite.solrwayback.solr.IndexWatcher}
-     * and is controlled by the property {@code solr.server.check.interval}.
+     * and is controlled by the property {@code solr.server.check.interval.seconds}.
      * See {@link dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader} for further information.
      * @return true if the backing Solr is available, else false. {@code N/A} if the status check has not been done.
      */

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
@@ -248,7 +248,29 @@ public class SolrWaybackResourceWeb {
         throw handleServiceExceptions(e);
       }
     }
-      
+
+    /**
+     * Returns the current availability status.
+     *
+     * NOTE: This does not trigger an active check, so the call is cheap.
+     *
+     * The availability status is updated internally by {@link dk.kb.netarchivesuite.solrwayback.solr.IndexWatcher}
+     * and is controlled by the property {@code solr.server.check.interval}.
+     * See {@link dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader} for further information.
+     * @return true if the backing Solr is available, else false.
+     */
+    @GET
+    @Path("solr/available")
+    @Produces(MediaType.TEXT_PLAIN +"; charset=UTF-8")
+    public String isSolrAvailable() throws SolrWaybackServiceException {
+        try {
+            return Boolean.toString(NetarchiveSolrClient.getInstance().isSolrAvailable());
+        } catch (Exception e) {
+            log.error("Unable to retrieve Solr availability", e);
+            throw handleServiceExceptions(e);
+        }
+    }
+
 
     @GET
     @Path("/help/search")

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
@@ -257,14 +257,15 @@ public class SolrWaybackResourceWeb {
      * The availability status is updated internally by {@link dk.kb.netarchivesuite.solrwayback.solr.IndexWatcher}
      * and is controlled by the property {@code solr.server.check.interval}.
      * See {@link dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader} for further information.
-     * @return true if the backing Solr is available, else false.
+     * @return true if the backing Solr is available, else false. {@code N/A} if the status check has not been done.
      */
     @GET
     @Path("solr/available")
     @Produces(MediaType.TEXT_PLAIN +"; charset=UTF-8")
     public String isSolrAvailable() throws SolrWaybackServiceException {
         try {
-            return Boolean.toString(NetarchiveSolrClient.getInstance().isSolrAvailable());
+            Boolean isAvailable = NetarchiveSolrClient.getInstance().isSolrAvailable();
+            return isAvailable == null ? "N/A": isAvailable.toString();
         } catch (Exception e) {
             log.error("Unable to retrieve Solr availability", e);
             throw handleServiceExceptions(e);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/CachingSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/CachingSolrClient.java
@@ -76,6 +76,7 @@ public class CachingSolrClient extends SolrClient {
      * Clear all cached entries. This does not clear the calls/hits-statistics.
      */
     public void clearCache() {
+        log.debug("Clearing cached queries");
         queryCache.clear();
         namedCache.clear();
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/IndexWatcher.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/IndexWatcher.java
@@ -1,0 +1,206 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.solr;
+
+import dk.kb.netarchivesuite.solrwayback.util.DateUtils;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.Locale;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.function.Consumer;
+
+/**
+ * Periodically checks if the Solr index has changed and fires a notification if that happens.
+ * Requires the backing Solr index to provide the field {@code index_time} of type {@code date}.
+ */
+public class IndexWatcher {
+    private static final Logger log = LoggerFactory.getLogger(IndexWatcher.class);
+
+    /**
+     * Status changes for Solr and its index.
+     */
+    public enum STATUS {
+        /** The backing Solr has become unresponsive after a period of responsiveness */
+        unavailable,
+        /** The backing Solr has become responsive after a period of unresponsiveness */
+        available,
+        /** The index of the backing solr has changed since last check */
+        changed
+    }
+
+    public static final String TIME_FIELD = "index_time";
+
+    private final SolrClient solrClient;
+    private final long intervalMS;
+    private final Consumer<STATUS> callback;
+    private final Timer timer;
+
+    private STATUS status = null;
+    private String lastMaxIndexTime = null;
+
+    /**
+     *
+     * @param solrClient standard SolrClient.
+     * @param intervalMS how long to wait between check for index changes.
+     * @param callback   called if the index changes status.
+     */
+    public IndexWatcher(SolrClient solrClient, long intervalMS, Consumer<STATUS> callback) {
+        this.solrClient = solrClient;
+        this.intervalMS = intervalMS;
+        this.callback = callback;
+
+        if (intervalMS <= 1000) {
+            log.warn("Watch interval is {} milliseconds. This is very low and might harm general Solr performance",
+                     intervalMS);
+        }
+
+        timer = new Timer("IndexWatcher", true);
+        timer.schedule(createWatchTask(), intervalMS, intervalMS);
+        initWatch();
+        log.info("Created index watcher with interval {}ms", intervalMS);
+    }
+
+    /**
+     * @return the number of milliseconds between each check.
+     */
+    public long getIntervalMS() {
+        return intervalMS;
+    }
+
+    /**
+     * @return current status for the Solr installation.
+     */
+    public STATUS getStatus() {
+        return status;
+    }
+
+    /**
+     * Close down the watcher. If a check is running during close and the index has changed, {@code callback} will
+     * be triggered.
+     */
+    public void close() {
+        log.info("Shutting down index watcher");
+        timer.cancel();
+    }
+
+    /**
+     * @return a task that periodically checks for Solr availability and index changes.
+     */
+    private TimerTask createWatchTask() {
+        return new TimerTask() {
+            @Override
+            public void run() {
+                try {
+                    boolean hasChanged = hasIndexChanged();
+                    setStatus(STATUS.available);
+                    if (hasChanged) {
+                        callback.accept(STATUS.changed);
+                    }
+                } catch (Exception e) {
+                    setStatus(STATUS.unavailable);
+                }
+            }
+        };
+    }
+
+    /**
+     * Sets the status and notifies {@link #callback} if the previous status was not null and not the same as the
+     * given status.
+     * @param status new status. No notification if is is the same as the old status.
+     */
+    private void setStatus(STATUS status) {
+        if (this.status == null) {
+            this.status = status;
+        } else if (this.status != status) {
+            this.status = status;
+            log.info("The Solr server changed status to {}", status);
+            callback.accept(status);
+        }
+    }
+
+    /**
+     * Extracts latest {@code index_time} from the Solr index.
+     */
+    private void initWatch() {
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.setQuery("*:*");
+        solrQuery.setRows(0);
+        solrQuery.set("facet", "false");
+        solrQuery.set("stats", "true");
+        solrQuery.set("stats.field", "{!max=true}index_time");
+
+        QueryResponse rsp;
+        try {
+            rsp = solrClient.query(solrQuery, SolrRequest.METHOD.POST);
+        } catch (Exception e) {
+            log.warn("Unable to determine initial watch condition for Solr index", e);
+            setStatus(STATUS.unavailable);
+            return;
+        }
+
+        try {
+            Date maxDate = (Date)rsp.getFieldStatsInfo().get(TIME_FIELD).getMax();
+            lastMaxIndexTime = DateUtils.getSolrDateFull(maxDate);
+            log.debug("Initial max {} was '{}'", TIME_FIELD, lastMaxIndexTime);
+        } catch (Exception e) {
+            log.warn("Got result for initial max {} with stats request but was unable to retrieve the value",
+                     TIME_FIELD);
+        }
+    }
+
+    private boolean hasIndexChanged() throws SolrServerException, IOException {
+        // Handle the situation where Solr was down initially
+        if (lastMaxIndexTime == null) {
+            initWatch();
+            if (lastMaxIndexTime == null) {
+                return false;
+            }
+        }
+
+        String changedQuery = String.format(Locale.ROOT, "%s:{%s TO *]", TIME_FIELD, lastMaxIndexTime);
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.setQuery(changedQuery);
+        solrQuery.setSort(TIME_FIELD, SolrQuery.ORDER.desc);
+        solrQuery.setRows(1);
+        solrQuery.setFields(TIME_FIELD);
+
+        // Only check for changes means passing exceptions to the caller
+        QueryResponse rsp = solrClient.query(solrQuery, SolrRequest.METHOD.POST);
+
+        if (rsp.getResults().getNumFound() == 0) {
+            return false;
+        }
+        try {
+            Date maxDate = (Date)rsp.getResults().get(0).getFieldValue(TIME_FIELD);
+            lastMaxIndexTime = DateUtils.getSolrDateFull(maxDate);
+        } catch (Exception e) {
+            log.warn("Got result for changes documents with query '{}' but was unable to retrieve new max index " +
+                     "time from field {}", changedQuery, TIME_FIELD);
+            return false;
+        }
+        log.debug("Received new max {} '{}' from query '{}'", TIME_FIELD, lastMaxIndexTime, changedQuery);
+        return true;
+    }
+
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/IndexWatcher.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/IndexWatcher.java
@@ -54,7 +54,7 @@ public class IndexWatcher {
     public static final String TIME_FIELD = "index_time";
 
     private final SolrClient solrClient;
-    private final long intervalMS;
+    private final long intervalSeconds;
     private final Consumer<STATUS> callback;
     private final Timer timer;
 
@@ -64,30 +64,30 @@ public class IndexWatcher {
     /**
      *
      * @param solrClient standard SolrClient.
-     * @param intervalMS how long to wait between check for index changes.
+     * @param intervalSeconds how long to wait between check for index changes.
      * @param callback   called if the index changes status.
      */
-    public IndexWatcher(SolrClient solrClient, long intervalMS, Consumer<STATUS> callback) {
+    public IndexWatcher(SolrClient solrClient, long intervalSeconds, Consumer<STATUS> callback) {
         this.solrClient = solrClient;
-        this.intervalMS = intervalMS;
+        this.intervalSeconds = intervalSeconds;
         this.callback = callback;
         log.debug("Initializing IndexWatcher");
 
-        if (intervalMS <= 1000) {
-            log.warn("Watch interval is {} milliseconds. This is very low and might harm general Solr performance",
-                     intervalMS);
+        if (intervalSeconds < 5) {
+            log.warn("Watch interval is {} seconds. This is very low and might harm general Solr performance",
+                     this.intervalSeconds);
         }
 
         timer = new Timer("IndexWatcher", true);
-        timer.schedule(createWatchTask(), intervalMS, intervalMS);
-        log.info("Created index watcher with interval {}ms", intervalMS);
+        timer.schedule(createWatchTask(), this.intervalSeconds*1000, this.intervalSeconds*1000);
+        log.info("Created index watcher with interval {} seconds", this.intervalSeconds);
     }
 
     /**
      * @return the number of milliseconds between each check.
      */
     public long getIntervalMS() {
-        return intervalMS;
+        return intervalSeconds;
     }
 
     /**

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/IndexWatcher.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/IndexWatcher.java
@@ -46,7 +46,9 @@ public class IndexWatcher {
         /** The backing Solr has become responsive after a period of unresponsiveness */
         available,
         /** The index of the backing solr has changed since last check */
-        changed
+        changed,
+        /** The backing Solr has not been queried */
+        undetermined
     }
 
     public static final String TIME_FIELD = "index_time";
@@ -56,7 +58,7 @@ public class IndexWatcher {
     private final Consumer<STATUS> callback;
     private final Timer timer;
 
-    private STATUS status = null;
+    private STATUS status = STATUS.undetermined;
     private String lastMaxIndexTime = null;
 
     /**
@@ -78,7 +80,6 @@ public class IndexWatcher {
 
         timer = new Timer("IndexWatcher", true);
         timer.schedule(createWatchTask(), intervalMS, intervalMS);
-        initWatch();
         log.info("Created index watcher with interval {}ms", intervalMS);
     }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -53,7 +53,7 @@ public class NetarchiveSolrClient {
     protected static String indexDocFieldList = "id,score,title,url,url_norm,links_images,source_file_path,source_file,source_file_offset,domain,resourcename,content_type,content_type_full,content_type_norm,hash,type,crawl_date,content_encoding,exif_location,status_code,last_modified,redirect_to_norm";
     protected static String indexDocFieldListShort = "url,url_norm,source_file_path,source_file,source_file_offset,crawl_date";
 
-    protected boolean solrAvailable = true;
+    protected Boolean solrAvailable = null;
 
     protected NetarchiveSolrClient() { // private. Singleton
     }
@@ -114,6 +114,9 @@ public class NetarchiveSolrClient {
             case unavailable:
                 solrAvailable = false;
                 break;
+            case undetermined:
+                log.debug("Got IndexWatcher.STATUS.undetermined. This should not be possible");
+                break;
             default:
                 log.warn("Unsupported value for IndexWatcher.STATUS: '{}'", status);
         }
@@ -122,9 +125,9 @@ public class NetarchiveSolrClient {
     /**
      * Requires a running {@link IndexWatcher}. If not enabled, the result will always be true.
      * Enabled per default, controlled by {@link PropertiesLoader#SOLR_SERVER_CHECK_INTERVAL}).
-     * @return true if the backing Solr is available, else false.
+     * @return true if the backing Solr is available, else false. null if not determined
      */
-    public boolean isSolrAvailable() {
+    public Boolean isSolrAvailable() {
         return solrAvailable;
     }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -46,11 +46,14 @@ public class NetarchiveSolrClient {
     protected static SolrClient solrServer;
     protected static SolrClient noCacheSolrServer;
     protected static NetarchiveSolrClient instance = null;
+    protected static IndexWatcher indexWatcher = null;
     protected static Pattern TAGS_VALID_PATTERN = Pattern.compile("[-_.a-zA-Z0-9Ã¦Ã¸Ã¥Ã†Ã˜Ã…]+");
   
     private static String NO_REVISIT_FILTER ="record_type:response OR record_type:arc OR record_type:resource";
     protected static String indexDocFieldList = "id,score,title,url,url_norm,links_images,source_file_path,source_file,source_file_offset,domain,resourcename,content_type,content_type_full,content_type_norm,hash,type,crawl_date,content_encoding,exif_location,status_code,last_modified,redirect_to_norm";
     protected static String indexDocFieldListShort = "url,url_norm,source_file_path,source_file,source_file_offset,crawl_date";
+
+    protected boolean solrAvailable = true;
 
     protected NetarchiveSolrClient() { // private. Singleton
     }
@@ -65,14 +68,12 @@ public class NetarchiveSolrClient {
     public static void initialize(String solrServerUrl) {
         SolrClient innerSolrClient = new HttpSolrClient.Builder(solrServerUrl).build();
 
-
-        if (PropertiesLoader.SOLR_SERVER_CACHING==true) {
+        if (PropertiesLoader.SOLR_SERVER_CACHING) {
             int maxCachingEntries = PropertiesLoader.SOLR_SERVER_CACHING_MAX_ENTRIES;
             int maxCachingSeconds = PropertiesLoader.SOLR_SERVER_CACHING_AGE_SECONDS;
             solrServer = new CachingSolrClient(innerSolrClient, maxCachingEntries,  maxCachingSeconds, -1); //-1 means no maximum number of connections 
             log.info("SolrClient initialized with caching properties: maxCachedEntrie="+maxCachingEntries +" cacheAgeSeconds="+maxCachingSeconds);
-        }
-        else {
+        } else {
             solrServer = new HttpSolrClient.Builder(solrServerUrl).build();
             log.info("SolClient initialized without caching");
         }
@@ -84,6 +85,12 @@ public class NetarchiveSolrClient {
         // error code 413/414, due to monster URI. (and it is faster)
 
         instance = new NetarchiveSolrClient();
+
+        if (PropertiesLoader.SOLR_SERVER_CHECK_INTERVAL > 0) {
+            indexWatcher = new IndexWatcher(
+                    innerSolrClient, PropertiesLoader.SOLR_SERVER_CHECK_INTERVAL, instance::indexStatusChanged);
+        }
+
         log.info("SolrClient initialized with solr server url:" + solrServerUrl);
     }
 
@@ -92,6 +99,33 @@ public class NetarchiveSolrClient {
             throw new IllegalArgumentException("SolrClient not initialized");
         }
         return instance;
+    }
+
+    private void indexStatusChanged(IndexWatcher.STATUS status) {
+        switch (status) {
+            case changed:
+                if (solrServer instanceof CachingSolrClient) {
+                    ((CachingSolrClient)solrServer).clearCache();
+                }
+                break;
+            case available:
+                solrAvailable = true;
+                break;
+            case unavailable:
+                solrAvailable = false;
+                break;
+            default:
+                log.warn("Unsupported value for IndexWatcher.STATUS: '{}'", status);
+        }
+    }
+
+    /**
+     * Requires a running {@link IndexWatcher}. If not enabled, the result will always be true.
+     * Enabled per default, controlled by {@link PropertiesLoader#SOLR_SERVER_CHECK_INTERVAL}).
+     * @return true if the backing Solr is available, else false.
+     */
+    public boolean isSolrAvailable() {
+        return solrAvailable;
     }
 
     /*

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/DateUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/DateUtils.java
@@ -36,11 +36,22 @@ public class DateUtils {
   }
   
   
+    /**
+     * @return Solr formatted timestamp with second precision.
+     */
   public static String getSolrDate(Date date){
     DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss"); //not thread safe, so create new         
     dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));    
     return dateFormat.format(date)+"Z";
+  }
 
+    /**
+     * @return Solr formatted timestamp with millisecond precision.
+     */
+  public static String getSolrDateFull(Date date){
+    DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS"); //not thread safe, so create new
+    dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    return dateFormat.format(date)+"Z";
   }
 
   public static String convertUtcDate2WaybackDate(String solrDate) throws RuntimeException{

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/IndexWatcherTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/IndexWatcherTest.java
@@ -4,8 +4,6 @@ import junit.framework.TestCase;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;
 
-import java.util.function.Consumer;
-
 /*
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/IndexWatcherTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/IndexWatcherTest.java
@@ -1,0 +1,42 @@
+package dk.kb.netarchivesuite.solrwayback.solr;
+
+import junit.framework.TestCase;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
+
+import java.util.function.Consumer;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+public class IndexWatcherTest extends TestCase {
+
+    public static final String SOLR_SERVER = "http://localhost:8983/solr/netarchivebuilder";
+
+    /**
+     * Not a unit test!
+     *
+     * This method requires a running Solr and only outputs state changes.
+     *
+     * Use this by starting the test, then start, stop or update the Solr collection {@code netarchivebuilder} on
+     * {@code localhost:8983} (default for the SolrWayback bundle) while watching the output.
+     */
+    public void disabledtestAgainstExistingIndex() throws InterruptedException {
+        SolrClient solrClient = new HttpSolrClient.Builder(SOLR_SERVER).build();
+        IndexWatcher watcher = new IndexWatcher(
+                solrClient, 500,
+                status -> System.out.println("New status: " + status));
+        Thread.sleep(100000000);
+    }
+}

--- a/src/test/resources/properties/solrwayback.properties
+++ b/src/test/resources/properties/solrwayback.properties
@@ -6,13 +6,15 @@ solr.server=http://localhost:8983/solr/netarchivebuilder/
 #Solr caching. Will be default false if not defined
 solr.server.caching=true
 solr.server.caching.max.entries=10000
-solr.server.caching.age.seconds=86400
+# Max age is set to a year as solr.server.check.interval is used.
+solr.server.caching.age.seconds=36586400
 
 # Solr availability and index change check interval.
 # The check is light if the index has not changes and moderate if the index has been changed
 # If an index change is detected, caches will be cleared
-# Default i 60000 milliseconds (1 minute).
+# Default is 60000 milliseconds (1 minute).
 # Disable by setting to -1
+# If the checking is disabled, consider setting solr.server.caching.age.seconds to something less than a year
 solr.server.check.interval=60000
 
 ## Link to this webapp itself. BaseURL for link rewrites must be full url.

--- a/src/test/resources/properties/solrwayback.properties
+++ b/src/test/resources/properties/solrwayback.properties
@@ -6,12 +6,17 @@ solr.server=http://localhost:8983/solr/netarchivebuilder/
 #Solr caching. Will be default false if not defined
 solr.server.caching=true
 solr.server.caching.max.entries=10000
-# Max age is set to a year as solr.server.check.interval is used.
+# Max age is set to a year, effectively disabling it, as solr.server.check.interval is used.
 solr.server.caching.age.seconds=36586400
 
 # Solr availability and index change check interval.
-# The check is light if the index has not changes and moderate if the index has been changed
+# The check is light if the index has not changes and moderate if the index has been changed.
 # If an index change is detected, caches will be cleared
+#
+# If the backing index has billions of records and is continuously updated, active checking
+# will strain the system. In that case it is recommended to disable active checking and use
+# fixed cache clearing with solr.server.caching.age.seconds instead.
+#
 # Default is 60000 milliseconds (1 minute).
 # Disable by setting to -1
 # If the checking is disabled, consider setting solr.server.caching.age.seconds to something less than a year

--- a/src/test/resources/properties/solrwayback.properties
+++ b/src/test/resources/properties/solrwayback.properties
@@ -6,7 +6,7 @@ solr.server=http://localhost:8983/solr/netarchivebuilder/
 #Solr caching. Will be default false if not defined
 solr.server.caching=true
 solr.server.caching.max.entries=10000
-# Max age is set to a year, effectively disabling it, as solr.server.check.interval is used.
+# Max age is set to a year, effectively disabling it, as solr.server.check.interval.seconds is used.
 solr.server.caching.age.seconds=36586400
 
 # Solr availability and index change check interval.
@@ -17,10 +17,10 @@ solr.server.caching.age.seconds=36586400
 # will strain the system. In that case it is recommended to disable active checking and use
 # fixed cache clearing with solr.server.caching.age.seconds instead.
 #
-# Default is 60000 milliseconds (1 minute).
+# Default is 60 seconds
 # Disable by setting to -1
 # If the checking is disabled, consider setting solr.server.caching.age.seconds to something less than a year
-solr.server.check.interval=60000
+solr.server.check.interval.seconds=60
 
 ## Link to this webapp itself. BaseURL for link rewrites must be full url.
 wayback.baseurl=http://localhost:8080/solrwayback/

--- a/src/test/resources/properties/solrwayback.properties
+++ b/src/test/resources/properties/solrwayback.properties
@@ -6,20 +6,21 @@ solr.server=http://localhost:8983/solr/netarchivebuilder/
 #Solr caching. Will be default false if not defined
 solr.server.caching=true
 solr.server.caching.max.entries=10000
-# Max age is set to a year, effectively disabling it, as solr.server.check.interval.seconds is used.
-solr.server.caching.age.seconds=36586400
+# Age based cache invalidation is not enabled per default as index watching works better for most cases
+# See the descrition of solr.server.check.interval.seconds below for more details
+#solr.server.caching.age.seconds=86400
 
-# Solr availability and index change check interval.
-# The check is light if the index has not changes and moderate if the index has been changed.
+# Solr availability and index change check interval: Every x seconds a query for new documents is issued.
 # If an index change is detected, caches will be cleared
 #
-# If the backing index has billions of records and is continuously updated, active checking
-# will strain the system. In that case it is recommended to disable active checking and use
-# fixed cache clearing with solr.server.caching.age.seconds instead.
+# The check is light (cached by Solr) if the index has not changed and moderate if the index has been
+# changed. If the backing index has billions of records and is continuously updated, active checking
+# will strain the system. In that case it is recommended to disable active checking and use fixed time
+# cache clearing with solr.server.caching.age.seconds instead.
 #
 # Default is 60 seconds
 # Disable by setting to -1
-# If the checking is disabled, consider setting solr.server.caching.age.seconds to something less than a year
+# If the checking is disabled, consider setting solr.server.caching.age.seconds instead
 solr.server.check.interval.seconds=60
 
 ## Link to this webapp itself. BaseURL for link rewrites must be full url.

--- a/src/test/resources/properties/solrwayback.properties
+++ b/src/test/resources/properties/solrwayback.properties
@@ -8,6 +8,13 @@ solr.server.caching=true
 solr.server.caching.max.entries=10000
 solr.server.caching.age.seconds=86400
 
+# Solr availability and index change check interval.
+# The check is light if the index has not changes and moderate if the index has been changed
+# If an index change is detected, caches will be cleared
+# Default i 60000 milliseconds (1 minute).
+# Disable by setting to -1
+solr.server.check.interval=60000
+
 ## Link to this webapp itself. BaseURL for link rewrites must be full url.
 wayback.baseurl=http://localhost:8080/solrwayback/
 


### PR DESCRIPTION
Add timer based cache invalidation by checks for index change, as suggested in #198 

Also adds webservice endpoint for checking Solr availability - maybe this could be used from the SolrWayback application in some way?

This closes #198 