### PR TITLE
More streaming cleanup

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
@@ -15,7 +15,6 @@
 package dk.kb.netarchivesuite.solrwayback.export;
 
 import com.google.common.base.Functions;
-import dk.kb.netarchivesuite.solrwayback.facade.Facade;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntryDescriptor;
 import dk.kb.netarchivesuite.solrwayback.solr.SolrGenericStreaming;
 import dk.kb.netarchivesuite.solrwayback.util.CollectionUtils;
@@ -25,11 +24,9 @@ import org.apache.solr.common.SolrDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -42,24 +39,28 @@ public class ContentStreams {
      * Searches images and webpages matching the given searchText. For webpages, linked images are resolved and
      * returned. In the case of multiple hits for the same image URL, the one harvested closest to the webpage
      * in time will be delivered.
-     * @param searchText       a query for images.
+     *
+     * If the caller needs {@link ArcEntryDescriptor}, use the helpers method in SolrUtils as
+     * {@code findImages(50, "kittens").map(SolrUtils::solrDocument2ArcEntryDescriptor)}.
      * @param maxImagesPerPage maximum number of images to resolve for any single page.
-     * @return a stream of image descriptors.
+     * @param query       a query for images.
+     * @param filterQueries 0 or more Solr queries.
+     * @return a stream of SolrDocuments representing images, containing the fields from
+     *         {@link SolrUtils#arcEntryDescriptorFieldList}.
      */
-    public static Stream<ArcEntryDescriptor> findImages(String searchText, int maxImagesPerPage) {
-        Stream<ArcEntryDescriptor> directImages =
+    public static Stream<SolrDocument> findImages(int maxImagesPerPage, String query, String... filterQueries) {
+        Stream<SolrDocument> directImages =
                 SolrGenericStreaming.create(
                                 Arrays.asList(SolrUtils.arcEntryDescriptorFieldList.split(", *")),
-                                searchText, "content_type_norm:image").stream().
-                        map(SolrUtils::solrDocument2ArcEntryDescriptor);
+                                query, SolrUtils.extend("content_type_norm:image", filterQueries)).stream();
 
         Stream<SolrDocument> htmlPages = SolrGenericStreaming.create(
                         Arrays.asList("crawl_date", "links_images"),
-                        searchText, "content_type_norm:html").stream().
+                        query, SolrUtils.extend("content_type_norm:html", filterQueries)).stream().
                 filter(solrDoc -> solrDoc.containsKey("links_images") &&
                                   !solrDoc.getFieldValues("links_images").isEmpty());
 
-        Stream<ArcEntryDescriptor> htmlImages =
+        Stream<SolrDocument> htmlImages =
                 // TODO: Make the maxImages per page configurable
                 Processing.batch(htmlPages.map(htmlPage -> createHTMLImageCallback(htmlPage, maxImagesPerPage))).
                         flatMap(Functions.identity());
@@ -69,10 +70,12 @@ public class ContentStreams {
     }
 
     /**
-     * Creates a callable delivering up to maxImages {@link ArcEntryDescriptor}s for images listed in
-     * {@code links_images} for the given htmlPage. The images are searched using
-     * {@link SolrGenericStreaming.SRequest#timeProximityDeduplication(String, String)} meaning that only one
-     * instance of a given image URL is returned, with preference to the one nearest in time to the htmlPage.
+     * Creates a callable delivering up to maxImages {@link SolrDocument}s for images listed in
+     * {@code links_images} for the given htmlPage. The documents will contain the fields from
+     * {@link SolrUtils#arcEntryDescriptorFieldList}.
+     * The images are searched using {@link SolrGenericStreaming.SRequest#timeProximityDeduplication(String, String)}
+     * meaning that only one instance of a given image URL is returned, with preference to the one nearest in time to
+     * the htmlPage.
      *
      * Note: Small images (less than 2000 pixels) are ignored, as are revisits.
      * @param htmlPage  a representation of a HTML page with links to images.
@@ -80,7 +83,7 @@ public class ContentStreams {
      * @param maxImages the maximum number of images to return.
      * @return a callable that will result in at most maxImages images linked from the given htmlPage.
      */
-    public static Callable<Stream<ArcEntryDescriptor>> createHTMLImageCallback(SolrDocument htmlPage, int maxImages) {
+    public static Callable<Stream<SolrDocument>> createHTMLImageCallback(SolrDocument htmlPage, int maxImages) {
         String timestamp = htmlPage.get("crawl_date").toString();
         Stream<String> urlQueries = ((List<String>)htmlPage.get("links_images")).stream().
                 distinct().
@@ -97,8 +100,7 @@ public class ContentStreams {
 
         return () -> SolrGenericStreaming.multiQuery(baseRequest, urlQueries, 500).
                 flatMap(SolrGenericStreaming::stream).
-                limit(maxImages).
-                map(SolrUtils::solrDocument2ArcEntryDescriptor);
+                limit(maxImages);
     }
 
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
@@ -1,0 +1,104 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.export;
+
+import com.google.common.base.Functions;
+import dk.kb.netarchivesuite.solrwayback.facade.Facade;
+import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntryDescriptor;
+import dk.kb.netarchivesuite.solrwayback.solr.SolrGenericStreaming;
+import dk.kb.netarchivesuite.solrwayback.util.CollectionUtils;
+import dk.kb.netarchivesuite.solrwayback.util.Processing;
+import dk.kb.netarchivesuite.solrwayback.util.SolrUtils;
+import org.apache.solr.common.SolrDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Stream oriented content delivery, suitable for export as well as special searches such as image search.
+ */
+public class ContentStreams {
+    private static final Logger log = LoggerFactory.getLogger(ContentStreams.class);
+
+    /**
+     * Searches images and webpages matching the given searchText. For webpages, linked images are resolved and
+     * returned. In the case of multiple hits for the same image URL, the one harvested closest to the webpage
+     * in time will be delivered.
+     * @param searchText       a query for images.
+     * @param maxImagesPerPage maximum number of images to resolve for any single page.
+     * @return a stream of image descriptors.
+     */
+    public static Stream<ArcEntryDescriptor> findImages(String searchText, int maxImagesPerPage) {
+        Stream<ArcEntryDescriptor> directImages =
+                SolrGenericStreaming.create(
+                                Arrays.asList(SolrUtils.arcEntryDescriptorFieldList.split(", *")),
+                                searchText, "content_type_norm:image").stream().
+                        map(SolrUtils::solrDocument2ArcEntryDescriptor);
+
+        Stream<SolrDocument> htmlPages = SolrGenericStreaming.create(
+                        Arrays.asList("crawl_date", "links_images"),
+                        searchText, "content_type_norm:html").stream().
+                filter(solrDoc -> solrDoc.containsKey("links_images") &&
+                                  !solrDoc.getFieldValues("links_images").isEmpty());
+
+        Stream<ArcEntryDescriptor> htmlImages =
+                // TODO: Make the maxImages per page configurable
+                Processing.batch(htmlPages.map(htmlPage -> createHTMLImageCallback(htmlPage, maxImagesPerPage))).
+                        flatMap(Functions.identity());
+
+        // Mix the two streams, 4 direct images for each 1 image derived from a page
+        return CollectionUtils.interleave(Arrays.asList(directImages, htmlImages), Arrays.asList(4, 1));
+    }
+
+    /**
+     * Creates a callable delivering up to maxImages {@link ArcEntryDescriptor}s for images listed in
+     * {@code links_images} for the given htmlPage. The images are searched using
+     * {@link SolrGenericStreaming.SRequest#timeProximityDeduplication(String, String)} meaning that only one
+     * instance of a given image URL is returned, with preference to the one nearest in time to the htmlPage.
+     *
+     * Note: Small images (less than 2000 pixels) are ignored, as are revisits.
+     * @param htmlPage  a representation of a HTML page with links to images.
+     *                  Required fields are {@code crawl_date} and {@code links_images}.
+     * @param maxImages the maximum number of images to return.
+     * @return a callable that will result in at most maxImages images linked from the given htmlPage.
+     */
+    public static Callable<Stream<ArcEntryDescriptor>> createHTMLImageCallback(SolrDocument htmlPage, int maxImages) {
+        String timestamp = htmlPage.get("crawl_date").toString();
+        Stream<String> urlQueries = ((List<String>)htmlPage.get("links_images")).stream().
+                distinct().
+                map(SolrUtils::createQueryStringForUrl);
+
+        SolrGenericStreaming.SRequest baseRequest =
+                SolrGenericStreaming.SRequest.builder().
+                        filterQueries("content_type_norm:image",   // only images
+                                      SolrUtils.NO_REVISIT_FILTER, // No binary for revisits.
+                                      "image_size:[2000 TO *]").   // No small images. (fillers etc.)
+                        fields(SolrUtils.arcEntryDescriptorFieldList).
+                        timeProximityDeduplication(timestamp, "url_norm").
+                        maxResults(maxImages); // No sense in returning more than maxImages from a sub-request
+
+        return () -> SolrGenericStreaming.multiQuery(baseRequest, urlQueries, 500).
+                flatMap(SolrGenericStreaming::stream).
+                limit(maxImages).
+                map(SolrUtils::solrDocument2ArcEntryDescriptor);
+    }
+
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 import javax.imageio.ImageIO;
 import javax.ws.rs.QueryParam;
 
-import dk.kb.netarchivesuite.solrwayback.util.SolrQueryUtils;
+import dk.kb.netarchivesuite.solrwayback.util.SolrUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -369,7 +369,7 @@ public class Facade {
         if (imageLinks.size() == 0) {
             return new ArrayList<>();
         }
-        String queryStr = SolrQueryUtils.createQueryStringForUrls(imageLinks);
+        String queryStr = SolrUtils.createQueryStringForUrls(imageLinks);
         ArrayList<ArcEntryDescriptor> imagesFromHtmlPage = NetarchiveSolrClient.getInstance().findImagesForTimestamp(queryStr, doc.getCrawlDate());
         return imagesFromHtmlPage;
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriter.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriter.java
@@ -134,7 +134,8 @@ public class HtmlParserUrlRewriter {
 		final long startMS = System.currentTimeMillis();
 		return replaceLinks(
 				arc.getBinaryContentAsStringUnCompressed(), arc.getUrl(), arc.getCrawlDate(),
-				(urls, timeStamp) -> NetarchiveSolrClient.getInstance().findNearestHarvestTimeForMultipleUrlsFewFields(urls, timeStamp),
+				(urls, timeStamp) -> NetarchiveSolrClient.getInstance().
+						findNearestHarvestTimeForMultipleUrlsFewFields(urls, timeStamp),
 				startMS);
 	}
 
@@ -348,16 +349,16 @@ public class HtmlParserUrlRewriter {
            
       log.info("#unique urlset to resolve:"+urlSet.size());
 
-      ArrayList<IndexDocShort> docs = NetarchiveSolrClient.getInstance().findNearestHarvestTimeForMultipleUrlsFewFields(urlSet,arc.getCrawlDate());
 
       StringBuffer buf = new StringBuffer();
-      for (IndexDocShort indexDoc: docs){
-          buf.append("<part>\n");        
-          buf.append("urn:pwid:"+collectionName+":"+indexDoc.getCrawlDate()+":part:"+indexDoc.getUrl() +"\n");
-          buf.append("</part>\n");
-          //pwid:netarkivet.dk:time:part:url      
-      }
-     return buf.toString();
+	  NetarchiveSolrClient.getInstance().findNearestHarvestTimeForMultipleUrlsFewFields(urlSet,arc.getCrawlDate()).
+			  forEach(shortDoc -> {
+				  buf.append("<part>\n");
+				  buf.append("urn:pwid:"+collectionName+":"+shortDoc.getCrawlDate()+":part:"+shortDoc.getUrl() +"\n");
+				  buf.append("</part>\n");
+				  //pwid:netarkivet.dk:time:part:url
+			  });
+		return buf.toString();
 	}
 
   

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriterBase.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriterBase.java
@@ -138,7 +138,10 @@ public abstract class RewriterBase {
    		parseResult.addTiming("getContent", System.currentTimeMillis()-startgetContentMS);
 
 		replaceLinks(
-				content, arc.getUrl(), arc.getCrawlDate(), (urls, timeStamp) -> NetarchiveSolrClient.getInstance().findNearestHarvestTimeForMultipleUrlsFewFields(urls, timeStamp), parseResult, packaging
+				content, arc.getUrl(), arc.getCrawlDate(),
+				(urls, timeStamp) -> NetarchiveSolrClient.getInstance().
+						findNearestHarvestTimeForMultipleUrlsFewFields(urls, timeStamp),
+				parseResult, packaging
 		);
 		log.info(String.format(
 				"replaceLinks.%s(<arc-entry of length %d bytes>, packaging=%s, base='%s', date=%s) completed: %s",

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/Twitter2Html.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/Twitter2Html.java
@@ -19,7 +19,7 @@ import dk.kb.netarchivesuite.solrwayback.service.dto.ImageUrl;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
 import dk.kb.netarchivesuite.solrwayback.service.dto.SearchResult;
 import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrClient;
-import dk.kb.netarchivesuite.solrwayback.util.SolrQueryUtils;
+import dk.kb.netarchivesuite.solrwayback.util.SolrUtils;
 import dk.kb.netarchivesuite.solrwayback.util.TwitterParsingUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -166,19 +166,19 @@ public class Twitter2Html {
         }
         String html =
                 "<div class='retweet-author'>" +
-                  "<div class='retweet-text-wrap'>" +
-                    "<div class='user-wrapper'>" +
-                      "<a href='" + SolrQueryUtils.createTwitterSearchURL("tw_user_id:" + mainUser.getId()) + "'>" +
-                        "<h3>" + mainUser.getName() + " Retweeted</h3>" +
-                      "</a>" +
-                      makeUserCard(profileImageUrl, mainUser.getName(),
+                "<div class='retweet-text-wrap'>" +
+                "<div class='user-wrapper'>" +
+                "<a href='" + SolrUtils.createTwitterSearchURL("tw_user_id:" + mainUser.getId()) + "'>" +
+                "<h3>" + mainUser.getName() + " Retweeted</h3>" +
+                "</a>" +
+                makeUserCard(profileImageUrl, mainUser.getName(),
                               mainUser.getScreenName(), mainUser.getDescription(),
                               mainUser.getFriendsCount(), mainUser.getFollowersCount(),
                               mainUser.isVerified()) +
-                    "</div>" +
-                    "<div class='date'>&middot " + tweet.getCreationDate() + "</div>" +
-                  "</div>" +
-                  makeButtonLinkingToTweet(tweet.getRetweetedTweet().getId(), "View original tweet") +
+                "</div>" +
+                "<div class='date'>&middot " + tweet.getCreationDate() + "</div>" +
+                "</div>" +
+                makeButtonLinkingToTweet(tweet.getRetweetedTweet().getId(), "View original tweet") +
                 "</div>";
         return html;
     }
@@ -191,22 +191,22 @@ public class Twitter2Html {
      */
     private String getAuthorHtml(List<ImageUrl> profileImageUrl, TweetUser user) {
         return "<div class='author'>" +
-                  "<div class='user-wrapper'>" +
-                    "<a href='" + SolrQueryUtils.createTwitterSearchURL(
+               "<div class='user-wrapper'>" +
+               "<a href='" + SolrUtils.createTwitterSearchURL(
                     "tw_user_id:" + user.getId()) + "'>" +
-                      "<div class='avatar'>" + imageUrlsToHtmlTags(profileImageUrl) + "</div>" +
-                      "<div class='user-handles'>" +
-                        "<h2>" + user.getName() + "</h2>" +
-                        (user.isVerified() ? "<span class='user-verified'></span>" : "") +
-                        "<h4>@" + user.getScreenName() + "</h4>" +
-                      "</div>" +
-                    "</a>" +
-                    makeUserCard(profileImageUrl, user.getName(),
+               "<div class='avatar'>" + imageUrlsToHtmlTags(profileImageUrl) + "</div>" +
+               "<div class='user-handles'>" +
+               "<h2>" + user.getName() + "</h2>" +
+               (user.isVerified() ? "<span class='user-verified'></span>" : "") +
+               "<h4>@" + user.getScreenName() + "</h4>" +
+               "</div>" +
+               "</a>" +
+               makeUserCard(profileImageUrl, user.getName(),
                             user.getScreenName(), user.getDescription(),
                             user.getFriendsCount(), user.getFollowersCount(),
                             user.isVerified()) +
-                  "</div>" +
-                "</div>";
+               "</div>" +
+               "</div>";
     }
 
     /**
@@ -218,7 +218,7 @@ public class Twitter2Html {
     private List<ImageUrl> getImageUrlsFromSolr(List<String> imageUrlStrings) {
         ArrayList<ImageUrl> imageUrls = new ArrayList<>();
         try {
-            String imagesSolrQuery = SolrQueryUtils.createQueryStringForUrls(imageUrlStrings);
+            String imagesSolrQuery = SolrUtils.createQueryStringForUrls(imageUrlStrings);
             ArrayList<ArcEntryDescriptor> imageEntries = NetarchiveSolrClient.getInstance()
                     .findImagesForTimestamp(imagesSolrQuery, crawlDate);
             imageUrls = Facade.arcEntrys2Images(imageEntries);
@@ -259,7 +259,7 @@ public class Twitter2Html {
         TweetVideoVariant bestVideo = TwitterParsingUtils.getBestBitrateVideoVariant(video);
         String bestVideoUrl = bestVideo.getUrl();
         String videoImageUrl = video.getMediaUrl();
-        String videoSolrQuery = SolrQueryUtils.createQueryStringForUrl(bestVideoUrl);
+        String videoSolrQuery = SolrUtils.createQueryStringForUrl(bestVideoUrl);
 
         String videoDownloadUrl = "";
         ArcEntryDescriptor videoSolrEntry = NetarchiveSolrClient.getInstance().findVideo(videoSolrQuery);
@@ -459,7 +459,7 @@ public class Twitter2Html {
     private static String makeMentionHtml(String mentionScreenName) {
         String searchString = "(author:" + mentionScreenName + " OR tw_user_mentions:"
                     + mentionScreenName.toLowerCase() + ")";
-        String searchUrl = SolrQueryUtils.createTwitterSearchURL(searchString);
+        String searchUrl = SolrUtils.createTwitterSearchURL(searchString);
         return "<span><a href='" + searchUrl + "'>@" + mentionScreenName + "</a></span>";
     }
 
@@ -471,7 +471,7 @@ public class Twitter2Html {
      */
     private static String makeHashtagHtml(String hashtagText) {
         String searchString = "keywords%3A" + hashtagText;
-        String searchUrl = SolrQueryUtils.createTwitterSearchURL(searchString);
+        String searchUrl = SolrUtils.createTwitterSearchURL(searchString);
         return "<span><a href='" + searchUrl + "'>#" + hashtagText + "</a></span>";
     }
 
@@ -624,7 +624,7 @@ public class Twitter2Html {
         try {
             SearchResult searchResult = Facade.search("tw_reply_to_tweet_id:" + tweetID, null);
             long resultCount = searchResult.getNumberOfResults();
-            String searchLink = SolrQueryUtils.createTwitterSearchURL("tw_reply_to_tweet_id:" + tweetID);
+            String searchLink = SolrUtils.createTwitterSearchURL("tw_reply_to_tweet_id:" + tweetID);
             if (resultCount > 0) {
                 log.info("Found replies to tweet id {}.. {}", tweetID, resultCount);
                 foundRepliesLine = "Found <a href='" + searchLink + "'>" + resultCount + "</a> replies";

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
@@ -128,8 +128,12 @@ public class PropertiesLoader {
 
             if (cachingStr != null && cachingStr.equalsIgnoreCase("true")) {
                 SOLR_SERVER_CACHING=true;
-                SOLR_SERVER_CACHING_AGE_SECONDS=Integer.parseInt(serviceProperties.getProperty(SOLR_SERVER_CACHING_AGE_SECONDS_PROPERTY).trim());
-                SOLR_SERVER_CACHING_MAX_ENTRIES=Integer.parseInt(serviceProperties.getProperty(SOLR_SERVER_CACHING_MAX_ENTRIES_PROPERTY).trim());
+                if (serviceProperties.containsKey(SOLR_SERVER_CACHING_AGE_SECONDS_PROPERTY)) {
+                    SOLR_SERVER_CACHING_AGE_SECONDS = Integer.parseInt(serviceProperties.getProperty(SOLR_SERVER_CACHING_AGE_SECONDS_PROPERTY).trim());
+                }
+                if (serviceProperties.containsKey(SOLR_SERVER_CACHING_MAX_ENTRIES_PROPERTY)) {
+                    SOLR_SERVER_CACHING_MAX_ENTRIES = Integer.parseInt(serviceProperties.getProperty(SOLR_SERVER_CACHING_MAX_ENTRIES_PROPERTY).trim());
+                }
             }
 
             SOLR_SERVER_CHECK_INTERVAL = Integer.parseInt(serviceProperties.getProperty(

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -721,6 +721,9 @@ public class NetarchiveSolrClient {
     }
 
     public static void mergeInto(SolrDocumentList main, SolrDocumentList additional) {
+        if (additional == null) {
+            return;
+        }
         main.addAll(additional);
         if (additional.getMaxScore() != null) {
             main.setMaxScore(main.getMaxScore() == null ? additional.getMaxScore() : Math.max(main.getMaxScore(), additional.getMaxScore()));

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -1290,4 +1290,25 @@ public class NetarchiveSolrClient {
         return rsp;
     }
 
+    /**
+     * Sets property defined query parameters with {@link SolrUtils#setSolrParams(SolrQuery)} and issues the query.
+     *
+     * Exceptions are caught and re-thrown as {@link RuntimeException}s.
+     * @param solrQuery any SolrQuery.
+     * @param useCachingClient if true, client side caching is used. If false, no client side caching is done.
+     * @return the result of issuing the query.
+     */
+    public static QueryResponse query(SolrQuery solrQuery, boolean useCachingClient) {
+        SolrUtils.setSolrParams(solrQuery);
+        try {
+            return useCachingClient ?
+                    solrServer.query(solrQuery, METHOD.POST) :
+                    noCacheSolrServer.query(solrQuery, METHOD.POST);
+        } catch (SolrServerException e) {
+            throw new RuntimeException("SolrServerException issuing query", e);
+        } catch (IOException e) {
+            throw new RuntimeException("IOException issuing query", e);
+        }
+    }
+
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -10,7 +10,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import dk.kb.netarchivesuite.solrwayback.util.CollectionUtils;
 import dk.kb.netarchivesuite.solrwayback.util.SolrUtils;
 import org.apache.solr.client.solrj.SolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -28,8 +27,6 @@ import org.apache.solr.common.util.NamedList;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.common.collect.Iterables;
 
 import dk.kb.netarchivesuite.solrwayback.normalise.Normalisation;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
@@ -161,7 +158,7 @@ public class NetarchiveSolrClient {
         solrQuery.addFilterQuery("crawl_date:[" + dateStart + " TO " + dateEnd + "]");
 
         solrQuery.add("fl","id");
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
         List<FacetCount> facetList = new ArrayList<FacetCount>();
         FacetField facet = rsp.getFacetField("domain");
@@ -191,7 +188,7 @@ public class NetarchiveSolrClient {
         solrQuery.add("facet.limit", "" + (facetLimit + 1)); // +1 because itself will be removed and is almost certain of resultset is self-linking
         solrQuery.addFilterQuery("crawl_date:[" + dateStart + " TO " + dateEnd + "]");
         solrQuery.add("fl","id");                                                                                                                                                                  // request
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = noCacheSolrServer.query(solrQuery, METHOD.POST); //do not cache
         List<FacetCount> facetList = new ArrayList<FacetCount>();
         FacetField facet = rsp.getFacetField("links_domains");
@@ -277,7 +274,7 @@ public class NetarchiveSolrClient {
         solrQuery.setGetFieldStatistics(statsField);
 
         long call1ns = -System.nanoTime();
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
         call1ns += System.nanoTime();
         final long call1nsSolr = rsp.getQTime();
@@ -302,7 +299,7 @@ public class NetarchiveSolrClient {
         solrQuery.setGetFieldStatistics(statsField);
 
         long call2ns = -System.nanoTime();
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         rsp = solrServer.query(solrQuery, METHOD.POST);
         call2ns += System.nanoTime();
         final long call2nsSolr = rsp.getQTime();
@@ -333,7 +330,7 @@ public class NetarchiveSolrClient {
             solrQuery.setGetFieldStatistics(statsField);
 
             callDomain = -System.nanoTime();
-            setSolrParams(solrQuery);
+            SolrUtils.setSolrParams(solrQuery);
             rsp = solrServer.query(solrQuery, METHOD.POST);
             callDomain += System.nanoTime();
             callDomainSolr = rsp.getQTime();
@@ -349,7 +346,7 @@ public class NetarchiveSolrClient {
         solrQuery.setGetFieldStatistics("content_length");
 
         long call3ns = -System.nanoTime();
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         rsp = solrServer.query(solrQuery, METHOD.POST);
         call3ns += System.nanoTime();
         final long call3nsSolr = rsp.getQTime();
@@ -405,7 +402,7 @@ public class NetarchiveSolrClient {
     public ArcEntryDescriptor findVideo(String videoQueryString) throws Exception {
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(videoQueryString);
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         solrQuery.setRows(1); // Just get one result
 
         solrQuery.set("facet", "false"); // Very important. Must overwrite to false. Facets are very slow and expensive.
@@ -439,7 +436,7 @@ public class NetarchiveSolrClient {
         solrQuery.set("facet", "false"); // very important. Must overwrite to false. Facets are very slow and expensive.
         solrQuery.add("fl", "id,crawl_date");
         solrQuery.setRows(1000000);
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = loggedSolrQuery("getHarvestTimeForUrl", solrQuery);
 
         SolrDocumentList docs = rsp.getResults();
@@ -461,7 +458,7 @@ public class NetarchiveSolrClient {
         solrQuery.add("fl", "id");
         solrQuery.setFilterQueries(filterQuery);
         solrQuery.setRows(0);
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
         return rsp.getResults().getNumFound();
     }
@@ -479,7 +476,7 @@ public class NetarchiveSolrClient {
         solrQuery.setRows(5000);
 
         long solrNS = -System.nanoTime();
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = noCacheSolrServer.query(solrQuery, METHOD.POST); //do not cache
         solrNS += System.nanoTime();
         SolrDocumentList docs = rsp.getResults();
@@ -509,7 +506,7 @@ public class NetarchiveSolrClient {
         solrQuery.setRows(1000000);
 
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         SolrDocumentList docs = rsp.getResults();
 
         ArrayList<IndexDoc> indexDocs = SolrUtils.solrDocList2IndexDoc(docs);
@@ -529,7 +526,7 @@ public class NetarchiveSolrClient {
         solrQuery.add("facet.limit", "100"); //All years...
         solrQuery.add("fl","id");
         solrQuery.setRows(0);
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
         ArrayList<FacetCount> facetList = new ArrayList<FacetCount>();
         FacetField facet = rsp.getFacetField("crawl_year");
@@ -563,7 +560,7 @@ public class NetarchiveSolrClient {
         solrQuery.setRows(1);
 
         // QueryResponse rsp = loggedSolrQuery("getArchEntry", solrQuery); //Timing disabled due to spam. Also only took 1-5 millis
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = noCacheSolrServer.query(solrQuery, METHOD.POST);
         SolrDocumentList docs = rsp.getResults();
 
@@ -620,7 +617,7 @@ public class NetarchiveSolrClient {
         solrQuery.setRows(results);
         
         
-        setSolrParams(solrQuery); //NOT SURE ABOUT THIS ONE!
+        SolrUtils.setSolrParams(solrQuery); //NOT SURE ABOUT THIS ONE!
         
         // The 3 lines defines geospatial search. The ( ) are required if you want to
         // AND with another query
@@ -653,7 +650,7 @@ public class NetarchiveSolrClient {
         }
         
       
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = loggedSolrQuery("search", solrQuery);
         SolrDocumentList docs = rsp.getResults();
 
@@ -666,7 +663,7 @@ public class NetarchiveSolrClient {
     public long numberOfDocuments() throws Exception {
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery("*:*");
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
         SolrDocumentList docs = rsp.getResults();
         return docs.getNumFound();
@@ -808,7 +805,7 @@ public class NetarchiveSolrClient {
         // other methods in this class, but not as critical there.
         // Hoping for a solr fix....
         solrQuery.setRows(10);
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = loggedSolrQuery(
                 String.format("findClosestHarvestTimeForUrl(url='%s', timestamp=%s)", url.length() > 50 ? url.substring(0, 50) + "..." : url, timeStamp),
                 solrQuery);
@@ -889,7 +886,7 @@ public class NetarchiveSolrClient {
         solrQuery.set("facet.field", "crawl_year");
         solrQuery.set("facet.sort", "index");
         solrQuery.set("facet.limit", "500"); // 500 is higher than number of different years
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
 
         FacetField facetField = rsp.getFacetField("crawl_year");
@@ -911,7 +908,7 @@ public class NetarchiveSolrClient {
         solrQuery.setRows(1); // 1 page only
 
         solrQuery.add("fl", SolrUtils.indexDocFieldList);
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = loggedSolrQuery("pwidQuery", solrQuery);
 
         SolrDocumentList docs = rsp.getResults();
@@ -937,7 +934,7 @@ public class NetarchiveSolrClient {
 
         solrQuery.add("fq","content_type_norm:html"); // only html pages
         solrQuery.add("fq", SolrUtils.NO_REVISIT_FILTER); // do not include record_type:revisit
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
 
         FacetField facetField = rsp.getFacetField("crawl_year");
@@ -969,7 +966,7 @@ public class NetarchiveSolrClient {
 
         solrQuery.add("fq","content_type_norm:html"); // only html pages
         solrQuery.add("fq", SolrUtils.NO_REVISIT_FILTER); // do not include record_type:revisit
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
 
         FacetField facetField = rsp.getFacetField("crawl_year");
@@ -993,7 +990,7 @@ public class NetarchiveSolrClient {
         solrQuery.set("group.sort", "abs(sub(ms(" + timeStamp + "), crawl_date)) asc");
         solrQuery.add("fl", SolrUtils.indexDocFieldList);
         solrQuery.setFilterQueries(SolrUtils.NO_REVISIT_FILTER); // No binary for revists.
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
         SolrDocumentList docs = groupsToDoc(rsp);
         return SolrUtils.solrDocList2IndexDoc(docs);
@@ -1031,7 +1028,7 @@ public class NetarchiveSolrClient {
             }
         }
 
-        setSolrParams(solrQuery);        
+        SolrUtils.setSolrParams(solrQuery);
         
         NoOpResponseParser rawJsonResponseParser = new NoOpResponseParser();
         rawJsonResponseParser.setWriterType("json");
@@ -1078,7 +1075,7 @@ public class NetarchiveSolrClient {
         }
 
         
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         
         NoOpResponseParser rawJsonResponseParser = new NoOpResponseParser();
         rawJsonResponseParser.setWriterType("json");
@@ -1132,7 +1129,7 @@ public class NetarchiveSolrClient {
             }
         }
        
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         
         NoOpResponseParser rawJsonResponseParser = new NoOpResponseParser();
         rawJsonResponseParser.setWriterType("json");
@@ -1167,7 +1164,7 @@ public class NetarchiveSolrClient {
 
         QueryRequest req = new QueryRequest(solrQuery);
         req.setResponseParser(rawJsonResponseParser);
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         NamedList<Object> resp = solrServer.request(req);
         String jsonResponse = (String) resp.get("response");
         return jsonResponse;
@@ -1201,7 +1198,7 @@ public class NetarchiveSolrClient {
         solrQuery.add("stats", "true");
         solrQuery.add("stats.field", "{!count=true cardinality=true}url_norm"); // Important, use cardinality and not unique.
         solrQuery.add("stats.field", "{!sum=true}content_length");
-        setSolrParams(solrQuery);
+        SolrUtils.setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery);
 
         Map<String, FieldStatsInfo> statsMap = rsp.getFieldStatsInfo();
@@ -1257,7 +1254,7 @@ public class NetarchiveSolrClient {
         for (String filter : fq) {
             solrQuery.addFilterQuery(filter);
         }
-        setSolrParams(solrQuery); //TODO not sure about this one
+        SolrUtils.setSolrParams(solrQuery); //TODO not sure about this one
         NoOpResponseParser rawJsonResponseParser = new NoOpResponseParser();
         rawJsonResponseParser.setWriterType("json");
 
@@ -1278,14 +1275,7 @@ public class NetarchiveSolrClient {
         return Normalisation.canonicaliseURL(url);
     }
 
-    private static void setSolrParams(SolrQuery solrQuery) {
-        HashMap<String, String> SOLR_PARAMS_MAP = PropertiesLoader.SOLR_PARAMS_MAP;
-        for (String key : SOLR_PARAMS_MAP.keySet()) {        
-            solrQuery.set(key,SOLR_PARAMS_MAP.get(key));            
-        }
-    }
 
-    
     /**
      * Performs a Solr call, logging the time it took; both measured and reported
      * QTime.

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -386,7 +386,7 @@ public class NetarchiveSolrClient {
                                               "image_size:[2000 TO *]").   // No small images. (fillers etc.)
                                 fields(SolrUtils.indexDocFieldList).
                                 timeProximityDeduplication(timeStamp, "url_norm").
-                                maxResults(50)
+                                maxResults(50) // TODO: Make this an argument instead
                 ).
                 stream().
                 map(SolrUtils::solrDocument2ArcEntryDescriptor).
@@ -702,7 +702,7 @@ public class NetarchiveSolrClient {
         Stream<String> urlQueries = urls.
                 filter(url -> !url.startsWith("data:")).
                 map(NetarchiveSolrClient::normalizeUrl).
-                map(NetarchiveSolrClient::createPhrase).
+                map(SolrUtils::createPhrase).
                 map(url -> "url_norm:" + url);
 
         return SolrGenericStreaming.multiQuery(baseRequest, urlQueries, chunkSize).
@@ -757,21 +757,11 @@ public class NetarchiveSolrClient {
                 sb.append(" ").append(operator).append(" ");
             }
             first = false;
-            sb.append(createPhrase(normalizeUrl(url)));
+            sb.append(SolrUtils.createPhrase(normalizeUrl(url)));
         }
         sb.append(")");
         return sb.toString();
     }
-
-     /**
-      * Quotes the given phrase and escapes characters that needs escaping (backslash and quote).
-      * {@code foo \bar "zoo} becomes {@code "foo \\bar \"zoo"}.
-      * @param phrase any phrase.
-      * @return the phrase quoted and escaped.
-      */
-     private static String createPhrase(String phrase) {
-         return "\"" + phrase.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
-     }
 
     /*
      * Notice here do we not fix url_norm

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -49,10 +49,6 @@ public class NetarchiveSolrClient {
     protected static NetarchiveSolrClient instance = null;
     protected static IndexWatcher indexWatcher = null;
     protected static Pattern TAGS_VALID_PATTERN = Pattern.compile("[-_.a-zA-Z0-9Ã¦Ã¸Ã¥Ã†Ã˜Ã…]+");
-  
-    private static String NO_REVISIT_FILTER ="record_type:response OR record_type:arc OR record_type:resource";
-    protected static String indexDocFieldList = "id,score,title,url,url_norm,links_images,source_file_path,source_file,source_file_offset,domain,resourcename,content_type,content_type_full,content_type_norm,hash,type,crawl_date,content_encoding,exif_location,status_code,last_modified,redirect_to_norm";
-    protected static String indexDocFieldListShort = "url,url_norm,source_file_path,source_file,source_file_offset,crawl_date";
 
     protected Boolean solrAvailable = null;
 
@@ -387,9 +383,9 @@ public class NetarchiveSolrClient {
         solrQuery.add("group.field", "url_norm");
         solrQuery.add("group.sort", "abs(sub(ms(" + timeStamp + "), crawl_date)) asc");
         solrQuery.add("fq", "content_type_norm:image"); // only images
-        solrQuery.add("fq", NO_REVISIT_FILTER); // No binary for revisits.
+        solrQuery.add("fq", SolrUtils.NO_REVISIT_FILTER); // No binary for revisits.
         solrQuery.add("fq","image_size:[2000 TO *]"); // No small images. (fillers etc.)
-        solrQuery.add("fl", indexDocFieldList);
+        solrQuery.add("fl", SolrUtils.indexDocFieldList);
 
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
 
@@ -432,8 +428,8 @@ public class NetarchiveSolrClient {
 
         solrQuery.set("facet", "false"); // Very important. Must overwrite to false. Facets are very slow and expensive.
         solrQuery.add("fq", "content_type_norm:video"); // only videos
-        solrQuery.add("fq", NO_REVISIT_FILTER);
-        solrQuery.add("fl", indexDocFieldList);
+        solrQuery.add("fq", SolrUtils.NO_REVISIT_FILTER);
+        solrQuery.add("fl", SolrUtils.indexDocFieldList);
 
         QueryResponse response = solrServer.query(solrQuery, METHOD.POST);
 
@@ -583,7 +579,7 @@ public class NetarchiveSolrClient {
 
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.set("facet", "false"); // very important. Must overwrite to false. Facets are very slow and expensive.
-        solrQuery.add("fl", indexDocFieldList);
+        solrQuery.add("fl", SolrUtils.indexDocFieldList);
 
         String query = null;
 
@@ -643,7 +639,7 @@ public class NetarchiveSolrClient {
         log.info("imagesLocationSearch:" + searchText + " coordinates:" + latitude + "," + longitude + " radius:" + radius);
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.set("facet", "false"); // very important. Must overwrite to false. Facets are very slow and expensive.
-        solrQuery.add("fl", indexDocFieldList);
+        solrQuery.add("fl", SolrUtils.indexDocFieldList);
         solrQuery.add("group", "true");
         solrQuery.add("group.field", "hash"); // Notice not using url_norm. We want really unique images.
         solrQuery.add("group.format", "simple");
@@ -679,7 +675,7 @@ public class NetarchiveSolrClient {
         SearchResult result = new SearchResult();
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.set("facet", "false"); // very important. Must overwrite to false. Facets are very slow and expensive.
-        solrQuery.add("fl", indexDocFieldList);
+        solrQuery.add("fl", SolrUtils.indexDocFieldList);
         solrQuery.setQuery(searchString); // only search images
         solrQuery.setRows(results);
         if (filterQuery != null) {
@@ -731,7 +727,7 @@ public class NetarchiveSolrClient {
     }
 
     private List<IndexDocShort> findNearestHarvestTimeForMultipleUrlsMax1000Short(HashSet<String> urls, String timeStamp) throws Exception {
-        SolrDocumentList docs = findNearestDocuments(urls, timeStamp, indexDocFieldListShort);
+        SolrDocumentList docs = findNearestDocuments(urls, timeStamp, SolrUtils.indexDocFieldListShort);
 
         ArrayList<IndexDocShort> allDocs = new ArrayList<IndexDocShort>(docs.size());
         for (SolrDocument current : docs) {
@@ -743,7 +739,7 @@ public class NetarchiveSolrClient {
     }
 
     private List<IndexDoc> findNearestHarvestTimeForMultipleUrlsMax1000(HashSet<String> urls, String timeStamp) throws Exception {
-        SolrDocumentList docs = findNearestDocuments(urls, timeStamp, indexDocFieldList);
+        SolrDocumentList docs = findNearestDocuments(urls, timeStamp, SolrUtils.indexDocFieldList);
 
         ArrayList<IndexDoc> allDocs = new ArrayList<IndexDoc>(docs.size());
         for (SolrDocument current : docs) {
@@ -783,7 +779,7 @@ public class NetarchiveSolrClient {
         solrQuery.set("group.sort", "abs(sub(ms(" + timeStamp + "), crawl_date)) asc");
         solrQuery.add("fl", fieldList);
 
-        solrQuery.setFilterQueries(NO_REVISIT_FILTER); // No binary for revists.
+        solrQuery.setFilterQueries(SolrUtils.NO_REVISIT_FILTER); // No binary for revists.
 
         long solrNS = -System.nanoTime();
         setSolrParams(solrQuery);
@@ -877,11 +873,11 @@ public class NetarchiveSolrClient {
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(query);
 
-        solrQuery.setFilterQueries(NO_REVISIT_FILTER); // No binary for revists.
+        solrQuery.setFilterQueries(SolrUtils.NO_REVISIT_FILTER); // No binary for revists.
 
         solrQuery.set("facet", "false"); // very important. Must overwrite to false. Facets are very slow and expensive.
         solrQuery.add("sort", "abs(sub(ms(" + timeStamp + "), crawl_date)) asc");
-        solrQuery.add("fl", indexDocFieldList);
+        solrQuery.add("fl", SolrUtils.indexDocFieldList);
         // solrQuery.setRows(1);
         // code below is temporary fix for the solr bug. Get the nearest and find which
         // one is nearest.
@@ -991,7 +987,7 @@ public class NetarchiveSolrClient {
         solrQuery.setQuery(pwidQuery);
         solrQuery.setRows(1); // 1 page only
 
-        solrQuery.add("fl", indexDocFieldList);
+        solrQuery.add("fl", SolrUtils.indexDocFieldList);
         setSolrParams(solrQuery);
         QueryResponse rsp = loggedSolrQuery("pwidQuery", solrQuery);
 
@@ -1017,7 +1013,7 @@ public class NetarchiveSolrClient {
         solrQuery.set("facet.limit", "500"); // 500 is higher than number of different years
 
         solrQuery.add("fq","content_type_norm:html"); // only html pages
-        solrQuery.add("fq",NO_REVISIT_FILTER); // do not include record_type:revisit
+        solrQuery.add("fq", SolrUtils.NO_REVISIT_FILTER); // do not include record_type:revisit
         setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
 
@@ -1049,7 +1045,7 @@ public class NetarchiveSolrClient {
         solrQuery.set("facet.limit", "500"); // 500 is higher than number of different years
 
         solrQuery.add("fq","content_type_norm:html"); // only html pages
-        solrQuery.add("fq",NO_REVISIT_FILTER); // do not include record_type:revisit
+        solrQuery.add("fq", SolrUtils.NO_REVISIT_FILTER); // do not include record_type:revisit
         setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
 
@@ -1072,8 +1068,8 @@ public class NetarchiveSolrClient {
         solrQuery.set("group.field", "domain");
         solrQuery.set("group.size", "10");
         solrQuery.set("group.sort", "abs(sub(ms(" + timeStamp + "), crawl_date)) asc");
-        solrQuery.add("fl", indexDocFieldList);
-        solrQuery.setFilterQueries(NO_REVISIT_FILTER); // No binary for revists.
+        solrQuery.add("fl", SolrUtils.indexDocFieldList);
+        solrQuery.setFilterQueries(SolrUtils.NO_REVISIT_FILTER); // No binary for revists.
         setSolrParams(solrQuery);
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
         SolrDocumentList docs = groupsToDoc(rsp);
@@ -1098,7 +1094,7 @@ public class NetarchiveSolrClient {
         solrQuery.set("f.crawl_year.facet.sort", "index"); // Sort by year and not count.
 
         if (!revisits) {
-            solrQuery.add("fq",NO_REVISIT_FILTER); // do not include record_type:revisit
+            solrQuery.add("fq", SolrUtils.NO_REVISIT_FILTER); // do not include record_type:revisit
         }
         if (fq != null) {
             for (String filter : fq) {
@@ -1150,7 +1146,7 @@ public class NetarchiveSolrClient {
 
 
         if (!revisits){
-            solrQuery.set("fq",NO_REVISIT_FILTER); // do not include record_type:revisit
+            solrQuery.set("fq", SolrUtils.NO_REVISIT_FILTER); // do not include record_type:revisit
         }
         if ( fq != null) {
             for (String filter : fq) {
@@ -1205,7 +1201,7 @@ public class NetarchiveSolrClient {
         }
 
         if (!revisits) {
-            solrQuery.set("fq", NO_REVISIT_FILTER); // do not include record_type:revisit
+            solrQuery.set("fq", SolrUtils.NO_REVISIT_FILTER); // do not include record_type:revisit
         }
         if (fq != null) {
             for (String filter : fq) {

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -191,7 +191,7 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
    */
   public static Stream<SolrGenericStreaming> multiQuery(SRequest baseRequest, Stream<String> queries, int batchSize) {
     return CollectionUtils.splitToLists(queries, batchSize).
-            map(batch -> String.join(" OR ", batch)). // 1 big OR query
+            map(batch -> "(" + String.join(") OR (", batch) + ")"). // 1 big OR query
             map(query -> baseRequest.deepCopy().query(query)).
             map(SolrGenericStreaming::create);
   }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -32,6 +32,7 @@ import static org.apache.commons.lang3.StringUtils.join;
 // TODO: Add support for redirects; needs to work with expandResources
 // TODO: Add support for revisits; needs (W)ARC lookup and needs to work with expandResources
 // TODO: Add optional graph traversal of JavaScript & CSS-includes with expandResources
+// TODO: Avoid extra paging request by looking at numFound and counting received documents
 
 /**
  * Cursormark based chunking search client allowing for arbitrary sized result sets.

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -337,7 +337,41 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
   }
 
   /**
+   * Stream the Solr response one document list at a time.
+   * @return a stream of lists of SolrDocuments.
+   */
+  public Stream<SolrDocumentList> streamList() {
+    return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iteratorList(), 0), false);
+  }
+
+  /**
+   * @return an iterator of SolrDocumentLists.
+   */
+  public Iterator<SolrDocumentList> iteratorList() {
+    return new Iterator<SolrDocumentList>() {
+      @Override
+      public boolean hasNext() {
+        return !hasFinished();
+      }
+
+      @Override
+      public SolrDocumentList next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException("No more elements");
+        }
+        try {
+          return nextDocuments();
+        } catch (Exception e) {
+          throw new RuntimeException("Exception requesting next document list", e);
+        }
+      }
+    };
+
+  }
+
+  /**
    * @return at least 1 and at most {@link SRequest#pageSize} documents or null if there are no more documents.
+   *         Call {@link #hasFinished()} to see if more document lists are available.
    * @throws SolrServerException if Solr could not handle a request for new documents.
    * @throws IOException if general communication with Solr failed.
    */

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -247,6 +247,9 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
       throw new IllegalArgumentException("group==true is not compatible with cursorMark paging");
     }
 
+    // Properties defined parameters
+    SolrUtils.setSolrParams(solrQuery);
+
     // Set default values if not already set
     solrQuery.set(CommonParams.FL,
                   solrQuery.get(CommonParams.FL, "source_file_path,source_file_offset"));

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/CollectionUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/CollectionUtils.java
@@ -15,17 +15,114 @@
 package dk.kb.netarchivesuite.solrwayback.util;
 
 import com.google.common.collect.Iterators;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterators;
+import java.util.stream.BaseStream;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class CollectionUtils {
-    private static final Logger log = LoggerFactory.getLogger(CollectionUtils.class);
+
+    /**
+     * Interleave the given Streams, passing 1 element from each non-depleted stream then starting over until there
+     * are no more elements in any stream. This is equivalent to calling {@link #interleave(List, List)} with a list
+     * of ratios where each ratio is 1.
+     *
+     * {code interleave(Stream.of("a", "b", "c", "d", "e"), Stream.of("1", "2", "3"))} becomes
+     * {@code "a", "1", "b", "2", "c", "3", "d", "e"}
+     * @param streams content from multiple sources that should be interleaved.
+     * @return a stream with all the elements from the given streams, interleaved 1 element at a time.
+     */
+    @SafeVarargs
+    public static <T> Stream<T> interleave(Stream<T>... streams) {
+        return interleave(Arrays.asList(streams), null);
+    }
+
+    /**
+     * Interleave the given list of Streams with the given ratio. The ratios define how many elements to deliver from
+     * the current stream before switching to the next stream. When the last stream has delivered its ratio, the process
+     * starts over with the first stream in the list. When a stream is depleted it is ignored.
+     *
+     * {code interleave(Arrays.asList(Stream.of("a", "b", "c", "d", "e"), Stream.of("1", "2", "3")), Arrays.asList(2, 1))}
+     * becomes {@code "a", "b", "1", "c", "d", "2", "e", "3}
+     * @param streams content from multiple sources that should be interleaved.
+     * @param ratios the interleaving ratios. If null, a list is created where each entry is {@code 1}.
+     * @return a stream with all the elements from the given streams, interleaved as defined by the ratios.
+     */
+    public static <T> Stream<T> interleave(List<Stream<T>> streams, List<Integer> ratios) {
+        List<Iterator<T>> iterators = streams.stream().
+                map(BaseStream::iterator).
+                collect(Collectors.toList());
+        return StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(interleaveIterators(iterators, ratios), 0),
+                false);
+    }
+
+    /**
+     * Interleave the given list of Iterators with the given ratio. The ratios define how many elements to deliver from
+     * the current stream before switching to the next iterator. When the last iterator has delivered its ratio, the
+     * process starts over with the first iterator in the list. When an iterator is depleted it is ignored.
+     *
+     * {code interleave(Arrays.asList(("a", "b", "c", "d", "e").iterator(), ("1", "2", "3").iterator()), List.of(2, 1))}
+     * becomes {@code "a", "b", "1", "c", "d", "2", "e", "3}
+     * @param iterators content from multiple sources that should be interleaved.
+     * @param ratios the interleaving ratios. If null, a list is created where each entry is {@code 1}.
+     * @return an iterator with all the elements from the given iterators, interleaved as defined by the ratios.
+     */
+    public static <T> Iterator<T> interleaveIterators(List<Iterator<T>> iterators, List<Integer> ratios) {
+        // Validate ratios
+        if (ratios == null) {
+            ratios = new ArrayList<>(iterators.size());
+            for (int i = 0 ; i < iterators.size() ; i++) {
+                ratios.add(1);
+            }
+        }
+        ratios.forEach(r -> { if (r < 1) {
+            throw new IllegalArgumentException("One ratio was " + r + ". All ratios must be >= 1");
+        }});
+        if (iterators.size() != ratios.size()) {
+            throw new IllegalArgumentException(
+                    "Got " + iterators.size() + " streams and " + ratios.size() + " ratios. The counts should be equal");
+        }
+        if (iterators.isEmpty()) {
+            return Collections.emptyIterator();
+        }
+        final List<Integer> fRatios = ratios;
+
+        // Construct interleaving iterator
+        return new Iterator<T>() {
+            int iIndex = 0;
+            int delivered = 0;
+
+            @Override
+            public boolean hasNext() {
+                return iterators.stream().anyMatch(Iterator::hasNext);
+            }
+
+            @Override
+            public T next() {
+                if (!hasNext()) {
+                    throw new IllegalStateException("next() called when hasNext() == false. No more elements");
+                }
+                while (true) {
+                    if (delivered++ == fRatios.get(iIndex) || !iterators.get(iIndex).hasNext()) {
+                        delivered = 0;
+                        if (++iIndex == iterators.size()) {
+                            iIndex = 0;
+                        }
+                        continue;
+                    }
+                    return iterators.get(iIndex).next();
+                }
+            }
+        };
+    }
 
     // splitTo* copy-pasted unchanged from https://github.com/kb-dk/kb-util/
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/DateUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/DateUtils.java
@@ -1,6 +1,7 @@
 package dk.kb.netarchivesuite.solrwayback.util;
 
 import java.text.DateFormat;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
@@ -11,7 +12,15 @@ import org.slf4j.LoggerFactory;
 public class DateUtils {
 
   private static final Logger log = LoggerFactory.getLogger(DateUtils .class);
-  
+
+  // dateSecond and dateMillisecond are used by solrTimestampToJavaDate
+  private static final DateFormat dateSecond = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+  private static final DateFormat dateMillisecond = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSS'Z'");
+  static {
+    dateSecond.setTimeZone(TimeZone.getTimeZone("UTC"));
+    dateMillisecond.setTimeZone(TimeZone.getTimeZone("UTC"));
+  }
+
    public static String  convertWaybackDate2SolrDate(String waybackdate) throws Exception {
     
     SimpleDateFormat dForm = null;    
@@ -67,4 +76,21 @@ public class DateUtils {
 	    throw new RuntimeException("Error parsing UTC date:"+solrDate,e);	
       }
   }
+
+    /**
+     * Converts {@code 2022-10-24T09:53:00Z} or {@code 2022-10-24T09:53:00.000Z} to Java Date.
+     * @return Java Date from Solr ISO-Date.
+     */
+  public static synchronized Date solrTimestampToJavaDate(String solrDate) {
+      try {
+          return dateMillisecond.parse(solrDate);
+      } catch (ParseException e) {
+          try {
+              return dateSecond.parse(solrDate);
+          } catch (ParseException ex) {
+              throw new RuntimeException("Unable to parse '" + solrDate + "' as a Solr ISO timestamp");
+          }
+      }
+  }
+
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/Processing.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/Processing.java
@@ -1,0 +1,89 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Helper methods for doing processing, i.e. threading of workloads.
+ */
+public class Processing {
+    private static final Logger log = LoggerFactory.getLogger(Processing.class);
+    // TODO: Make the number fo threads configurable
+    public static final int THREADS = 20;
+
+    // Shared between all callers, so this also acts as a limiter towards Solr/WARC-resolving
+    private static ExecutorService executorService = Executors.newFixedThreadPool(THREADS);
+
+    /**
+     * Threaded batch job execution.
+     *
+     * Packs the given jobs in batches of maximum {@link #THREADS} entries,
+     * runs the batches using a threaded executor,
+     * collects the results of the batch
+     * passes the results as a Stream.
+     *
+     * Note that a shared {@link #executorService} is used with a maximum of {@link #THREADS} threads.
+     * @param jobs the jobs to batch and execute in parallel.
+     * @return the result of the jobs, in the same order as the jobs.
+     */
+    public static <T> Stream<T> batch(Stream<Callable<T>> jobs) {
+        return batch(jobs, THREADS);
+    }
+
+    /**
+     * Threaded batch job execution.
+     *
+     * Packs the given jobs in batches of maximum batchSize entries,
+     * runs the batches using a threaded executor,
+     * collects the results of the batch
+     * passes the results as a Stream.
+     *
+     * Note that a shared {@link #executorService} is used with a maximum of {@link #THREADS} threads.
+     * @param jobs the jobs to batch and execute in parallel.
+     * @param batchSize if the batchSize exceeds {@link #THREADS}, the excess jobs will be queued by
+     *                  {@link #executorService}. Having a large batchSize improves throughput at the cost of higher
+     *                  latency, where latency in this case means the time before the returned Stream can deliver
+     *                  job results. Conversely a low batchSize wil result in a poorer throughput and lower latency.
+     * @return the result of the jobs, in the same order as the jobs.
+     */
+    public static <T> Stream<T> batch(Stream<Callable<T>> jobs, int batchSize) {
+        return CollectionUtils.splitToLists(jobs, batchSize).
+                flatMap(batch -> {
+                    try {
+                        return executorService.invokeAll(batch).stream();
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException("Iterrupted while waiting for batch processing", e);
+                    }
+                }).
+                map(future -> {
+                    try {
+                        return future.get();
+                    } catch (Exception e) {
+                        throw new RuntimeException("Exception while getting result from batch Future", e);
+                    }
+                });
+    }
+
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -7,8 +7,8 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 
-public class SolrQueryUtils {
-    public static final Logger log = LoggerFactory.getLogger(SolrQueryUtils.class);
+public class SolrUtils {
+    public static final Logger log = LoggerFactory.getLogger(SolrUtils.class);
 
     /**
      * Normalizes a given list of urls and makes a Solr search string from the result.

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -63,7 +63,7 @@ public class SolrUtils {
      */
     public static String createQueryStringForUrl(String url) {
         String canonicalizedUrl = Normalisation.canonicaliseURL(url);
-        return "url_norm:\"" + canonicalizedUrl + "\"";
+        return "url_norm:" + createPhrase(canonicalizedUrl);
     }
 
     /**
@@ -89,6 +89,7 @@ public class SolrUtils {
 
     /**
      * Convert the given {@link SolrDocument} to a {@link IndexDoc}.
+     * See {@link #indexDocFieldList} for Solr fields for the IndexDoc.
      *
      * Note that {@link IndexDoc}s only holds a subset of all possible fields from {@link SolrDocument}.
      * @param doc a document from a Solr search.
@@ -154,6 +155,7 @@ public class SolrUtils {
 
     /**
      * Convert the given {@link SolrDocument} to a {@link IndexDocShort}.
+     * See {@link #indexDocFieldListShort} for Solr fields for the IndexDocShort.
      *
      * Note that {@link IndexDocShort}s only holds a tiny subset of all possible fields from {@link SolrDocument}:
      * {@code url}, {@code url_norm}, {@code source_file_path}m {@code source_file_offset} and {@code crawl_date}.
@@ -225,5 +227,15 @@ public class SolrUtils {
         for (String key : SOLR_PARAMS_MAP.keySet()) {
             solrQuery.set(key,SOLR_PARAMS_MAP.get(key));
         }
+    }
+
+    /**
+     * Quotes the given phrase and escapes characters that needs escaping (backslash and quote).
+     * {@code foo \bar "zoo} becomes {@code "foo \\bar \"zoo"}.
+     * @param phrase any phrase.
+     * @return the phrase quoted and escaped.
+     */
+    public static String createPhrase(String phrase) {
+        return "\"" + phrase.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
     }
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -2,6 +2,7 @@ package dk.kb.netarchivesuite.solrwayback.util;
 
 import dk.kb.netarchivesuite.solrwayback.normalise.Normalisation;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
+import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntryDescriptor;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDocShort;
 import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrClient;
@@ -166,5 +167,33 @@ public class SolrUtils {
         Date date = (Date) doc.get("crawl_date");
         indexDoc.setCrawlDate(DateUtils.getSolrDate(date));
         return indexDoc;
+    }
+
+    /**
+     * Convert the given {@link SolrDocument} to an {@link ArcEntryDescriptor}.
+     * @param solrDoc a Solr document with {@code url}, {@code url_norm}, {@code source_file_path},
+     * {@code source_file_offset}, {@code hash} and {@code content_type} defined.
+     * @return an ARC entry descriptor.
+     */
+    public static ArcEntryDescriptor solrDocument2ArcEntryDescriptor(SolrDocument solrDoc) {
+        return indexDoc2ArcEntryDescriptor(solrDocument2IndexDoc(solrDoc));
+    }
+
+    /**
+     * Convert the given {@link IndexDoc} to an {@link ArcEntryDescriptor}.
+     * @param indexDoc a document with {@link IndexDoc#getUrl()}, {@link IndexDoc#getUrl_norm()},
+     * {@link IndexDoc#getSource_file_path()}, {@link IndexDoc#getOffset()}, {@link IndexDoc#getHash()} and
+     * {@link IndexDoc#getMimeType()} returning usable values.
+     * @return an ARC entry descriptor.
+     */
+    public static ArcEntryDescriptor indexDoc2ArcEntryDescriptor(IndexDoc indexDoc) {
+        ArcEntryDescriptor desc = new ArcEntryDescriptor();
+        desc.setUrl(indexDoc.getUrl());
+        desc.setUrl_norm(indexDoc.getUrl_norm());
+        desc.setSource_file_path(indexDoc.getSource_file_path());
+        desc.setHash(indexDoc.getHash());
+        desc.setOffset(indexDoc.getOffset());
+        desc.setContent_type(indexDoc.getMimeType());
+        return desc;
     }
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -210,5 +211,19 @@ public class SolrUtils {
               peek(entry -> entry.setValue(Arrays.copyOf(entry.getValue(), entry.getValue().length))).
               forEach(entry -> qc.set(entry.getKey(), entry.getValue()));
       return qc;
+    }
+
+    /**
+     * Sets properties-defined parameters.
+     * This should be called with ALL SolrQuery instances before issuing the query.
+     *
+     * The semantics of whether it should be called before or after setting method specific parameters is unclear.
+     * @param solrQuery a Solr query
+     */
+    public static void setSolrParams(SolrQuery solrQuery) {
+        HashMap<String, String> SOLR_PARAMS_MAP = PropertiesLoader.SOLR_PARAMS_MAP;
+        for (String key : SOLR_PARAMS_MAP.keySet()) {
+            solrQuery.set(key,SOLR_PARAMS_MAP.get(key));
+        }
     }
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -2,10 +2,18 @@ package dk.kb.netarchivesuite.solrwayback.util;
 
 import dk.kb.netarchivesuite.solrwayback.normalise.Normalisation;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
+import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
+import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDocShort;
+import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrClient;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrDocumentList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class SolrUtils {
     public static final Logger log = LoggerFactory.getLogger(SolrUtils.class);
@@ -59,5 +67,101 @@ public class SolrUtils {
     public static String createTwitterSearchURL(String searchString) {
         String searchParams = " AND type%3A\"Twitter Tweet\"";
         return PropertiesLoader.WAYBACK_BASEURL + "search?query=" + searchString + searchParams;
+    }
+
+    /**
+     * Convert the given list of {@link SolrDocument}s to a list of {@link IndexDoc}s.
+     * @param docs 0 or more SolrDocuments.
+     * @return a list of {@link IndexDoc}s constructed from the given {@link SolrDocument}s.
+     */
+    public static ArrayList<IndexDoc> solrDocList2IndexDoc(SolrDocumentList docs) {
+        return docs.stream().
+                map(SolrUtils::solrDocument2IndexDoc).
+                collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * Convert the given {@link SolrDocument} to a {@link IndexDoc}.
+     *
+     * Note that {@link IndexDoc}s only holds a subset of all possible fields from {@link SolrDocument}.
+     * @param doc a document from a Solr search.
+     * @return an index document.
+     */
+    public static IndexDoc solrDocument2IndexDoc(SolrDocument doc) {
+        IndexDoc indexDoc = new IndexDoc();
+        indexDoc.setScore(Double.valueOf((float) doc.getFieldValue("score")));
+        indexDoc.setId((String) doc.get("id"));
+        indexDoc.setTitle((String) doc.get("title"));
+        indexDoc.setSource_file_path((String) doc.get("source_file_path"));
+        indexDoc.setResourceName((String) doc.get("resourcename"));
+        indexDoc.setDomain((String) doc.get("domain"));
+        indexDoc.setUrl((String) doc.get("url"));
+        indexDoc.setUrl_norm((String) doc.get("url_norm"));
+        indexDoc.setOffset(NetarchiveSolrClient.getOffset(doc));
+        // Cope with some minor schema variations:
+        if ( doc.get("content_type") instanceof ArrayList) {
+            ArrayList<String> types = (ArrayList<String>) doc.get("content_type");
+            indexDoc.setContentType(types.get(0));
+        } else {
+            indexDoc.setContentType((String) doc.get("content_type"));
+        }
+        indexDoc.setContentTypeNorm((String) doc.get("content_type_norm"));
+        indexDoc.setContentEncoding((String) doc.get("content_encoding"));
+        indexDoc.setType((String) doc.get("type"));
+        indexDoc.setExifLocation((String) doc.get("exif_location"));
+        indexDoc.setRedirectToNorm((String) doc.get("redirect_to_norm"));
+        indexDoc.setContent_type_full((String) doc.get("content_type_full"));
+        Date dateModified = (Date) doc.get("last_modified");
+        if (dateModified != null) {
+            indexDoc.setLastModifiedLong(dateModified.getTime());
+        }
+
+        Object statusCodeObj = doc.get("status_code");
+        if (statusCodeObj != null) {
+            indexDoc.setStatusCode((Integer) statusCodeObj);
+        }
+        String hash = (String) doc.get("hash");
+        indexDoc.setHash((String) hash);
+
+        Date date = (Date) doc.get("crawl_date");
+        indexDoc.setCrawlDateLong(date.getTime());
+        indexDoc.setCrawlDate(DateUtils.getSolrDate(date));
+
+        // Cope with some minor schema variations:
+        if ( doc.get("content_type") instanceof ArrayList) {
+            ArrayList<String> types = (ArrayList<String>) doc.get("content_type");
+            indexDoc.setMimeType(types.get(0));
+        } else {
+            indexDoc.setMimeType((String) doc.get("content_type"));
+        }
+
+        indexDoc.setOffset(NetarchiveSolrClient.getOffset(doc));
+
+        Object o = doc.getFieldValue("links_images");
+        if (o != null) {
+            indexDoc.setImageUrls((ArrayList<String>) o);
+        }
+
+        return indexDoc;
+    }
+
+    /**
+     * Convert the given {@link SolrDocument} to a {@link IndexDocShort}.
+     *
+     * Note that {@link IndexDocShort}s only holds a tiny subset of all possible fields from {@link SolrDocument}:
+     * {@code url}, {@code url_norm}, {@code source_file_path}m {@code source_file_offset} and {@code crawl_date}.
+     * @param doc a document from a Solr search.
+     * @return a short index document.
+     */
+    public static IndexDocShort solrDocument2IndexDocShort(SolrDocument doc) {
+        IndexDocShort indexDoc = new IndexDocShort();
+
+        indexDoc.setUrl((String) doc.get("url"));
+        indexDoc.setUrl_norm((String) doc.get("url_norm"));
+        indexDoc.setOffset(NetarchiveSolrClient.getOffset(doc));
+        indexDoc.setSource_file_path((String) doc.get("source_file_path"));
+        Date date = (Date) doc.get("crawl_date");
+        indexDoc.setCrawlDate(DateUtils.getSolrDate(date));
+        return indexDoc;
     }
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -24,6 +24,7 @@ public class SolrUtils {
     public static String NO_REVISIT_FILTER ="record_type:response OR record_type:arc OR record_type:resource";
     public static String indexDocFieldList = "id,score,title,url,url_norm,links_images,source_file_path,source_file,source_file_offset,domain,resourcename,content_type,content_type_full,content_type_norm,hash,type,crawl_date,content_encoding,exif_location,status_code,last_modified,redirect_to_norm";
     public static String indexDocFieldListShort = "url,url_norm,source_file_path,source_file,source_file_offset,crawl_date";
+    public static String arcEntryDescriptorFieldList = "url,url_norm,source_file_path,source_file_offset,hash,content_type";
 
     /**
      * Normalizes a given list of urls and makes a Solr search string from the result.

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -6,12 +6,14 @@ import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntryDescriptor;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDocShort;
 import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -195,5 +197,18 @@ public class SolrUtils {
         desc.setOffset(indexDoc.getOffset());
         desc.setContent_type(indexDoc.getMimeType());
         return desc;
+    }
+
+    /**
+     * Makes an independent copy of the given SolrQuery by deep-copying the {@code String[]} values.
+     * @param solrQuery any Solr query.
+     * @return an independent copy of the given Solr query.
+     */
+    public static SolrQuery deepCopy(SolrQuery solrQuery) {
+      SolrQuery qc = new SolrQuery();
+      solrQuery.getMap().entrySet().stream().
+              peek(entry -> entry.setValue(Arrays.copyOf(entry.getValue(), entry.getValue().length))).
+              forEach(entry -> qc.set(entry.getKey(), entry.getValue()));
+      return qc;
     }
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -239,4 +239,31 @@ public class SolrUtils {
     public static String createPhrase(String phrase) {
         return "\"" + phrase.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
     }
+
+    /**
+     * Construct a new array from the given strArray and the additions.
+     * The result is guaranteed to be independent from the given strArray.
+     * @param strArray  any String array.
+     * @param additions 0 or more additions to the strArray.
+     * @return a concatenation of strArray and additions.
+     */
+    public static String[] extend(String[] strArray, String... additions) {
+        String[] extended = new String[strArray.length + additions.length];
+        System.arraycopy(strArray, 0, extended, 0, strArray.length);
+        System.arraycopy(additions, 0, extended, strArray.length, additions.length);
+        return extended;
+    }
+
+    /**
+     * Construct a String array from the given str and the additions.
+     * @param str any String.
+     * @param additions 0 or more additions to the str.
+     * @return a concatenation of str and additions.
+     */
+    public static String[] extend(String str, String... additions) {
+        String[] extended = new String[1 + additions.length];
+        extended[0] = str;
+        System.arraycopy(additions, 0, extended, 1, additions.length);
+        return extended;
+    }
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -17,6 +17,9 @@ import java.util.stream.Collectors;
 
 public class SolrUtils {
     public static final Logger log = LoggerFactory.getLogger(SolrUtils.class);
+    public static String NO_REVISIT_FILTER ="record_type:response OR record_type:arc OR record_type:resource";
+    public static String indexDocFieldList = "id,score,title,url,url_norm,links_images,source_file_path,source_file,source_file_offset,domain,resourcename,content_type,content_type_full,content_type_norm,hash,type,crawl_date,content_encoding,exif_location,status_code,last_modified,redirect_to_norm";
+    public static String indexDocFieldListShort = "url,url_norm,source_file_path,source_file,source_file_offset,crawl_date";
 
     /**
      * Normalizes a given list of urls and makes a Solr search string from the result.

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreamingTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreamingTest.java
@@ -15,6 +15,8 @@
 package dk.kb.netarchivesuite.solrwayback.solr;
 
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
+import dk.kb.netarchivesuite.solrwayback.util.DateUtils;
+import dk.kb.netarchivesuite.solrwayback.util.SolrUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
@@ -29,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -158,9 +161,9 @@ public class SolrGenericStreamingTest {
                 collect(Collectors.toList());
         assertTrue("Multiple results expected",
                      docs.size() > 1);
-        Set<Object> dates = new HashSet<>();
+        Set<Date> dates = new HashSet<>();
         for (SolrDocument doc: docs) {
-            dates.add(doc.get("crawl_date"));
+            dates.add((Date) doc.get("crawl_date"));
         }
         assertTrue("There should be more than 1 unique data in the time proximity result set",
                    dates.size() > 1);
@@ -282,7 +285,7 @@ public class SolrGenericStreamingTest {
         document.addField("source_file_path", "some.warc_" + id);
         document.addField("links", Arrays.asList("http://example.com/everywhere", "http://example.com/mod10_" + id%10));
         document.addField("status_code", "200");
-        document.setField("crawl_date", CRAWL_TIMES[r.nextInt(CRAWL_TIMES.length)]);
+        document.setField("crawl_date", DateUtils.solrTimestampToJavaDate(CRAWL_TIMES[r.nextInt(CRAWL_TIMES.length)]));
         embeddedServer.add(document);
     }
 

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/util/CollectionUtilsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/util/CollectionUtilsTest.java
@@ -1,0 +1,50 @@
+package dk.kb.netarchivesuite.solrwayback.util;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+public class CollectionUtilsTest {
+
+    @Test
+    public void interleave() {
+        List<String> interleaved = CollectionUtils.interleave(
+                Stream.of("a", "b", "c", "d", "e"), 
+                Stream.of("1", "2", "3")).collect(Collectors.toList());
+        assertEquals("Interleaving with default ratios should yield the expected result",
+                     "[a, 1, b, 2, c, 3, d, e]", interleaved.toString());
+    }
+
+    @Test
+    public void interleaveRatio() {
+        List<String> interleaved = CollectionUtils.interleave(
+                Arrays.asList(
+                        Stream.of("a", "b", "c", "d", "e"),
+                        Stream.of("1", "2", "3")
+                ),
+                Arrays.asList(2, 1)
+        ).collect(Collectors.toList());
+        assertEquals("Interleaving with default ratios should yield the expected result",
+                     "[a, b, 1, c, d, 2, e, 3]", interleaved.toString());
+    }
+}

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/util/ProcessingTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/util/ProcessingTest.java
@@ -1,0 +1,46 @@
+package dk.kb.netarchivesuite.solrwayback.util;
+
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+public class ProcessingTest {
+
+    @Test
+    public void testBatching() {
+        List<Callable<Integer>> callables = new ArrayList<>();
+        for (int i = 0 ; i < 100 ; i++) {
+            final int value = i;
+            callables.add(() -> value);
+        }
+        List<Integer> results = Processing.batch(callables.stream()).collect(Collectors.toList());
+
+        assertEquals("The number of result should match the number of callables",
+                     callables.size(), results.size());
+
+        for (int i = 0 ; i < 100 ; i++) {
+            assertEquals("Result #" + i + " should be as expected",
+                         Integer.valueOf(i), results.get((i)));
+        }
+
+    }
+}

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/util/ProcessingTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/util/ProcessingTest.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 
@@ -26,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 public class ProcessingTest {
 
     @Test
-    public void testBatching() {
+    public void testBasicBatching() {
         List<Callable<Integer>> callables = new ArrayList<>();
         for (int i = 0 ; i < 100 ; i++) {
             final int value = i;
@@ -41,6 +42,15 @@ public class ProcessingTest {
             assertEquals("Result #" + i + " should be as expected",
                          Integer.valueOf(i), results.get((i)));
         }
+    }
 
+    @Test
+    public void testInfiniteInputStream() {
+        Stream<Callable<String>> callables = Stream.generate(() -> () -> "a"); // Infinite
+        long processed = Processing.batch(callables).
+                limit(5000).
+                count();
+        assertEquals("The number of processed jobs should match the limit",
+                     5000, processed);
     }
 }


### PR DESCRIPTION
This pull request introduces a generic mechanism for the problem "Given a (large) list of queries, return all matches while performing deduplication".

This pull request uses the new mechanism to simplify some of the methods in `NetarchiveSolrClient`.

Note: Refactoring did funny things to `Twitter2HTML.java`. Better check that Twitter playback works as intended!