### PR TITLE
Fix broken image search

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
@@ -77,10 +77,12 @@ public class ContentStreams {
                         query, SolrUtils.extend("content_type_norm:html", filterQueries)).stream().
                 filter(solrDoc -> solrDoc.containsKey("links_images") &&
                                   !solrDoc.getFieldValues("links_images").isEmpty());
+        Stream<Callable<Stream<SolrDocument>>> htmlCallbacks = htmlPages.
+                map(htmlPage -> createHTMLImageCallback(htmlPage, maxImagesPerPage));
 
         Stream<SolrDocument> htmlImages =
                 // TODO: Make the maxImages per page configurable
-                Processing.batch(htmlPages.map(htmlPage -> createHTMLImageCallback(htmlPage, maxImagesPerPage))).
+                Processing.batch(htmlCallbacks).
                         flatMap(Functions.identity());
 
         // Mix the two streams, 4 direct images for each 1 image derived from a page

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
@@ -1,23 +1,19 @@
 package dk.kb.netarchivesuite.solrwayback.parsers;
 
-import java.io.BufferedInputStream;
-
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-
-import java.util.Locale;
-import java.util.zip.GZIPInputStream;
-
 import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
+import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
+import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry.TYPE;
+import dk.kb.netarchivesuite.solrwayback.util.DateUtils;
 import dk.kb.netarchivesuite.solrwayback.util.InputStreamUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
-import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry.TYPE;
-import dk.kb.netarchivesuite.solrwayback.util.DateUtils;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.Locale;
+import java.util.zip.GZIPInputStream;
 
 public class WarcParser extends  ArcWarcFileParserAbstract {
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class SolrUtils {
@@ -97,8 +98,13 @@ public class SolrUtils {
      * @return an index document.
      */
     public static IndexDoc solrDocument2IndexDoc(SolrDocument doc) {
+        if (doc == null) {
+            throw new NullPointerException("The input SolrDocument was null");
+        }
         IndexDoc indexDoc = new IndexDoc();
-        indexDoc.setScore(Double.valueOf((float) doc.getFieldValue("score")));
+        if (doc.containsKey("score")) { // Not an essential value
+            indexDoc.setScore(Double.valueOf((float) doc.getFieldValue("score")));
+        }
         indexDoc.setId((String) doc.get("id"));
         indexDoc.setTitle((String) doc.get("title"));
         indexDoc.setSource_file_path((String) doc.get("source_file_path"));
@@ -133,10 +139,14 @@ public class SolrUtils {
         indexDoc.setHash((String) hash);
 
         Date date = (Date) doc.get("crawl_date");
+        if (date == null) {
+            throw new IllegalArgumentException("Mandatory crawl_date not available in SolrDocument");
+        }
         indexDoc.setCrawlDateLong(date.getTime());
         indexDoc.setCrawlDate(DateUtils.getSolrDate(date));
 
         // Cope with some minor schema variations:
+
         if ( doc.get("content_type") instanceof ArrayList) {
             ArrayList<String> types = (ArrayList<String>) doc.get("content_type");
             indexDoc.setMimeType(types.get(0));
@@ -182,7 +192,35 @@ public class SolrUtils {
      * @return an ARC entry descriptor.
      */
     public static ArcEntryDescriptor solrDocument2ArcEntryDescriptor(SolrDocument solrDoc) {
-        return indexDoc2ArcEntryDescriptor(solrDocument2IndexDoc(solrDoc));
+//        return indexDoc2ArcEntryDescriptor(solrDocument2IndexDoc(solrDoc));
+        ArcEntryDescriptor desc = new ArcEntryDescriptor();
+        desc.setUrl((String) solrDoc.get("url"));
+        desc.setUrl_norm((String) solrDoc.get("url_norm"));
+        desc.setSource_file_path((String) solrDoc.get("source_file_path"));
+        desc.setOffset((Long) solrDoc.get("source_file_offset"));
+        desc.setHash((String) solrDoc.get("hash"));
+        desc.setContent_type(getSingleStringValue(solrDoc, "content_type"));
+        return desc;
+    }
+
+    /**
+     * If the content of the field is a list, {@code Objects.toString(...)} of the first element is returned.
+     * If the content of the field is a single value, {@code Objects.toString(...)} of the element is returned.
+     * @param solrDoc a SolrDocument.
+     * @param field the field to get the first value from.
+     * @return a String representation of the first value in the field.
+     * @throws ArrayIndexOutOfBoundsException if a value could not be extracted.
+     */
+    public static String getSingleStringValue(SolrDocument solrDoc, String field) {
+        if (!solrDoc.containsKey(field)) {
+            log.warn("The field '{}' was not available in the SolrDocument", field);
+            throw new NullPointerException("The field '" + field + "' was not available in the SolrDocument");
+        }
+        Object value = solrDoc.get(field);
+        if (value instanceof List) {
+            return Objects.toString(((List<?>) value).get(0));
+        }
+        return Objects.toString(value);
     }
 
     /**
@@ -193,6 +231,9 @@ public class SolrUtils {
      * @return an ARC entry descriptor.
      */
     public static ArcEntryDescriptor indexDoc2ArcEntryDescriptor(IndexDoc indexDoc) {
+        if (indexDoc == null) {
+            throw new NullPointerException("The IndexDoc was null");
+        }
         ArcEntryDescriptor desc = new ArcEntryDescriptor();
         desc.setUrl(indexDoc.getUrl());
         desc.setUrl_norm(indexDoc.getUrl_norm());


### PR DESCRIPTION
The DTO conversion code tried to chain 2 other converters, but that did not work for the Solrdocuments from imageSearch as they were missing some fields for the intermediate DTO. This implementation creates the DTO directly from SolrDocument.

This closes #283