### PR TITLE
Alternative playback engines can  be defined based on collectionid.

### DIFF
--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -200,12 +200,12 @@
   font-size:130%;
 }
 
-.SingleEntryStandardInfo .openWaybackLink {
+.SingleEntryStandardInfo .alternativePlaybackLink {
 	display: inline-block;
 	padding-left: 8px;
 }
 
-.SingleEntryStandardInfo .openWaybackLink:after {
+.SingleEntryStandardInfo .alternativePlaybackLink:after {
     content: '';
     display: block;
     position: relative;

--- a/src/js/src/components/searchSingleItemComponents/SearchSingleItemStandardInfo.vue
+++ b/src/js/src/components/searchSingleItemComponents/SearchSingleItemStandardInfo.vue
@@ -84,11 +84,11 @@ export default {
 
     getAlternativePlaybackEngineLink(wayback_date, url, collection) {    
         //Test if collection specific playback is enabled. 
-        var collectionPlayback=configs.collection.playback.get('PLAYBACK_'+collection)
+        const collectionPlayback=configs.collection.playback.get('PLAYBACK_'+collection)
         if (collectionPlayback != null){ //Use default playback engine
-         //console.log('collection playback')
-         var collectionPlaybackLink = collectionPlayback+wayback_date+'/'+url                                                                    
-         return collectionPlaybackLink            
+          //console.log('collection playback')
+          const collectionPlaybackLink = collectionPlayback+wayback_date+'/'+url                                                                    
+          return collectionPlaybackLink            
         }
         else if(configs.playbackConfig.alternativePlaybackBaseURL != null){ //Alternative playback
           //console.log('alternative playback')

--- a/src/js/src/components/searchSingleItemComponents/SearchSingleItemStandardInfo.vue
+++ b/src/js/src/components/searchSingleItemComponents/SearchSingleItemStandardInfo.vue
@@ -20,10 +20,10 @@
         </span>
       </span>
 
-      <a v-if="result.content_type_norm === 'html' && !playbackDisabled()"
-         :href="getOpenWaybackLink(result.wayback_date, result.url)"
+      <a v-if="result.content_type_norm === 'html' && !playbackDisabled() && getAlternativePlaybackEngineLink(result.wayback_date, result.url, result.collection) !== null"
+         :href="getAlternativePlaybackEngineLink(result.wayback_date, result.url, result.collection)"
          title="Alternative playback engine"
-         class="openWaybackLink"
+         class="alternativePlaybackLink"
          target="_blank" />
     </p>
     <p class="entryInfo type">
@@ -82,9 +82,25 @@ export default {
       return `${configs.playbackConfig.solrwaybackBaseURL}services/viewForward?source_file_path=${source_file_path}&offset=${source_file_offset}`    
     },
 
-    getOpenWaybackLink(wayback_date, url) {
-      return `${configs.playbackConfig.openwaybackBaseURL}${wayback_date}/${url}`    
+    getAlternativePlaybackEngineLink(wayback_date, url, collection) {    
+        //Test if collection specific playback is enabled. 
+        var collectionPlayback=configs.collection.playback.get('PLAYBACK_'+collection)
+        if (collectionPlayback != null){ //Use default playback engine
+         //console.log('collection playback')
+         var collectionPlaybackLink = collectionPlayback+wayback_date+'/'+url                                                                    
+         return collectionPlaybackLink            
+        }
+        else if(configs.playbackConfig.alternativePlaybackBaseURL != null){ //Alternative playback
+          //console.log('alternative playback')
+          return `${configs.playbackConfig.alternativePlaybackBaseURL}${wayback_date}/${url}`
+                
+        }
+        else{ //No alternative playback defined
+          //console.log('no alternative playback')
+          return null
+        }    
     },
+
 
     playbackDisabled(){
       return isPlaybackDisabled()

--- a/src/js/src/configs/configHelper.js
+++ b/src/js/src/configs/configHelper.js
@@ -1,7 +1,7 @@
 import configs from './index'
 
 export function setServerConfigInApp(configFromServer) {
-        configs.playbackConfig.openwaybackBaseURL = configFromServer['openwayback.baseurl']
+        configs.playbackConfig.alternativePlaybackBaseURL = configFromServer['openwayback.baseurl']
         configs.playbackConfig.solrwaybackBaseURL = configFromServer['wayback.baseurl']
         configs.playbackConfig.playbackDisabled = configFromServer['playback.disabled']
         configs.search.uploadedFileDisabled = configFromServer['search.uploaded.file.disabled']
@@ -16,6 +16,16 @@ export function setServerConfigInApp(configFromServer) {
         configs.visualizations.ngram.startYear = configFromServer['archive.start.year']
         configs.logo.url = configFromServer['top.left.logo.image']
         configs.logo.link = configFromServer['top.left.logo.image.link']
+                        
+        // Collection values starting with PLAYBACK_<collection>. The collectioname is dynamic from solrwaybackweb.properties  
+        // Set as attribute configs.collection.key 
+        // Example PLAYBACK_coronacollection = http://server1.com/pywbcorona
+        Object.keys(configFromServer).forEach(function(key,index) {
+           if (key.startsWith('PLAYBACK_')){
+              configs.collection.playback.set(key,configFromServer[key])                           
+            }                      
+        })        
+        
 }
 
 export function isPlaybackDisabled(){

--- a/src/js/src/configs/index.js
+++ b/src/js/src/configs/index.js
@@ -1,6 +1,6 @@
 export default {
   playbackConfig: { 
-      openwaybackBaseURL: '',
+      alternativePlaybackBaseURL: '',
       solrwaybackBaseURL:'',
       playbackDisabled:false
   },
@@ -18,6 +18,10 @@ export default {
 
   logo:{
     url: ''
+  },
+
+  collection:{
+   playback: new Map()  
   },
 
   search:{

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -852,6 +852,15 @@ public class Facade {
             props.put(PropertiesLoaderWeb.TOP_LEFT_LOGO_IMAGE_LINK_PROPERTY,PropertiesLoaderWeb.TOP_LEFT_LOGO_IMAGE_LINK);
         }
 
+        if (PropertiesLoaderWeb.ALTERNATIVE_PLAYBACK_COLLECTION_MAPPING.size() >0) {
+            props.put("COLLECTION_PLAYBACK","true");
+            for (String mapping: PropertiesLoaderWeb.ALTERNATIVE_PLAYBACK_COLLECTION_MAPPING.keySet()) {
+               props.put("PLAYBACK_"+mapping,PropertiesLoaderWeb.ALTERNATIVE_PLAYBACK_COLLECTION_MAPPING.get(mapping));                        
+            }            
+        }
+        
+        
+        
         return props;
     }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Properties;
 
@@ -26,6 +27,8 @@ public class PropertiesLoaderWeb {
     public static final String WEBAPP_PREFIX_PROPERTY="webapp.prefix";
     
     public static final String OPENWAYBACK_SERVER_PROPERTY="openwayback.baseurl";	
+    public static final String ALTERNATIVE_PLAYBACK_COLLECTION_MAPPING_PROPERTY="alternative.playback.collection.mapping";
+    
     public static final String FACETS_PROPERTY = "facets";	
     public static final String FIELDS_PROPERTY = "fields";
     public static final String MAPS_LATITUDE_PROPERTY = "maps.latitude";
@@ -51,6 +54,9 @@ public class PropertiesLoaderWeb {
     public static final String TOP_LEFT_LOGO_IMAGE_PROPERTY = "top.left.logo.image";
     public static final String TOP_LEFT_LOGO_IMAGE_LINK_PROPERTY = "top.left.logo.image.link";
  
+    
+    
+    public static LinkedHashMap<String,String> ALTERNATIVE_PLAYBACK_COLLECTION_MAPPING= new LinkedHashMap<String,String>(); 
     public static String SOLRWAYBACK_VERSION; //Will be set from initialcontext-listener
     public static String OPENWAYBACK_SERVER;
     public static int ARCHIVE_START_YEAR;
@@ -187,6 +193,15 @@ public class PropertiesLoaderWeb {
                 FIELDS=fieldsStr;                
             }
                         
+            
+            //Format is key1=value1,key2=value2
+            String mapping= serviceProperties.getProperty(ALTERNATIVE_PLAYBACK_COLLECTION_MAPPING_PROPERTY);
+            if (mapping != null) {
+              buildPlaybackCollectionMapping(mapping);
+            }
+            else {
+             log.info("No collection playback mapping loaded.");   
+            }
             //Set max export sizes                                   
             log.info("Property:"+ WEBAPP_PREFIX_PROPERTY +" = " + WEBAPP_PREFIX);
             log.info("Property:"+ OPENWAYBACK_SERVER_PROPERTY +" = " + OPENWAYBACK_SERVER);
@@ -212,6 +227,13 @@ public class PropertiesLoaderWeb {
             log.info("Property:"+ TOP_LEFT_LOGO_IMAGE_PROPERTY +" = " + TOP_LEFT_LOGO_IMAGE);
             log.info("Property:"+ TOP_LEFT_LOGO_IMAGE_LINK_PROPERTY +" = " + TOP_LEFT_LOGO_IMAGE_LINK);
             
+            if (ALTERNATIVE_PLAYBACK_COLLECTION_MAPPING.size() >0) {
+                for (String key : ALTERNATIVE_PLAYBACK_COLLECTION_MAPPING.keySet())
+                {
+                    log.info("Collection playback mapping:"+ key +" = " + ALTERNATIVE_PLAYBACK_COLLECTION_MAPPING.get(key));                
+                }                                
+            }
+            
         }
         catch (Exception e) {
             e.printStackTrace();
@@ -227,4 +249,18 @@ public class PropertiesLoaderWeb {
         Object o = serviceProperties.getProperty(key);
         return o == null ? defaultValue : o.toString();
     }
+    
+    //Format is key1=value1,key2=value2
+    private static void buildPlaybackCollectionMapping(String mapping) {
+    
+        String[] params = mapping.split(";");
+        
+        for (String param : params) {
+            String[] keyVal=param.split("=");            
+            ALTERNATIVE_PLAYBACK_COLLECTION_MAPPING.put(keyVal[0],keyVal[1]);            
+        }        
+    
+    }
+    
+    
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -1093,7 +1093,7 @@ public class NetarchiveSolrClient {
         solrQuery.set("rows", "20"); // Hardcoded pt.
         solrQuery.set("start", startStr);
         solrQuery.set("q", query);
-        solrQuery.set("fl", "id,score,title,hash,source_file_path,source_file_offset,url,url_norm,wayback_date,domain,content_type,crawl_date,content_type_norm,type");
+        solrQuery.set("fl", "id,score,title,hash,source_file_path,source_file_offset,url,url_norm,wayback_date,domain,content_type,crawl_date,content_type_norm,type, collection");
         solrQuery.set("wt", "json");
         solrQuery.set("hl", "on");
         solrQuery.set("q.op", "AND");

--- a/src/test/resources/properties/solrwaybackweb.properties
+++ b/src/test/resources/properties/solrwaybackweb.properties
@@ -6,8 +6,14 @@ wayback.baseurl=http://localhost:8080/solrwayback/
 # Only define if solrwayback is not installed right after domain url element. If it is installed as https:kb.dk/covid-collection/solrwayback , then set the property below
 #webapp.prefix=/covid-collection/solrwayback/
 
-## Optional additional playback engine. 
+## Optional additional playback engine. Using collection base playback below will overrule this value.  
 openwayback.baseurl=http://web.archive.org/web/
+
+# Use collections field to map to different alternative playback engines. This require the collection-field was specified when indexing the WARC-file.
+# Syntax is collectionname1=playbackurl1;collectionname2=playbackurl2  (Must end with a slash /)
+# Example coronacollection=http://server.com/pywbcorona/;examplecollection=http://server1.com/pywbexample
+#alternative.playback.collection.mapping=coronacollection=http://servername.com/pywbcorona/;examplecollection=http://servername1.com/pywbexample/
+
 
 # Will toogle the warc+csv export options.
 allow.export.warc=true


### PR DESCRIPTION
Alternative playback engines can  be defined based on collectionid for the document. This requires the WARC files has been indexed with a collectionid.

@jorntx  Wait with merge until Volodymyr Kushnarenko has tested and approved. 