### PR TITLE
Lenient url search

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -4,7 +4,6 @@ import dk.kb.netarchivesuite.solrwayback.concurrency.ImageSearchExecutor;
 import dk.kb.netarchivesuite.solrwayback.export.ContentStreams;
 import dk.kb.netarchivesuite.solrwayback.export.StreamingSolrExportBufferedInputStream;
 import dk.kb.netarchivesuite.solrwayback.export.StreamingSolrWarcExportBufferedInputStream;
-import dk.kb.netarchivesuite.solrwayback.normalise.Normalisation;
 import dk.kb.netarchivesuite.solrwayback.parsers.ArcParserFileResolver;
 import dk.kb.netarchivesuite.solrwayback.parsers.DomainStatisticsForDomainParser;
 import dk.kb.netarchivesuite.solrwayback.parsers.HtmlParserUrlRewriter;
@@ -56,7 +55,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.net.IDN;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -369,31 +367,6 @@ public class Facade {
         ArrayList<ArcEntryDescriptor> arcs = getImagesForHtmlPageNewThreaded(source_file_path, offset);
 
         return arcEntrys2Images(arcs);
-    }
-
-    public static String punyCodeAndNormaliseUrl(String url) throws Exception {
-        if (!(url.startsWith("http://") || url.startsWith("https://"))) {
-            throw new Exception("Url not starting with http:// or https://");
-        }
-
-        URL uri = new URL(url);
-        String hostName = uri.getHost();
-        String hostNameEncoded = IDN.toASCII(hostName);
-        
-        String path = uri.getPath();
-        if ("".equals(path)) {
-            path = "/";
-        }
-        String urlQueryPath = uri.getQuery();
-        String urlPunied = null;
-        if (urlQueryPath == null) {
-             urlPunied = "http://" + hostNameEncoded + path;
-        }
-        else {
-            urlPunied = "http://" + hostNameEncoded + path +"?"+ urlQueryPath;            
-        }
-        String urlPuniedAndNormalized = Normalisation.canonicaliseURL(urlPunied);       
-        return urlPuniedAndNormalized;
     }
 
     /*

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -817,7 +817,9 @@ public class Facade {
     }
 
 
-    public static ArcEntry viewResource(String source_file_path, long offset, IndexDoc doc, Boolean showToolbar) throws Exception {
+    public static ArcEntry viewResource(
+            String source_file_path, long offset, IndexDoc doc, Boolean showToolbar, Boolean lenient) throws Exception {
+        lenient = Boolean.TRUE.equals(lenient);
         if (showToolbar == null) {
             showToolbar = false;
         }
@@ -838,22 +840,22 @@ public class Facade {
 
         if (doc.getType().equals("Twitter Tweet")) {
             TwitterPlayback twitterPlayback = new TwitterPlayback(arc, doc, showToolbar);
-            return twitterPlayback.playback();
+            return twitterPlayback.playback(lenient);
         } else if (doc.getType().equals("Jodel Post") || doc.getType().equals("Jodel Thread")) {
             JodelPlayback jodelPlayback = new JodelPlayback(arc, doc, showToolbar);
-            return jodelPlayback.playback();
+            return jodelPlayback.playback(lenient);
         } else if ("Web Page".equals(doc.getType())|| ((300 <= doc.getStatusCode() && arc.getContentType() != null && arc.getContentType().equals("text/html")))) {
 
             // We still want the toolbar to show for http moved (302 etc.)
             HtmlPlayback htmlPlayback = new HtmlPlayback(arc, doc, showToolbar);
-            return htmlPlayback.playback();
+            return htmlPlayback.playback(lenient);
         } else if ("text/css".equals(arc.getContentType()) ) {
             CssPlayback cssPlayback = new CssPlayback(arc, doc, showToolbar); // toolbar is never shown anyway.
-            return cssPlayback.playback();
+            return cssPlayback.playback(lenient);
         }
         else if ("text/javascript".equals(arc.getContentType()) ) {
             JavascriptPlayback javascriptPlayback = new JavascriptPlayback(arc, doc, showToolbar); // toolbar is never shown anyway.
-            return javascriptPlayback.playback();
+            return javascriptPlayback.playback(lenient);
         }
 
         else { // Serve as it is. (Javascript, images, pdfs etc.)

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriter.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriter.java
@@ -127,15 +127,16 @@ public class HtmlParserUrlRewriter {
 	 * Extracts the HTML from the ArcEntry and replaces links and other URLs with the archived versions that are
 	 * closest to the ArcEntry in time.
 	 * @param arc an arc-entry that is expected to be a HTML page.
+	 * @param lenient if true, lenient URL-matching is used.
+	 *                See {@link dk.kb.netarchivesuite.solrwayback.util.UrlUtils#lenientURLQuery(String)}.
 	 * @return the page with links to archived versions instead of live web version.
 	 * @throws Exception if link-resolving failed.
 	 */
-	public static ParseResult replaceLinks(ArcEntry arc) throws Exception{
+	public static ParseResult replaceLinks(ArcEntry arc, boolean lenient) throws Exception{
 		final long startMS = System.currentTimeMillis();
 		return replaceLinks(
 				arc.getBinaryContentAsStringUnCompressed(), arc.getUrl(), arc.getCrawlDate(),
-				(urls, timeStamp) -> NetarchiveSolrClient.getInstance().
-						findNearestHarvestTimeForMultipleUrlsFewFields(urls, timeStamp),
+				(urls, timeStamp) -> NetarchiveSolrClient.getInstance().findNearestUrlsShort(urls, timeStamp, lenient),
 				startMS);
 	}
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/CssPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/CssPlayback.java
@@ -16,8 +16,9 @@ public class CssPlayback  extends PlaybackHandler{
     super(arc,doc,showToolbar);
   }
 
+  // TODO: Enable propagation of lenient through HtmlParserUrlRewriter.replaceLinksCss(arc)
   @Override
-  public ArcEntry playback() throws Exception{    
+  public ArcEntry playback(boolean lenient) throws Exception{
     //Never show the toolbar.
       arc.setBinary(IOUtils.toByteArray(arc.getBinaryContentAsStringUnCompressed())); //TODO charset;          
       

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/HtmlPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/HtmlPlayback.java
@@ -20,8 +20,9 @@ public class HtmlPlayback  extends PlaybackHandler{
   }
 
   @Override
-  public ArcEntry playback() throws Exception{    
-    log.debug(" Generate webpage from FilePath:" + doc.getSource_file_path() + " offset:" + doc.getOffset() +" content encoding:"+arc.getContentEncoding());
+  public ArcEntry playback(boolean lenient) throws Exception{
+    log.debug(" Generate webpage from FilePath:{} offset:{} content encoding:{} lenient:{}",
+              doc.getSource_file_path(), doc.getOffset(), arc.getContentEncoding(), lenient);
     long start = System.currentTimeMillis();
     
      String raw = arc.getBinaryContentAsStringUnCompressed();
@@ -35,7 +36,7 @@ public class HtmlPlayback  extends PlaybackHandler{
       arc.setBinary(raw.getBytes(Charset.forName(charset)));
          
     
-     ParseResult htmlReplaced = HtmlParserUrlRewriter.replaceLinks(arc);
+     ParseResult htmlReplaced = HtmlParserUrlRewriter.replaceLinks(arc, lenient);
       String textReplaced=htmlReplaced.getReplaced();
 
       boolean xhtml =doc.getContentType().toLowerCase().indexOf("application/xhtml") > -1;            

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/JavascriptPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/JavascriptPlayback.java
@@ -16,8 +16,9 @@ public class JavascriptPlayback  extends PlaybackHandler{
     super(arc,doc,showToolbar);
   }
 
+  // TODO: Enable propagation of lenient through HtmlParserUrlRewriter.replaceLinksCss
   @Override
-  public ArcEntry playback() throws Exception{    
+  public ArcEntry playback(boolean lenient) throws Exception{
     //Never show the toolbar.
       arc.setBinary(IOUtils.toByteArray(arc.getBinaryContentAsStringUnCompressed())); //TODO charset;
       //log.debug("javascript playback");

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/JodelPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/JodelPlayback.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 
 
 import dk.kb.netarchivesuite.solrwayback.parsers.ParseResult;
-import dk.kb.netarchivesuite.solrwayback.parsers.Jodel2Html;
 import dk.kb.netarchivesuite.solrwayback.parsers.WaybackToolbarInjecter;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
@@ -22,7 +21,7 @@ public class JodelPlayback extends PlaybackHandler{
   }
 
   @Override
-  public ArcEntry playback() throws Exception{
+  public ArcEntry playback(boolean lenient) throws Exception{
     log.debug(" Generate Jodel post from FilePath:" + doc.getSource_file_path() + " offset:" + doc.getOffset());
     //Fake html into arc.
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/PlaybackHandler.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/PlaybackHandler.java
@@ -14,7 +14,14 @@ public abstract class PlaybackHandler {
     this.doc=doc;
     this.showToolbar=showToolbar;
   }
-    
-  public abstract ArcEntry playback() throws Exception;
+
+  /**
+   * Deliver a webpage for playback.
+   * @param lenient if true, lenient resource URL resolving is used.
+   *                If false, only {@code url_norm:"normURL"} is used.
+   * @return a webpage for playback.
+   * @throws Exception if the webpage could not be rendered.
+   */
+  public abstract ArcEntry playback(boolean lenient) throws Exception;
   
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/TwitterPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/TwitterPlayback.java
@@ -19,8 +19,9 @@ public class TwitterPlayback extends PlaybackHandler{
         super(arc,doc,showToolbar);
     }
 
+    // TODO: add support for lenient
     @Override
-    public ArcEntry playback() throws Exception{
+    public ArcEntry playback(boolean lenient) throws Exception{
 
         log.debug(" Generate twitter webpage from FilePath:" + doc.getSource_file_path() + " offset:" + doc.getOffset());
         // Fake html into arc.

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
@@ -662,7 +662,7 @@ public class SolrWaybackResource {
            
       //log.debug("return viewImpl for type:"+doc.getMimeType() +" and url:"+doc.getUrl());
           
-      Response viewImpl = viewImpl(doc.getSource_file_path() , doc.getOffset(),true, null);
+      Response viewImpl = viewImpl(doc.getSource_file_path() , doc.getOffset(),true, lenient);
       
       return viewImpl;
     } catch (Exception e) {

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
@@ -489,7 +489,7 @@ public class SolrWaybackResource {
       }
       //log.info("Found url with harvesttime:"+doc.getUrl() +" and arc:"+doc.getArc_full());        
       log.info("return viewImpl for type:"+doc.getMimeType() +" and url:"+doc.getUrl());
-      return viewImpl(doc.getSource_file_path() , doc.getOffset(),false); //NO TOOLBAR!        
+      return viewImpl(doc.getSource_file_path() , doc.getOffset(),false, null); //NO TOOLBAR!
       
                      
     } catch (Exception e) {
@@ -571,16 +571,34 @@ public class SolrWaybackResource {
    */
   @GET
   @Path("/web/{path:.+}")      
-  public Response waybackAPIResolver(@Context UriInfo uriInfo, @Context HttpServletRequest httpRequest, @PathParam("path") String path) throws SolrWaybackServiceException {
-    try {        
+  public Response waybackAPIResolver(@Context UriInfo uriInfo, @Context HttpServletRequest httpRequest,
+                                     @PathParam("path") String path) throws SolrWaybackServiceException {
+    return waybackAPIResolverHelper("/web/", uriInfo, httpRequest, path, false);
+  }
+  /*
+   * Playback with lenient URL resolving.
+   * The last part of the path '/web/' is the same as wayback machine uses.
+   *
+   * Jersey syntax to match all after /lenient/web/.
+   */
+  @GET
+  @Path("/lenient/web/{path:.+}")
+  public Response waybackAPIResolverLenient(@Context UriInfo uriInfo, @Context HttpServletRequest httpRequest,
+                                     @PathParam("path") String path) throws SolrWaybackServiceException {
+    return waybackAPIResolverHelper("/lenient/web/", uriInfo, httpRequest, path, true);
+  }
+  private Response waybackAPIResolverHelper(
+          String basePath, // "/lenient/web/" or "/web/"
+          UriInfo uriInfo, HttpServletRequest httpRequest, String path, Boolean lenient) throws SolrWaybackServiceException {
+    try {
       //For some reason the var regexp does not work with comma (;) and other characters. So I have to grab the full url from uriInfo
-      log.debug("/web/ called with data:"+path);
+      log.debug("{} called with data:{} lenient:{}", basePath, path, lenient);
       String fullUrl = uriInfo.getRequestUri().toString();
 //   log.info("full url:"+fullUrl);
      
-      int dataStart=fullUrl.indexOf("/web/");
+      int dataStart=fullUrl.indexOf(basePath);
       
-      String waybackDataObject = fullUrl.substring(dataStart+5);
+      String waybackDataObject = fullUrl.substring(dataStart+basePath.length());
       //log.info("Waybackdata object:"+waybackDataObject);
 
       int indexFirstSlash = waybackDataObject.indexOf("/");  
@@ -630,7 +648,7 @@ public class SolrWaybackResource {
        // html forward to a new request so date in url will show the true crawldate of the document. Avoid having 2020 in url with the page is from 2021 etc.      
       String htmlPageCrawlDate= DateUtils.convertUtcDate2WaybackDate(doc.getCrawlDate());
         if ("html".equalsIgnoreCase(doc.getContentTypeNorm()) &&  !htmlPageCrawlDate.equals(waybackDate)) {                         
-          String newUrl=PropertiesLoader.WAYBACK_BASEURL+"services/web/"+htmlPageCrawlDate+"/"+url;
+          String newUrl=PropertiesLoader.WAYBACK_BASEURL+"services" + basePath + htmlPageCrawlDate+"/"+url;
           log.info("Forwarding html view to a url where crawldate matches html crawltime. url crawltime:"+htmlPageCrawlDate +" true crawl:"+htmlPageCrawlDate);
           newUrl = newUrl.replace("|", "%7C");//For some unknown reason Java does not accept |, must encode.
           newUrl = newUrl.replace("%2f", "/"); // or url will not match Rest pattern for method. (not clear why)
@@ -644,7 +662,7 @@ public class SolrWaybackResource {
            
       //log.debug("return viewImpl for type:"+doc.getMimeType() +" and url:"+doc.getUrl());
           
-      Response viewImpl = viewImpl(doc.getSource_file_path() , doc.getOffset(),true);                                   
+      Response viewImpl = viewImpl(doc.getSource_file_path() , doc.getOffset(),true, null);
       
       return viewImpl;
     } catch (Exception e) {
@@ -709,7 +727,7 @@ public class SolrWaybackResource {
          throw new NotFoundServiceException("URL:"+pwidUrl +" and time:"+onlyUTC + " is not found in collection:"+thisCollectionName);
        }
 
-      return viewImpl(doc.getSource_file_path() , doc.getOffset(),true);                                   
+      return viewImpl(doc.getSource_file_path() , doc.getOffset(),true, null);
     } catch (Exception e) {
       throw handleServiceExceptions(e);
     }
@@ -762,7 +780,9 @@ public class SolrWaybackResource {
  */
   @GET
   @Path("/viewForward")
-  public Response viewForward(@QueryParam("source_file_path") String source_file_path, @QueryParam("offset") long offset, @QueryParam("showToolbar") Boolean showToolbar) throws SolrWaybackServiceException {
+  public Response viewForward(@QueryParam("source_file_path") String source_file_path, @QueryParam("offset") long offset,
+                              @QueryParam("showToolbar") Boolean showToolbar, @QueryParam("lenient") Boolean lenient)
+          throws SolrWaybackServiceException {
     try {
               
        if (PropertiesLoader.PLAYBACK_DISABLED) {            
@@ -776,7 +796,10 @@ public class SolrWaybackResource {
       String waybackDate = DateUtils.convertUtcDate2WaybackDate(crawlDate);      
                                              
      //Format is: /web/20080331193533/http://ekstrabladet.dk/112/article990050.ece 
-      String newUrl=PropertiesLoader.WAYBACK_BASEURL+"services/web/"+waybackDate+"/"+url;
+      String newUrl= Boolean.TRUE.equals(lenient) ?
+              PropertiesLoader.WAYBACK_BASEURL+"services/lenient/web/"+waybackDate+"/"+url :
+              PropertiesLoader.WAYBACK_BASEURL+"services/web/"+waybackDate+"/"+url;
+              
       newUrl = newUrl.replace("|", "%7C");//For some unknown reason Java does not accept |, must encode.
       newUrl = newUrl.replace("%2f", "/"); // or url will not rest Rest pattern for method. (not clear why)
       newUrl = newUrl.replace("%2F", "/"); // or url will not rest Rest pattern for method. (not clear why)
@@ -821,10 +844,12 @@ public class SolrWaybackResource {
   
   @GET
   @Path("/view") 
-  public Response view(@QueryParam("source_file_path") String source_file_path, @QueryParam("offset") long offset, @QueryParam("showToolbar") Boolean showToolbar) throws SolrWaybackServiceException {
+  public Response view(@QueryParam("source_file_path") String source_file_path, @QueryParam("offset") long offset,
+                       @QueryParam("showToolbar") Boolean showToolbar, @QueryParam("lenient") Boolean lenient)
+          throws SolrWaybackServiceException {
     try {
 
-      return viewImpl(source_file_path, offset,showToolbar);
+      return viewImpl(source_file_path, offset,showToolbar, lenient);
 
     } catch (Exception e) {
       throw handleServiceExceptions(e);
@@ -861,7 +886,7 @@ public class SolrWaybackResource {
   }
 */
 
-  private Response viewImpl(String source_file_path, long offset,Boolean showToolbar) throws Exception{    	    	
+  private Response viewImpl(String source_file_path, long offset,Boolean showToolbar, Boolean lenient) throws Exception{
     
       if (PropertiesLoader.PLAYBACK_DISABLED) {          
           throw new InvalidArgumentServiceException("Playback has been disabled in the configuration");
@@ -875,7 +900,7 @@ public class SolrWaybackResource {
       return redirect;
     }
     
-    ArcEntry arcEntry= Facade.viewResource(source_file_path, offset, doc, showToolbar);
+    ArcEntry arcEntry= Facade.viewResource(source_file_path, offset, doc, showToolbar, lenient);
     
     
     String contentType = arcEntry.getContentType();
@@ -929,7 +954,7 @@ public class SolrWaybackResource {
       }
 
       //log.debug("Closest harvest to: " +crawlDate +" is "+indexDoc.getCrawlDate());
-      return view(indexDoc.getSource_file_path(),indexDoc.getOffset(),showToolbar);
+      return view(indexDoc.getSource_file_path(),indexDoc.getOffset(),showToolbar, null);
 
     } catch (Exception e) {
       throw handleServiceExceptions(e);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
@@ -26,6 +26,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.ResponseBuilder;
 import javax.ws.rs.core.UriInfo;
 
+import dk.kb.netarchivesuite.solrwayback.util.UrlUtils;
 import org.apache.cxf.jaxrs.ext.multipart.Attachment;
 import org.brotli.dec.BrotliInputStream;
 import org.slf4j.Logger;
@@ -383,7 +384,7 @@ public class SolrWaybackResourceWeb {
       try{
        
         //also rewrite to puny code
-        String url_norm =  Facade.punyCodeAndNormaliseUrl(url);       
+        String url_norm =  UrlUtils.punyCodeAndNormaliseUrl(url);
         log.info("Normalize url:"+url +" -> " +  url_norm);        
         UrlWrapper wrapper = new UrlWrapper();
         wrapper.setUrl(url_norm);      

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -515,6 +515,7 @@ public class NetarchiveSolrClient {
         SRequest request = SRequest.builder().
                 queries(urlQueries).
                 queryBatchSize(1000). // Same as partitionSize in splitToStreams
+                usePaging(false). // Optimize Solr lookups
                 fields(fields).
                 filterQueries(filterQueries);
         if (idealTime != null) {
@@ -938,6 +939,8 @@ public class NetarchiveSolrClient {
                 queries(urlQueries).
                 filterQueries(SolrUtils.extend(SolrUtils.NO_REVISIT_FILTER, filterQueries)). // No binary for revists
                 queryBatchSize(chunkSize). // URL-searches are single-clause queries, so we can use large batches
+                pageSize(chunkSize).
+                usePaging(false). // 1 URL = 1 hit as we deduplicate on url_norm
                 fields(fieldList).
                 timeProximityDeduplication(timeStamp, "url_norm").
                 stream();

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -515,7 +515,7 @@ public class NetarchiveSolrClient {
         SRequest request = SRequest.builder().
                 queries(urlQueries).
                 queryBatchSize(1000). // Same as partitionSize in splitToStreams
-                usePaging(false). // Optimize Solr lookups
+                //usePaging(false). // Optimize Solr lookups (no longer needed)
                 fields(fields).
                 filterQueries(filterQueries);
         if (idealTime != null) {
@@ -945,7 +945,7 @@ public class NetarchiveSolrClient {
                 filterQueries(SolrUtils.extend(SolrUtils.NO_REVISIT_FILTER, filterQueries)). // No binary for revists
                 queryBatchSize(chunkSize). // URL-searches are single-clause queries, so we can use large batches
                 pageSize(chunkSize).
-                usePaging(false). // 1 URL = 1 hit as we deduplicate on url_norm
+                //usePaging(false). // 1 URL = 1 hit as we deduplicate on url_norm (no longer needed)
                 fields(fieldList).
                 timeProximityDeduplication(timeStamp, "url_norm").
                 stream();

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -904,8 +904,8 @@ public class NetarchiveSolrClient {
      */
     public ArrayList<IndexDocShort> findNearestUrlsShort(Collection<String> urls, String timeStamp, boolean lenient) {
         Stream<SolrDocument> docs = lenient ?
-                findNearestDocuments(SolrUtils.indexDocFieldListShort, timeStamp, urls.stream()) :
-                findNearestDocumentsLenient(SolrUtils.indexDocFieldListShort, timeStamp, urls.stream());
+                findNearestDocumentsLenient(SolrUtils.indexDocFieldListShort, timeStamp, urls.stream()) :
+                findNearestDocuments(SolrUtils.indexDocFieldListShort, timeStamp, urls.stream());
 
         return docs.
                 map(SolrUtils::solrDocument2IndexDocShort).

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -557,6 +557,11 @@ public class NetarchiveSolrClient {
 
         // Run jobs and collect Map with [originalURL, SolrDocument]
         return Processing.batch(lenientJobs).
+                peek(jobPair -> {
+                    if (Objects.isNull(jobPair.second())) {
+                        log.debug("Unable to lenient resolve '{}'", jobPair.first());
+                    }
+                }).
                 filter(jobPair -> Objects.nonNull(jobPair.second())).
                 peek(jobPair -> {
                     String originalURL = jobPair.first();

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -431,7 +431,7 @@ public class NetarchiveSolrClient {
      * resulting {@link SolrDocument} is passed on.
      * <p>
      * This implementation performs a full resolve of all URLs before delivery, which delays the time before first
-     * delivered {@code Solrdocument} and introduces a memory overhead: This method should only be called for a limited
+     * delivered {@code SolrDocument} and introduces a memory overhead: This method should only be called for a limited
      * amount of URLs, such as 1000-10,000.
      * <p>
      * All URLs without hits are resolved individually using {@link dk.kb.netarchivesuite.solrwayback.util.UrlUtils#lenientURLQuery(String)},
@@ -949,8 +949,8 @@ public class NetarchiveSolrClient {
      * <p>
      * If a document cannot be resolved using direct matching with {@code url_norm:<normURL>}, lenient matching is used.
      * Lenient first locates the {@code url_norm} closest to the original URL, then feeds that {@code url_norm} to
-     * time prioritized resolving. When producing {@link SolrDocument}s, the original URL is set as the document's
-     * {@code url} instead off the one originally returned by Solr.
+     * time prioritized resolving. When producing {@link SolrDocument}s, a normalised version of the original URL is
+     * set as the document's {@code url_norm} instead of the one originally returned by Solr.
      * <p>
      * Note: Revisits are not considered as candidates: See {@link SolrUtils#NO_REVISIT_FILTER}.
      *
@@ -981,8 +981,8 @@ public class NetarchiveSolrClient {
       <p>
      * If a document cannot be resolved using direct matching with {@code url_norm:<normURL>}, lenient matching is used.
      * Lenient first locates the {@code url_norm} closest to the original URL, then feeds that {@code url_norm} to
-     * time prioritized resolving. When producing {@link SolrDocument}s, the original URL is set as the document's
-     * {@code url} instead off the one originally returned by Solr.
+     * time prioritized resolving. When producing {@link SolrDocument}s, a normalised version of the original URL is
+     * set as the document's {@code url_norm} instead of the one originally returned by Solr.
      * <p>
      * Note: Revisits are not considered as candidates: See {@link SolrUtils#NO_REVISIT_FILTER}.
      *
@@ -1034,7 +1034,8 @@ public class NetarchiveSolrClient {
                 map(originalURL -> getValueFromMaps(originalURL, direct, lenient)).
                 filter(Objects::nonNull).
                 peek(resultPair -> resultPair.second().setField("originalURL", resultPair.first())).
-                peek(resultPair -> resultPair.second().setField("url", resultPair.first())).
+                peek(resultPair -> resultPair.second().setField(
+                        "url_norm", UrlUtils.punyCodeAndNormaliseUrlSafe(resultPair.first()))).
                 map(Pair::second);
     }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SRequest.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SRequest.java
@@ -176,7 +176,6 @@ public class SRequest {
      *                         Note: deduplicateField does not affect expandResources. Set ensureUnique to true if
      *                         if expandResources is true and uniqueness must also be guaranteed for resources.
      * @return the SRequest adjusted with the provided value.
-     * @see #usePaging(boolean) 
      */
     public SRequest deduplicateField(String deduplicateField) {
         if (deduplicateField != null && deduplicateField.isEmpty()) {
@@ -201,7 +200,6 @@ public class SRequest {
      *                         Also supports {@code oldest} and {@code newest} as values.
      * @param deduplicateField The field to use for de-duplication. This is typically {@code url}.
      * @return the SRequest adjusted with the provided values.
-     * @see #usePaging(boolean) 
      */
     public SRequest timeProximityDeduplication(String idealTime, String deduplicateField) {
         if (deduplicateField != null && deduplicateField.isEmpty()) {
@@ -578,16 +576,14 @@ public class SRequest {
     }
 
     /**
-     * Disables paging through result sets, so that only {@link #pageSize(int)} results are processed.
-     * Disabling of paging allows for optimization of Solr queries when {@link #deduplicateField(String)} or
-     * {@link #timeProximityDeduplication(String, String)} are used.
+     * Disables paging through result sets, so that only {@link #pageSize(int)} results are processed for each query.
      * <p>
-     * Warning: Disabling paging means skipping results if there are more than pageSize hits for a query.
-     * This is typically used when the number of maximum hits is known beforehand and when {@link #pageSize(int)}
-     * is set to that number.
+     * Use case: Getting a limited number of results from each query when using {@link #queries}.
+     *           For that scenario, remember setting {@link #queryBatchSize(int)} to 1.
      * <p>
-     * Prime example is URL-lookups using {@code url_norm} that are also deduplicated on {@code url_norm}.
-     * When {@code usePaging(false)} is specified this will be changed to a grouping Solr query internally.
+     * Previously this was used for optimization of specific cases with {@link #deduplicateField(String)} and
+     * {@link #timeProximityDeduplication(String, String)} requests. This optimization is no longer needed.
+     * <p>
      * @param usePaging if true (the default), paging is used. If false, paging is not used and only the first
      *                  {@link #pageSize(int)} documents are processed for each query.
      * @return the SRequest adjusted with the provided value.
@@ -615,7 +611,7 @@ public class SRequest {
     /**
      * Copies {@link #solrQuery} and adjusts it with defined attributes from the SRequest, extending with needed
      * SolrRequest-attributes.
-     *
+     * <p>
      * Note: This does assign {@link #query}, but not {@link #queries}: They muct be handled explicitly.
      * @return a SolrQuery ready for processing.
      */

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -32,11 +32,13 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
 import java.util.Spliterators;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -119,10 +121,15 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
    */
   public static final String STOP_PAGING = "___STOP_PAGING___";
 
+  static final AtomicLong solrRequests = new AtomicLong(0);
+
   private final SRequest request;
-  private final SolrQuery solrQuery; // Constructed from request. Used for single-query requests
-  private SolrQuery solrBatchQuery = null; // Used for multi-query requests
-  private final Iterator<String> queries; // Only defined if the request is multi-query
+  private final SolrQuery originalSolrQuery; // The original SolrQuery from the SRequest. Never modify this!
+  private SolrQuery solrQuery;               // Deep copy of originalSolrQuery. Potentially modified with e.g. q and cursorMark
+  private final Iterator<String> queries;    // Only defined if the request is multi-query
+  private boolean queryDepleted;             // Whether or not all documents has been resolved for the current q
+  private String lastDeduplicateValue = null; // Used for simulated cursorMark
+  private String userQuery = null;            // Used for simulated cursorMark
 
   private final List<String> initialFields;  // Caller provided fields
   private final List<String> adjustedFields; // Fields after adjusting for unique etc.
@@ -177,7 +184,10 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
    */
   public SolrGenericStreaming(SRequest request) {
     this.request = request;
-    solrQuery = request.getMergedSolrQuery();
+    originalSolrQuery = request.getMergedSolrQuery();
+    solrQuery = SolrUtils.deepCopy(originalSolrQuery);
+    queryDepleted = request.isMultiQuery(); // Single query starts assigned, multi are initialized later
+    userQuery = request.isMultiQuery() ? null : solrQuery.getQuery();
     this.initialFields = Arrays.asList(solrQuery.getFields().split(","));
 
     adjustSolrQuery(solrQuery, request.expandResources, request.ensureUnique, request.deduplicateField);
@@ -273,27 +283,31 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
    * @param request the request responsible for the solrQuery.
    */
   private void optimizeSolrQuery(SolrQuery solrQuery, SRequest request) {
-    if (!request.usePaging && request.deduplicateField != null) {
-      String cursorMark = solrQuery.get(CursorMarkParams.CURSOR_MARK_PARAM, CursorMarkParams.CURSOR_MARK_START);
-      if (!CursorMarkParams.CURSOR_MARK_START.equals(cursorMark)) {
-        log.debug("Unable to enable group-based deduplication on '{}' as cursorMark is defined to '{}'",
-                  request.deduplicateField, cursorMark);
-        return;
-      }
-
-      log.debug("Enabling group-based deduplication on '{}' as usePaging==true", request.deduplicateField);
-      // group=true&group.field=url_norm&group.limit=1&group.format=simple&group.main=true
-      solrQuery.set(GroupParams.GROUP, true);
-      solrQuery.set(GroupParams.GROUP_FIELD, request.deduplicateField);
-      solrQuery.set(GroupParams.GROUP_LIMIT, 1);
-
-      // Make grouping return the first (and only) document from each group flattened as a standard search result
-      solrQuery.set(GroupParams.GROUP_FORMAT, "simple");
-      solrQuery.set(GroupParams.GROUP_MAIN, true);
-
-      // Remove cursorMark
-      solrQuery.remove(CursorMarkParams.CURSOR_MARK_PARAM);
+    if (request.deduplicateField == null) { // No need for grouping
+      return;
     }
+
+    // Check for already existing cursorMark
+    String cursorMark = solrQuery.get(CursorMarkParams.CURSOR_MARK_PARAM, CursorMarkParams.CURSOR_MARK_START);
+    if (!CursorMarkParams.CURSOR_MARK_START.equals(cursorMark)) {
+      log.debug("Unable to enable group-based deduplication on '{}' as cursorMark is defined to '{}'",
+                request.deduplicateField, cursorMark);
+      // TODO: Should this throw an Exception instead?
+      return;
+    }
+
+    log.debug("Enabling group-based deduplication on '{}'", request.deduplicateField);
+    // group=true&group.field=url_norm&group.limit=1&group.format=simple&group.main=true
+    solrQuery.set(GroupParams.GROUP, true);
+    solrQuery.set(GroupParams.GROUP_FIELD, request.deduplicateField);
+    solrQuery.set(GroupParams.GROUP_LIMIT, 1);
+
+    // Make grouping return the first (and only) document from each group flattened as a standard search result
+    solrQuery.set(GroupParams.GROUP_FORMAT, "simple");
+    solrQuery.set(GroupParams.GROUP_MAIN, true);
+
+    // Remove cursorMark if it is present
+    solrQuery.remove(CursorMarkParams.CURSOR_MARK_PARAM);
   }
 
   /**
@@ -389,48 +403,60 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
    */
   public SolrDocumentList nextDocuments() throws SolrServerException, IOException {
     while (!hasFinished && delivered < request.maxResults) {
+
       // Return batch if undelivered contains any documents
       if (undelivered != null && undelivered.size() > 0) {
         return nextPageUndelivered();
       }
 
-      SolrQuery solrRealQuery = solrQuery;
-      if (request.isMultiQuery()) {   // Multi-query
-        if (solrBatchQuery == null) { // Move to next query in multi-query
-          if (!queries.hasNext()) {
-            hasFinished = true;
-            return null;
-          }
-          // TODO: Switch to only using 1 deep copy instead of one for each query
-          solrBatchQuery = SolrUtils.deepCopy(solrQuery).setQuery(queries.next());
+      // Move to next query is needed
+      if (queryDepleted) {
+        if (request.isMultiQuery() && queries.hasNext()) {
+          userQuery = queries.next();
+          solrQuery.setQuery(userQuery);
+          queryDepleted = false;
           if (request.usePaging) {
-            solrBatchQuery.set(CursorMarkParams.CURSOR_MARK_PARAM,
-                               solrQuery.get(CursorMarkParams.CURSOR_MARK_PARAM, CursorMarkParams.CURSOR_MARK_START));
+            if (request.deduplicateField == null) { // Plain paging initialization
+              solrQuery.set(
+                      CursorMarkParams.CURSOR_MARK_PARAM,
+                      originalSolrQuery.get(CursorMarkParams.CURSOR_MARK_PARAM, CursorMarkParams.CURSOR_MARK_START));
+            } else { // Simulated cursorMark reset
+              lastStreamDeduplicateValue = null;
+            }
           }
+        } else {
+          hasFinished = true;
+          return null;
         }
-        solrRealQuery = solrBatchQuery;
       }
 
-      String cursorMark = solrRealQuery.get(CursorMarkParams.CURSOR_MARK_PARAM, CursorMarkParams.CURSOR_MARK_START);
-
-      // Only page to next page if there are more pages
-      if (STOP_PAGING.equals(cursorMark)) {
-        if (request.isMultiQuery()) {
-          // Multi-query, so skip to next query
-          solrBatchQuery = null;
-          continue;
-        }
-        hasFinished = true;
-        return null;
-      }
-
-      // No more documents buffered, attempt to require new documents
+      // Handle påaging (cursorMark) setup
+      String cursorMark = solrQuery.get(CursorMarkParams.CURSOR_MARK_PARAM, CursorMarkParams.CURSOR_MARK_START);
       if (request.usePaging) {
-        solrRealQuery.set(CursorMarkParams.CURSOR_MARK_PARAM, cursorMark);
+        if (request.deduplicateField == null) { // Plain cursorMark
+          solrQuery.set(CursorMarkParams.CURSOR_MARK_PARAM, cursorMark);
+        } else if (lastStreamDeduplicateValue == null) { // Simulated cursorMark initial call
+          solrQuery.setQuery(userQuery);
+        } else {  // Simulated cursorMark subsequent call
+          solrQuery.setQuery(String.format(
+                  Locale.ROOT, "(%s) AND %s:{%s TO *]", // Range query with non-inclusive start and open end
+                  userQuery, request.deduplicateField, SolrUtils.createPhrase(lastDeduplicateValue)));
+        }
       }
-      QueryResponse rsp = request.solrClient.query(solrRealQuery, METHOD.POST);
-      undelivered = rsp.getResults();
 
+      // Perform request and update depleted & paging variables
+      solrRequests.incrementAndGet();
+      QueryResponse rsp = request.solrClient.query(solrQuery, METHOD.POST);
+      undelivered = rsp.getResults();
+      if (undelivered.size() < solrQuery.getRows() || rsp.getResults().getNumFound() <= solrQuery.getRows()) {
+        queryDepleted = true;
+      }
+      if (request.usePaging && request.deduplicateField != null && !undelivered.isEmpty()) {
+        lastDeduplicateValue = SolrUtils.fieldValueToString(
+                undelivered.get(undelivered.size()-1).getFieldValue(request.deduplicateField));
+      }
+
+      // Expand or contract result set based on options
       if (request.deduplicateField != null) {
         streamDeduplicate(undelivered);
       }
@@ -445,17 +471,20 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
         undelivered.remove(undelivered.size()-1);
       }
 
-      // Only deliver the fields that were requested
+      // Reduce documents to contain requested fields only
       undelivered.forEach(this::reduceAndSortFields);
 
-      // Has the last page been reached?
-      String newCursormark = request.usePaging ? rsp.getNextCursorMark() : cursorMark;
-      if (newCursormark.equals(cursorMark)) { // No more documents
-        cursorMark = STOP_PAGING;
-      } else {
-        cursorMark = newCursormark;
-      }
-      solrRealQuery.set(CursorMarkParams.CURSOR_MARK_PARAM, cursorMark);
+      // Prepare for next page
+      if (!request.usePaging) { // No paging
+        queryDepleted = true;
+      } else if (request.deduplicateField == null) { // Plain cursorMark
+        String newCursormark = rsp.getNextCursorMark();
+        if (newCursormark.equals(cursorMark)) { // No more documents for this query
+          queryDepleted = true;
+        } else {
+          solrQuery.set(CursorMarkParams.CURSOR_MARK_PARAM, newCursormark);
+        }
+      } // Simulated cursorMark is handled right after the raw response from the query
 
       // Loop as deduplication & unique might mean that the current batch is empty
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -364,14 +364,16 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
       }
 
       SolrQuery solrRealQuery = solrQuery;
-      if (request.isMultiQuery() && solrBatchQuery == null) { // Multi-query
-        if (!queries.hasNext()) {
-          hasFinished = true;
-          return null;
+      if (request.isMultiQuery()) {   // Multi-query
+        if (solrBatchQuery == null) { // Move to next queri in multi-query
+          if (!queries.hasNext()) {
+            hasFinished = true;
+            return null;
+          }
+          solrBatchQuery = SolrUtils.deepCopy(solrQuery).setQuery(queries.next());
+          solrBatchQuery.set(CursorMarkParams.CURSOR_MARK_PARAM,
+                             solrQuery.get(CursorMarkParams.CURSOR_MARK_PARAM, CursorMarkParams.CURSOR_MARK_START));
         }
-        solrBatchQuery = SolrUtils.deepCopy(solrQuery).setQuery(queries.next());
-        solrBatchQuery.set(CursorMarkParams.CURSOR_MARK_PARAM,
-                           solrQuery.get(CursorMarkParams.CURSOR_MARK_PARAM, CursorMarkParams.CURSOR_MARK_START));
         solrRealQuery = solrBatchQuery;
       }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -47,7 +47,6 @@ import static org.apache.commons.lang3.StringUtils.join;
 // TODO: Add support for redirects; needs to work with expandResources
 // TODO: Add support for revisits; needs (W)ARC lookup and needs to work with expandResources
 // TODO: Add optional graph traversal of JavaScript & CSS-includes with expandResources
-// TODO: Avoid extra paging request by looking at numFound and counting received documents
 
 /**
  * Cursormark based chunking search client allowing for arbitrary sized result sets.

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/Processing.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/Processing.java
@@ -71,10 +71,14 @@ public class Processing {
     public static <T> Stream<T> batch(Stream<Callable<T>> jobs, int batchSize) {
         return CollectionUtils.splitToLists(jobs, batchSize).
                 flatMap(batch -> {
+                    long startTime = System.currentTimeMillis();
                     try {
                         return executorService.invokeAll(batch).stream();
                     } catch (InterruptedException e) {
                         throw new RuntimeException("Iterrupted while waiting for batch processing", e);
+                    } finally {
+                        log.debug("Batch processed {} jobs in {} ms",
+                                  batch.size(), System.currentTimeMillis()-startTime);
                     }
                 }).
                 map(future -> {

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -14,9 +14,11 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class SolrUtils {
@@ -265,5 +267,28 @@ public class SolrUtils {
         extended[0] = str;
         System.arraycopy(additions, 0, extended, 1, additions.length);
         return extended;
+    }
+
+    /**
+     * Convert the given Solr field value to a String.
+     * <p>
+     * For most values this is a simple toString, but
+     * Dates are converted using {@link DateUtils#getSolrDateFull(Date)} and Collections are expanded.
+     * @param value a value from a Solr field.
+     * @return a String representation of the given Solr field value or null if the input was null;
+     */
+    public static String fieldValueToString(Object value) {
+        if (value == null) {
+            return null;
+        }
+        if (value instanceof Date) {
+            return DateUtils.getSolrDate((Date) value);
+        }
+        if (value instanceof Collection) {
+            return ((Collection<?>)value).stream().
+                    map(SolrUtils::fieldValueToString).
+                    collect(Collectors.joining(", ", "[", "]"));
+        }
+        return Objects.toString(value);
     }
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/UrlUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/UrlUtils.java
@@ -1,5 +1,9 @@
 package dk.kb.netarchivesuite.solrwayback.util;
 
+import dk.kb.netarchivesuite.solrwayback.normalise.Normalisation;
+
+import java.net.IDN;
+import java.net.URL;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -93,6 +97,31 @@ public class UrlUtils {
         String[] tokens= url.split("/");
         return tokens[tokens.length-1];
 
+    }
+
+    public static String punyCodeAndNormaliseUrl(String url) throws Exception {
+        if (!(url.startsWith("http://") || url.startsWith("https://"))) {
+            throw new Exception("Url not starting with http:// or https://");
+        }
+
+        URL uri = new URL(url);
+        String hostName = uri.getHost();
+        String hostNameEncoded = IDN.toASCII(hostName);
+
+        String path = uri.getPath();
+        if ("".equals(path)) {
+            path = "/";
+        }
+        String urlQueryPath = uri.getQuery();
+        String urlPunied = null;
+        if (urlQueryPath == null) {
+             urlPunied = "http://" + hostNameEncoded + path;
+        }
+        else {
+            urlPunied = "http://" + hostNameEncoded + path +"?"+ urlQueryPath;
+        }
+        String urlPuniedAndNormalized = Normalisation.canonicaliseURL(urlPunied);
+        return urlPuniedAndNormalized;
     }
 }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/UrlUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/UrlUtils.java
@@ -168,9 +168,9 @@ public class UrlUtils {
      *
      * If anything goes wrong during parsing and handling, a simple {@code url:"<url>"} query is returned.
      *
-     * Note: As this produces a query with multiple elements, care should be taken to set
-     * {@link SRequest#queryBatchSize} fairly low, e.g. {@code 100}, if {@link SRequest#queries(Stream)}} is used with
-     * multiple queries from this method. If not, the default Solr limit of 1024 boolean clauses can easily be exceeded.
+     * Note: This should normally NOT be used with {@link SRequest#queries(Stream)}} as it is likely to match multiple
+     * documents and give a lot of false positives. The typical use case would be for dedicated URL search with the
+     * returned documents either being showed in ranked order or pruned so that only the first document is used.
      * @param url a HTTP-URL: Must start with {@code http://} or {@code https://}
      * @return a Solr query for the URL that allows partial matching on arguments.
      */

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/UrlUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/UrlUtils.java
@@ -102,6 +102,19 @@ public class UrlUtils {
 
     }
 
+    /**
+     * Safe version of {@link #punyCodeAndNormaliseUrl(String)} where null is returned if an Exception is thrown.
+     * @param url any URL, but only HTTP and HTTPS are handled.
+     * @return the URL in punicode (if needed) form and normalised, null in case of Exceptions.
+     */
+    public static String punyCodeAndNormaliseUrlSafe(String url) {
+        try {
+            return punyCodeAndNormaliseUrl(url);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
     public static String punyCodeAndNormaliseUrl(String url) throws Exception {
         if (!(url.startsWith("http://") || url.startsWith("https://"))) {
             throw new Exception("Url not starting with http:// or https://");

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/normalize/PunyEncodeAndNormaliseTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/normalize/PunyEncodeAndNormaliseTest.java
@@ -2,19 +2,12 @@ package dk.kb.netarchivesuite.solrwayback.normalize;
 
 import static org.junit.Assert.*;
 
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.IOException;
-
 import dk.kb.netarchivesuite.solrwayback.normalise.Normalisation;
 import dk.kb.netarchivesuite.solrwayback.normalise.Normalisation.NormaliseType;
-import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
-import org.junit.Before;
+import dk.kb.netarchivesuite.solrwayback.util.UrlUtils;
 import org.junit.Test;
 
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
-import dk.kb.netarchivesuite.solrwayback.facade.Facade;
-import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
 
 
 public class PunyEncodeAndNormaliseTest extends UnitTestUtils {
@@ -25,26 +18,26 @@ public class PunyEncodeAndNormaliseTest extends UnitTestUtils {
         
         Normalisation.setType(NormaliseType.NORMAL);
         String url="http://www.test.dk/ABC.cfm?value=27";        
-        String urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+        String urlPunyNorm= UrlUtils.punyCodeAndNormaliseUrl(url);
         assertEquals("http://test.dk/abc.cfm?value=27", urlPunyNorm);
         
         
         url="http://test.dk/abc.cfm?value=27&value2=Z.Y";
-        urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+        urlPunyNorm= UrlUtils.punyCodeAndNormaliseUrl(url);
         assertEquals("http://test.dk/abc.cfm?value=27&value2=z.y", urlPunyNorm);
         
         
         url="http://pølser.dk/pølseguf.html?pølse=Medister";
-        urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+        urlPunyNorm= UrlUtils.punyCodeAndNormaliseUrl(url);
         assertEquals("http://xn--plser-vua.dk/pølseguf.html?pølse=medister", urlPunyNorm);
         
         
         url="http://www.pølser.dk/pølseguf.html?pølse=Medister"; //normal normaliser removes www
-        urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+        urlPunyNorm= UrlUtils.punyCodeAndNormaliseUrl(url);
         assertEquals("http://xn--plser-vua.dk/pølseguf.html?pølse=medister", urlPunyNorm);
         
         url="http://www.pølser.dk/"; //normal normaliser removes www 
-        urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+        urlPunyNorm= UrlUtils.punyCodeAndNormaliseUrl(url);
         assertEquals("http://xn--plser-vua.dk/", urlPunyNorm);
 
         
@@ -55,15 +48,15 @@ public class PunyEncodeAndNormaliseTest extends UnitTestUtils {
         Normalisation.setType(NormaliseType.LEGACY);
        
         String url="http://www.pølser.dk"; //normal should NOT remove www. 
-        String urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+        String urlPunyNorm= UrlUtils.punyCodeAndNormaliseUrl(url);
         assertEquals("http://www.xn--plser-vua.dk/", urlPunyNorm);
 
          url="http://www.pølser.dk/"; //normal should NOT remove www. 
-         urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+         urlPunyNorm= UrlUtils.punyCodeAndNormaliseUrl(url);
          assertEquals("http://www.xn--plser-vua.dk/", urlPunyNorm);
         
          url="http://www.pølser.dk/pølseguf.html?pølse=ostepølse"; //legacy should remove www 
-         urlPunyNorm= Facade.punyCodeAndNormaliseUrl(url);
+         urlPunyNorm= UrlUtils.punyCodeAndNormaliseUrl(url);
          assertEquals("http://xn--plser-vua.dk/pølseguf.html?pølse=ostepølse", urlPunyNorm);
          
     }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterTest.java
@@ -69,6 +69,7 @@ public class HtmlParserUrlRewriterTest {
 
     @Test
     public void testCSS2Rewriting() throws Exception {
+        // TODO: FIXME: This uses the port from ~/solrwayback.properties instead of port 0000 stated in @Before
         assertRewrite("css2", 3, 2);
     }
 
@@ -153,7 +154,7 @@ public class HtmlParserUrlRewriterTest {
                 input, "http://example.com/somefolder/", "2020-04-30T13:07:00",
                 RewriteTestHelper.createOXResolver(expectedNotFound >= 0));
 
-        assertEquals("The result should be as expected for test '" + testPrefix + "'",
+        assertEquals("The result should be as expected for test '" + testPrefix + "' ",
                      normalise(expected), normalise(rewritten.getReplaced()));
         assertEquals("The number of replaced links should be as expected",
                      expectedReplaced, rewritten.getNumberOfLinksReplaced());

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrTestClient.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrTestClient.java
@@ -12,6 +12,7 @@ public class NetarchiveSolrTestClient extends NetarchiveSolrClient{
    */
   public static void initializeOverLoadUnitTest(EmbeddedSolrServer server) {
     solrServer=server;
+    noCacheSolrServer=server;
     instance = new NetarchiveSolrTestClient();
     log.info("SolrClient initialized with embedded solr for unittest");
   }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/UrlResolveTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/UrlResolveTest.java
@@ -236,7 +236,7 @@ public class UrlResolveTest {
     @Test
     public void testTimeProximityLenient() {
         final String URL_2 = "https://www.EXAMPLE.org/foo?bar=ged&zoo=ooling";
-        final String URL_2_FAULTY = "https://www.EXAMPLE.org/foo?bar=hest&zoo=ooling";
+        final String URL_2_FAULTY = "https://www.EXAMPLE.org/foo?bar=hest&zoo=ooling"; // hest
         final String FIELDS = "id, url, url_norm";
 
         {
@@ -269,8 +269,9 @@ public class UrlResolveTest {
             assertEquals("There should be a change to the number of successful lenient attempts for lenient " +
                          "search with no direct url_norm match",
                          success+1, NetarchiveSolrClient.instance.getLenientSuccesses());
-            assertEquals("The ID of the returned document should as expected (the one nearest in similarity)",
-                         "doc_1_old", docs.get(0).getFieldValue("id").toString());
+            assertEquals("The ID of the returned document should as expected (the one nearest in URL similarity, " +
+                         "secondarily time)",
+                         "doc_2_new", docs.get(0).getFieldValue("id").toString());
         }
     }
 

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/UrlResolveTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/UrlResolveTest.java
@@ -1,0 +1,214 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.solr;
+
+import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
+import dk.kb.netarchivesuite.solrwayback.util.DateUtils;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
+import org.apache.solr.common.SolrDocument;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.core.CoreContainer;
+import org.apache.solr.core.NodeConfig;
+import org.apache.solr.core.SolrCore;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ */
+public class UrlResolveTest {
+    private static final Logger log = LoggerFactory.getLogger(UrlResolveTest.class);
+
+    private static final String SOLR_HOME = "target/test-classes/solr";
+    private static CoreContainer coreContainer= null;
+    private static ConvenientEmbeddedSolrServer solr = null;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        log.info("Setting up embedded server");
+
+        PropertiesLoader.initProperties();
+
+        coreContainer = new CoreContainer(SOLR_HOME);
+        coreContainer.load();
+        solr = new ConvenientEmbeddedSolrServer(coreContainer, "netarchivebuilder");
+        NetarchiveSolrTestClient.initializeOverLoadUnitTest(solr);
+
+        // Remove any items from previous executions:
+        solr.deleteByQuery("*:*");
+
+        fillSolr();
+        SolrGenericStreaming.setDefaultSolrClient(solr);
+        log.info("Embedded server ready");
+    }
+
+    private static void fillSolr() throws SolrServerException, IOException {
+        log.info("Filling embedded server with documents");
+        final Random r = new Random(87); // Random but not too random
+
+        solr.addDoc("id", "doc_1",
+                    "host", "example.org",
+                    "url_norm", "http example org foo bar hest zoo pling",
+                    "url", "https://www.EXAMPLE.org/foo?bar=hest&zoo=pling",
+                    "url_norm", "http://example.org/foo?bar=hest&zoo=pling"
+        );
+        solr.addDoc("id", "doc_2",
+                    "host", "example.org",
+                    "url_search", "http example org foo bar ged zoo ooling",
+                    "url", "https://www.EXAMPLE.org/foo?bar=ged&zoo=ooling",
+                    "url_norm", "http://example.org/foo?bar=ged&zoo=ooling"
+        );
+
+        solr.commit();
+    }
+
+    @Test
+    public void testLenientNoTrigger() {
+        final String URL_1 = "https://www.EXAMPLE.org/foo?bar=hest&zoo=pling";
+        final String URL_2_PARTIAL = "https://www.EXAMPLE.org/foo?bar=hest&zoo=ooling"; // hest is intentionally wrong
+        final List<String> fields = Arrays.asList("id", "url", "url_norm");
+
+        {
+            long attempts = NetarchiveSolrClient.instance.getLenientAttempts();
+            long success = NetarchiveSolrClient.instance.getLenientSuccesses();
+            Stream<SolrDocument> docs = NetarchiveSolrClient.getInstance().searchURLs(fields, Stream.of(URL_1));
+            long found = docs.count();
+            assertEquals("The right amount of documents should be located for a matching search", 1, found);
+            assertEquals("There should be a no change to the number of lenient attempts for matching search",
+                         attempts, NetarchiveSolrClient.instance.getLenientAttempts());
+            assertEquals("There should be a no change to the number of successful lenient attempts for matching search",
+                         success, NetarchiveSolrClient.instance.getLenientSuccesses());
+        }
+    }
+
+    @Test
+    public void testLenientTriggerSucces() {
+        final String URL_2_PARTIAL = "https://www.EXAMPLE.org/foo?bar=hest&zoo=ooling"; // hest is intentionally wrong
+        final List<String> fields = Arrays.asList("id", "url", "url_norm");
+// url:"https://www.EXAMPLE.org/foo?bar=hest&zoo=ooling"^200 OR url_norm:"http://example.org/foo?bar=hest&zoo=ooling"^100 OR (host:"example.org" AND url_search:"foo" AND (host:"example.org" OR url_search:"bar=hest" OR url_search:"zoo=ooling"))
+        {
+            long attempts = NetarchiveSolrClient.instance.getLenientAttempts();
+            long success = NetarchiveSolrClient.instance.getLenientSuccesses();
+            Stream<SolrDocument> docs = NetarchiveSolrClient.getInstance().searchURLs(fields, Stream.of(URL_2_PARTIAL));
+            long found = docs.count();
+            assertEquals("The right amount of documents should be located for a lenient search", 1, found);
+            assertEquals("There should be one change to the number of lenient attempts for lenient search",
+                         attempts+1, NetarchiveSolrClient.instance.getLenientAttempts());
+            assertEquals("There should be one change to the number of successful lenient attempts for lenient search",
+                         success+1, NetarchiveSolrClient.instance.getLenientSuccesses());
+        }
+    }
+
+    @Test
+    public void testLenientTriggerFail() {
+        final String URL_NONEXISTING = "https://www.EXAMPLE.org/drop?bar=ged&zoo=ooling"; // drop is wrong
+        final List<String> fields = Arrays.asList("id", "url", "url_norm");
+// url:"https://www.EXAMPLE.org/foo?bar=hest&zoo=ooling"^200 OR url_norm:"http://example.org/foo?bar=hest&zoo=ooling"^100 OR (host:"example.org" AND url_search:"foo" AND (host:"example.org" OR url_search:"bar=hest" OR url_search:"zoo=ooling"))
+        {
+            long attempts = NetarchiveSolrClient.instance.getLenientAttempts();
+            long success = NetarchiveSolrClient.instance.getLenientSuccesses();
+            Stream<SolrDocument> docs = NetarchiveSolrClient.getInstance().searchURLs(fields, Stream.of(URL_NONEXISTING));
+            long found = docs.count();
+            assertEquals("The right amount of documents should be located for a lenient search", 0, found);
+            assertEquals("There should be one change to the number of lenient attempts for lenient search",
+                         attempts+1, NetarchiveSolrClient.instance.getLenientAttempts());
+            assertEquals("There should be no change to the number of successful lenient attempts for lenient search",
+                         success, NetarchiveSolrClient.instance.getLenientSuccesses());
+        }
+    }
+
+    private static void addDoc(int id, Random r) throws SolrServerException, IOException {
+        final String[] CRAWL_TIMES = new String[]{
+                "2018-03-15T12:31:51Z",
+                "2019-03-15T12:31:51Z",
+                "2020-03-15T12:31:51Z",
+                "2021-03-15T12:31:51Z"
+        };
+        SolrInputDocument document = new SolrInputDocument();
+
+        document.setField("id", "doc_" + id);
+        document.addField("source_file_offset", id);
+        document.addField("title", "title_" + id%10);
+        document.addField("url", "https://example.COM/" + id%10); // %10 to get duplicates
+        document.addField("url_norm", "http://example.com/" + id%10);
+        document.addField("record_type","response");
+        document.addField("source_file_path", "some.warc_" + id);
+        document.addField("links", Arrays.asList("http://example.com/everywhere", "http://example.com/mod10_" + id % 10));
+        document.addField("status_code", "200");
+        document.setField("crawl_date", DateUtils.solrTimestampToJavaDate(CRAWL_TIMES[r.nextInt(CRAWL_TIMES.length)]));
+        solr.add(document);
+    }
+
+    private static class ConvenientEmbeddedSolrServer extends EmbeddedSolrServer {
+        public ConvenientEmbeddedSolrServer(Path solrHome, String defaultCoreName) {
+            super(solrHome, defaultCoreName);
+        }
+
+        public ConvenientEmbeddedSolrServer(NodeConfig nodeConfig, String defaultCoreName) {
+            super(nodeConfig, defaultCoreName);
+        }
+
+        public ConvenientEmbeddedSolrServer(SolrCore core) {
+            super(core);
+        }
+
+        public ConvenientEmbeddedSolrServer(CoreContainer coreContainer, String coreName) {
+            super(coreContainer, coreName);
+        }
+
+        /**
+         * Create a SolrDocument from the given content and add it to the server.
+         * Does not call {@link #commit()}.
+         * @param content content for a SolrDocument.
+         */
+        public void addDoc(Map<String, Object> content) {
+            SolrInputDocument document = new SolrInputDocument();
+            content.forEach(document::addField);
+            try {
+                solr.add(document);
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to add document", e);
+            }
+        }
+
+        /**
+         * Somewhat hacky convenience method for constructing a map and calling {@link #addDoc(Map)}.
+         * Takes "pairs" of [String, Object] as [key, value].
+         *
+         * With Java 9 we could use {@code Map.of(...)}, but this is Java 8.
+         */
+        public void addDoc(Object... keyValues) {
+            Map<String, Object> map = new HashMap<>();
+            for (int i = 0 ; i < keyValues.length ; i+=2) {
+                map.put((String) keyValues[i], keyValues[i + 1]);
+            }
+            addDoc(map);
+        }
+    }
+}

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/UrlResolveTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/UrlResolveTest.java
@@ -45,7 +45,7 @@ import static org.junit.Assert.assertEquals;
 public class UrlResolveTest {
     private static final Logger log = LoggerFactory.getLogger(UrlResolveTest.class);
 
-    private static final String SOLR_HOME = "target/test-classes/solr";
+    private static final String SOLR_HOME = "target/test-classes/solr_url_resolve";
     private static CoreContainer coreContainer= null;
     private static ConvenientEmbeddedSolrServer solr = null;
 

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/UrlResolveTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/UrlResolveTest.java
@@ -23,6 +23,8 @@ import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.CoreContainer;
 import org.apache.solr.core.NodeConfig;
 import org.apache.solr.core.SolrCore;
+import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -45,7 +47,7 @@ import static org.junit.Assert.assertEquals;
 public class UrlResolveTest {
     private static final Logger log = LoggerFactory.getLogger(UrlResolveTest.class);
 
-    private static final String SOLR_HOME = "target/test-classes/solr_url_resolve";
+    private static final String SOLR_HOME = "target/test-classes/solr";
     private static CoreContainer coreContainer= null;
     private static ConvenientEmbeddedSolrServer solr = null;
 
@@ -66,6 +68,15 @@ public class UrlResolveTest {
         fillSolr();
         SolrGenericStreaming.setDefaultSolrClient(solr);
         log.info("Embedded server ready");
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @AfterClass
+    public static void tearDown() throws Exception {
+      coreContainer.shutdown();
+      solr.close();
     }
 
     private static void fillSolr() throws SolrServerException, IOException {

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/util/UrlUtilsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/util/UrlUtilsTest.java
@@ -91,5 +91,50 @@ public class UrlUtilsTest {
     url="test/images/horse.png"; // only a relative url
     assertFalse(UrlUtils.isUrlWithDomain(url));    
   }
-    
+
+  @Test
+  public void testLenientURLQueryNoArgs() {
+      assertEquals("url:\"http://example.com/\"^200 OR url_norm:\"http://example.com/\"^100",
+                   UrlUtils.lenientURLQuery("http://example.com/"));
+      assertEquals("url:\"https://www.EXAMPLE.com/\"^200 OR url_norm:\"http://example.com/\"^100",
+                   UrlUtils.lenientURLQuery("https://www.EXAMPLE.com/"));
+  }
+
+  @Test
+  public void testLenientURLQueryArgs() {
+      assertEquals(("url:\"http://example.com/IMAGES/search?q=horse&fq=animals&_=67890\"^200 OR " +
+                   "url_norm:\"http://example.com/images/search?q=horse&fq=animals&_=67890\"^100 OR (" +
+                   "host:\"example.com\" AND " +
+                   "url_search:\"images/search\" AND" +
+                   " (host:\"example.com\" OR" +
+                   " url_search:\"q=horse\"" +
+                   " OR url_search:\"fq=animals\"" +
+                   " OR url_search:\"_=67890\")" +
+                   ")").replace(" ", "\n"),
+                   UrlUtils.lenientURLQuery("http://example.com/IMAGES/search?q=horse&fq=animals&_=67890").replace(" ", "\n"));
+  }
+
+  @Test
+  public void testLenientURLQueryArgsHost() {
+      assertEquals(("url:\"http://hello.example.com/IMAGES/search?q=horse\"^200 OR " +
+                   "url_norm:\"http://hello.example.com/images/search?q=horse\"^100 OR (" +
+                   "host:\"hello.example.com\" AND " +
+                   "url_search:\"images/search\" AND" +
+                   " (host:\"hello.example.com\" OR" +
+                   " url_search:\"q=horse\")" +
+                   ")").replace(" ", "\n"),
+                   UrlUtils.lenientURLQuery("http://hello.example.com/IMAGES/search?q=horse").replace(" ", "\n"));
+  }
+
+  @Test
+  public void testLenientURLQueryArgsWWW() {
+      assertEquals(("url:\"https://www.example.com/IMAGES/search?q=horse\"^200 OR " +
+                   "url_norm:\"http://example.com/images/search?q=horse\"^100 OR (" +
+                   "host:\"example.com\" AND " +
+                   "url_search:\"images/search\" AND" +
+                   " (host:\"example.com\" OR" +
+                   " url_search:\"q=horse\")" +
+                   ")").replace(" ", "\n"),
+                   UrlUtils.lenientURLQuery("https://www.example.com/IMAGES/search?q=horse").replace(" ", "\n"));
+  }
 }


### PR DESCRIPTION
Adds `UrlUtils.lenientURLQuery(url)` which takes an URL and creates a query that accepts partial match on arguments in the URL, as described in #255. The code is not tied to anything at the moment, as it is not clear when we want to be lenient.