### PR TITLE
Refine time frame and time scale on "Visualization of search result by domain"

### DIFF
--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -297,7 +297,8 @@ margin: 1em 0 0 0;
 .exportContent .downloadButton, 
 .wordcloudButton, 
 .domainContentContainer .domainStatsButton,
-.linkGraphContainer .linkGraphButton  {
+.linkGraphContainer .linkGraphButton,
+.searchVisualizationContainer .searchVisualizationButton {
   float:right;
   border:2px solid var(--secondary-bg-color);
   border-radius: 0;
@@ -316,7 +317,8 @@ margin: 1em 0 0 0;
 .exportContent .downloadButton:hover, 
 .wordcloudButton:hover, 
 .domainContentContainer .domainStatsButton:hover,
-.linkGraphContainer .linkGraphButton:hover {
+.linkGraphContainer .linkGraphButton:hover,
+.searchVisualizationContainer .searchVisualizationButton:hover {
   border:2px solid var(--secondary-bg-color);
   color:white;
   background-color:var(--secondary-bg-color);
@@ -1150,6 +1152,37 @@ margin-left:40px;
 .searchVisualizationHeadline span {
   font-weight: bold;
   color:var(--main-highlight-color);
+}
+
+.searchVisualizationSettings, .timePeriodRefinerSettings {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.searchVisualizationSettings {
+  margin-top:15px;
+}
+
+.timePeriodRefinerContainer .timePeriodRefinerPeriodContainer,
+.timePeriodRefinerContainer .timePeriodRefinerTimeScaleContainer,
+.searchVisualizationContainer .generateButtonContainer {
+  box-sizing: border-box;
+  height:40px;
+}
+
+.timePeriodRefinerContainer .timePeriodRefinerTimeScaleContainer,
+.searchVisualizationSettings .generateButtonContainer {
+  padding:0 10px;
+}
+
+.timePeriodRefinerLabel {
+  margin-right: 5px;
+}
+
+.timePeriodRefinerPeriodContainer input,
+.timePeriodRefinerTimeScaleContainer select {
+  width:150px;
+  margin: 0 5px;
 }
 
 .modalContainer .closeButton, .toolboxCloseButton {

--- a/src/js/src/assets/styles/search.scss
+++ b/src/js/src/assets/styles/search.scss
@@ -535,7 +535,9 @@ color:var(--secondary-text-color);
   overflow:hidden;
 }
 
-.wordcloudContainer .wordcloudExplanation input, .domainContentContainer input, .linkGraphContainer input, .searchTypeContainer input{
+.wordcloudContainer .wordcloudExplanation input, .domainContentContainer input,
+.linkGraphContainer input, .searchTypeContainer input,
+.timePeriodRefinerPeriodContainer input,.timePeriodRefinerTimeScaleContainer select {
   width:100%;
   border-radius: 0px;
 	border: 1px solid var(--seethrough-black);

--- a/src/js/src/components/TimePeriodRefiner.vue
+++ b/src/js/src/components/TimePeriodRefiner.vue
@@ -49,6 +49,11 @@ export default {
     endDateInput:(new Date().getUTCFullYear() + 1) + '-01-01',
     timeScaleInput:'YEAR'
   }),
+  mounted() {
+    this.updateStartDate()
+    this.updateEndDate()
+    this.updateTimeScale()
+  },
   methods: {
     updateStartDate(){
       this.$emit('startdate', this.startDateInput)

--- a/src/js/src/components/TimePeriodRefiner.vue
+++ b/src/js/src/components/TimePeriodRefiner.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="timePeriodRefinerSettings">
+    <div class="timePeriodRefinerPeriodContainer contain">
+      <label class="timePeriodRefinerLabel">Refine:</label>
+      <label class="timePeriodRefinerLabel">Time frame:</label>
+      between
+      <input v-model="startDateInput"
+             placeholder="YYYY-MM-DD"
+             :class="$_checkDate(startDateInput) ? '' : 'urlNotTrue'"
+             @input="updateStartDate()">
+      and
+      <input v-model="endDateInput" 
+             placeholder="YYYY-MM-DD"
+             :class="$_checkDate(endDateInput) ? '' : 'urlNotTrue'"
+             @input="updateEndDate()">
+    </div>
+    <div id="timeScaleDropdown" class="timePeriodRefinerTimeScaleContainer">
+      <label class="timePeriodRefinerLabel">Time scale:</label>
+      <select id="timeScaleSelect"
+              v-model="timeScaleInput"
+              @change="updateTimeScale()">
+        <option value="YEAR">
+          Year
+        </option>
+        <option value="MONTH">
+          Month
+        </option>
+        <option value="WEEK">
+          Week
+        </option>
+        <option value="DAY">
+          Day
+        </option>
+      </select>
+    </div>
+  </div>
+</template>
+
+<script>
+
+import StringManipulationUtils from './../mixins/StringManipulationUtils'
+import configs from './../configs'
+
+export default {
+  mixins: [StringManipulationUtils],
+  emits: ['startdate', 'enddate', 'timescale'],
+  data: () => ({
+    startDateInput:configs.visualizations.ngram.startYear + '-01-01',
+    endDateInput:(new Date().getUTCFullYear() + 1) + '-01-01',
+    timeScaleInput:'YEAR'
+  }),
+  methods: {
+    updateStartDate(){
+      this.$emit('startdate', this.startDateInput)
+    },
+    updateEndDate(){
+      this.$emit('enddate', this.endDateInput)
+    },
+    updateTimeScale(){
+      this.$emit('timescale', this.timeScaleInput)
+    }
+  }
+}
+
+</script>

--- a/src/js/src/components/modalComponents/SearchVisualization.vue
+++ b/src/js/src/components/modalComponents/SearchVisualization.vue
@@ -8,6 +8,16 @@
       <p v-if="searchAppliedFacets.length > 0">
         filters: <span>{{ searchAppliedFacets.join('') }}</span>
       </p>
+      <div class="searchVisualizationSettings">
+        <time-period-refiner @startdate="(sdate) => startDate = sdate"
+                             @enddate="(edate) => endDate = edate" 
+                             @timescale="(ts) => timeScale = ts" />
+        <div class="generateButtonContainer contain">
+          <button class="searchVisualizationButton" @click.prevent="loadVisualisation()">
+            Generate
+          </button>
+        </div>
+      </div>
     </div>
     <div v-show="!loading" key="d3-viz" class="visualized" />
     <div v-if="loading" key="spinner-viz" class="spinner" />
@@ -19,11 +29,18 @@
 import { requestService } from '../../services/RequestService'
 import { mapState } from 'vuex'
 import Visualization from './Visualization'
+import TimePeriodRefiner from './../TimePeriodRefiner.vue'
 
 export default {
   name: 'SearchVisualization',
+  components: {
+    TimePeriodRefiner
+  },
   data: () => ({
-    loading:false
+    loading:false,
+    startDate:'',
+    endDate:'',
+    timeScale:''
   }),
   computed: {
     ...mapState({
@@ -40,9 +57,17 @@ export default {
   }, */
   mounted () {
     this.loading = true
-    Visualization.createVisualization(this.query, this.searchAppliedFacets, this.solrSettings).then(() =>{
+    Visualization.createVisualization(this.query, this.searchAppliedFacets, this.solrSettings, null, null, null).then(() =>{
     this.loading = false
     })
+  },
+  methods: {
+    loadVisualisation() {
+      this.loading = true
+      Visualization.createVisualization(this.query, this.searchAppliedFacets, this.solrSettings, this.startDate, this.endDate, this.timeScale) .then(() =>{
+      this.loading = false
+      })
+    }
   }
 }
 

--- a/src/js/src/components/modalComponents/Visualization.js
+++ b/src/js/src/components/modalComponents/Visualization.js
@@ -1,12 +1,16 @@
 import * as d3 from 'd3'
 
 export default {
-   async createVisualization(query, facets, options) {
+   async createVisualization(query, facets, options, startDate, endDate, timeScale) {
     
     let optionString = '&start=' + options.offset + '&grouping=' + options.grouping
-    let dataUrl =  `services/frontend/graph/domain_result/?q=${query + facets.join('') + optionString}`
+    let settings = ''
+    if (timeScale != null && timeScale != '') {
+        settings = '&startdate=' + startDate +'&enddate='+ endDate + '&scale=' + timeScale
+    }
+    let dataUrl =  `services/frontend/graph/domain_result/?q=${query + facets.join('') + optionString + settings}`
     
-    var margin = {top: 20, right: 200, bottom: 50, left: 32},
+    var margin = {top: 20, right: 200, bottom: 70, left: 32},
     width = 1050 - margin.left - margin.right,
     height = 700 - margin.top - margin.bottom
 
@@ -67,6 +71,8 @@ export default {
     .scale(y)
     .orient('left')
     .tickFormat(d3.format('.2s'))
+
+    d3.select('svg').remove()
 
     var svg = d3.select('.visualized').append('svg')
     .attr('width', width + margin.left + margin.right)

--- a/src/js/src/mixins/StringManipulationUtils.js
+++ b/src/js/src/mixins/StringManipulationUtils.js
@@ -11,5 +11,9 @@ export default {
       // Matches at least 1 dot in the string, and no spaces. 
       return domain.match(/^[^\s]+\.[^\s]+$/)
     },
+    $_checkDate(date) {
+      // Matches format YYYY-MM-DD
+      return date.match(/^([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))$/)
+    },
   }
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -111,9 +111,9 @@ public class Facade {
         return collectionText;
     }
 
-    public static String generateDomainResultGraph(@QueryParam("q") String q, @QueryParam("fq") List<String> fq) throws Exception {
-        String jsonStr = NetarchiveSolrClient.getInstance().domainStatisticsForQuery(q, fq);
-        HashMap<Integer, List<FacetCount>> domainStatisticsForQuery = DomainStatisticsForDomainParser.parseDomainStatisticsJson(jsonStr);
+    public static String generateDomainResultGraph(String q, List<String> fq, String startdate, String enddate, String scale) throws Exception {
+        String jsonStr = NetarchiveSolrClient.getInstance().domainStatisticsForQuery(q, fq, startdate , enddate, scale);
+        HashMap<String, List<FacetCount>> domainStatisticsForQuery = DomainStatisticsForDomainParser.parseDomainStatisticsJson(jsonStr, scale == null);
         String matrix = DomainStatisticsForDomainParser.generateDomainQueryStatisticsString(domainStatisticsForQuery);
         return matrix;
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/DomainStatisticsForDomainParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/DomainStatisticsForDomainParser.java
@@ -16,8 +16,8 @@ public class DomainStatisticsForDomainParser {
 
   
   
-  public static HashMap<Integer,List<FacetCount>> parseDomainStatisticsJson(String jsonString){       
-    HashMap<Integer,List<FacetCount>> yearFacetDomainCountMap = new HashMap<Integer,List<FacetCount>>();
+  public static HashMap<String,List<FacetCount>> parseDomainStatisticsJson(String jsonString, boolean fromCrawlYear){
+    HashMap<String,List<FacetCount>> yearFacetDomainCountMap = new HashMap<String,List<FacetCount>>();
     
     
     JSONObject json = new JSONObject(jsonString);
@@ -36,7 +36,13 @@ public class DomainStatisticsForDomainParser {
     
       for (int j =0;j<yearBuckets.length();j++) {
         JSONObject pair = (   JSONObject) yearBuckets.get(j);
-        int year =  pair.getInt("val");
+        String year;
+        if (fromCrawlYear) {
+            year = Integer.toString(pair.getInt("val"));
+        } else {
+            // format : YYYY-MM-DDT00:00:00Z -> YYYY-MM-DD
+            year =  pair.getString("val").substring(0, 10);
+        }
         long count = pair.getLong("count");
        
         //All info needed now
@@ -61,12 +67,12 @@ public class DomainStatisticsForDomainParser {
    * TODO specify format
    * 
    */  
-  public static String generateDomainQueryStatisticsString(HashMap<Integer, List<FacetCount>> domainStatisticsForQuery) {      
+  public static String generateDomainQueryStatisticsString(HashMap<String, List<FacetCount>> domainStatisticsForQuery) {
       StringBuilder matrix = new StringBuilder();
       
       //Logic to create to matrix.
       TreeSet<String> allValues = new TreeSet<String>(); //will be sorted 
-      for (int year : domainStatisticsForQuery.keySet()){                
+      for (String year : domainStatisticsForQuery.keySet()){
           List<FacetCount> list = domainStatisticsForQuery.get(year);
           for ( FacetCount facetCount : list) {
              allValues.add(facetCount.getValue());                       
@@ -84,10 +90,10 @@ public class DomainStatisticsForDomainParser {
             
             
       //Iterate over years and generate each line
-      TreeSet<Integer> yearsSorted = new TreeSet<Integer>();
+      TreeSet<String> yearsSorted = new TreeSet<String>();
       yearsSorted.addAll(domainStatisticsForQuery.keySet());
       
-      for (int year : yearsSorted) {
+      for (String year : yearsSorted) {
           joiner = new StringJoiner(",");
           joiner.add(""+year);    
           

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
@@ -7,7 +7,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
@@ -24,11 +23,10 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.UriInfo;
 import javax.ws.rs.core.Response.ResponseBuilder;
+import javax.ws.rs.core.UriInfo;
 
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
-import org.apache.zookeeper.client.FourLetterWordMain;
 import org.brotli.dec.BrotliInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,8 +41,6 @@ import dk.kb.netarchivesuite.solrwayback.service.dto.HarvestDates;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ImageUrl;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
 import dk.kb.netarchivesuite.solrwayback.service.dto.PagePreview;
-import dk.kb.netarchivesuite.solrwayback.service.dto.PagePreviewYearsInfo;
-import dk.kb.netarchivesuite.solrwayback.service.dto.TimestampsForPage;
 import dk.kb.netarchivesuite.solrwayback.service.dto.UrlWrapper;
 import dk.kb.netarchivesuite.solrwayback.service.dto.WordCloudWordAndCount;
 import dk.kb.netarchivesuite.solrwayback.service.dto.graph.D3Graph;
@@ -139,9 +135,10 @@ public class SolrWaybackResourceWeb {
     @GET
     @Path("graph/domain_result")
     @Produces({ MediaType.TEXT_PLAIN})
-    public String domainResultGraph(@QueryParam("q") String q, @QueryParam("fq") List<String> fq ) throws SolrWaybackServiceException {
+    public String domainResultGraph(@QueryParam("q") String q, @QueryParam("fq") List<String> fq, @QueryParam("startdate") String startdate,
+            @QueryParam("enddate") String enddate, @QueryParam("scale") String scale) throws SolrWaybackServiceException {
      try {
-       return Facade.generateDomainResultGraph(q,fq);
+       return Facade.generateDomainResultGraph(q, fq, startdate ,enddate, scale);
       } catch (Exception e) {           
         throw handleServiceExceptions(e);
       }    


### PR DESCRIPTION
As discussed in issue #270, I have added the possibility of refining the time frame and time scale on "Visualization of search result by domain".

The first graph is the same as before (using crawl_year) but by refining the field crawl_date will be used.

For now, there is no check (except for the date format) because it seems like there is no blocking checks in the features that are in a modal window. 
For the time scale, an automatic selection according to the time frame can be added to prevent a too big range for a gap size DAY or MONTH