### PR TITLE
Ensure image uniqueness on findImages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,11 @@
       <version>20180130</version>
     </dependency>
 
+    <dependency>
+        <groupId>it.unimi.dsi</groupId>
+        <artifactId>fastutil</artifactId>
+        <version>8.5.9</version>
+    </dependency>
 
     <dependency>
       <groupId>org.netpreserve.openwayback</groupId>

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
@@ -91,7 +91,7 @@ public class ContentStreams {
 
         // Resolving images for a page is fairly heavy and tend to produce a lot of results.
         // As we prefer direct images (see the ration in "merged" below), it is likely that we don't need to
-        // process many htmlCallbacks before we have enough images from webpages, so we set the batch size very low.
+        // process many htmlCallbacks before we have enough images from webpages, so we set the batch size low.
         Stream<SolrDocument> htmlImages = Processing.batch(htmlCallbacks, 5).flatMap(Functions.identity());
 
         Stream<SolrDocument> merged =
@@ -100,7 +100,7 @@ public class ContentStreams {
             merged = merged.filter(new UniqueFilter(true, 20_000_000, "hash"));
         }
         // Mix the two streams, 4 direct images for each 1 image derived from a page
-        return merged.filter(new ThroughputTracker("ImageSearch:", "solrDocs", log, 100));
+        return merged.filter(new ThroughputTracker("findImages:", "images", log, 100));
     }
 
     /**

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.zip.GZIPOutputStream;
 
@@ -130,7 +131,10 @@ public class ContentStreams {
                 timeProximityDeduplication(isotime, "url_norm").
                 maxResults(maxImages); // No sense in returning more than maxImages from a sub-request
 
-        return request::stream;
+        // The strange construction where the stream is collected and then re-streamed is to ensure that the
+        // resolving of all images happens at evaluation time of the lambda, i.e. by the executor service.
+        // If the stream is returned directly, the evaluation will happen in the calling thread.
+        return () ->  request.stream().collect(Collectors.toList()).stream();
     }
 
     /**

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/export/ContentStreams.java
@@ -89,10 +89,7 @@ public class ContentStreams {
         Stream<Callable<Stream<SolrDocument>>> htmlCallbacks = htmlPages.
                 map(htmlPage -> createHTMLImageCallback(htmlPage, maxImagesPerPage));
 
-        // Resolving images for a page is fairly heavy and tend to produce a lot of results.
-        // As we prefer direct images (see the ration in "merged" below), it is likely that we don't need to
-        // process many htmlCallbacks before we have enough images from webpages, so we set the batch size low.
-        Stream<SolrDocument> htmlImages = Processing.batch(htmlCallbacks, 5).flatMap(Functions.identity());
+        Stream<SolrDocument> htmlImages = Processing.batch(htmlCallbacks).flatMap(Functions.identity());
 
         Stream<SolrDocument> merged =
                 CollectionUtils.interleave(Arrays.asList(directImages, htmlImages), Arrays.asList(4, 1));

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -149,7 +149,7 @@ public class Facade {
      * @see Facade#exportImages(boolean, boolean, String, String...)
      */
     public static ArrayList<ArcEntryDescriptor> findImages(String query, String... filterQueries) {
-        return ContentStreams.findImages(50, query, filterQueries).
+        return ContentStreams.findImages(true, 50, query, filterQueries).
                 limit(500).
                 map(SolrUtils::solrDocument2ArcEntryDescriptor).
                 collect(Collectors.toCollection(ArrayList::new));
@@ -456,11 +456,11 @@ public class Facade {
      * @param query image search query.
      * @param filterqueries Solr filter queries.
      * @return an InputStream where the product is a WARC.
-     * @see ContentStreams#findImages(int, String, String...)
+     * @see ContentStreams#findImages(boolean, int, String, String...) 
      * @see Facade#findImages(String, String...)
      */
     public static InputStream exportImages(boolean avoidDuplicates, boolean gzip, String query, String... filterqueries) {
-        Stream<SolrDocument> imageDocs = ContentStreams.findImages(50, query, filterqueries);
+        Stream<SolrDocument> imageDocs = ContentStreams.findImages(true,50, query, filterqueries);
 
         if (avoidDuplicates) {
             Set<Object> hashes = new HashSet<>();
@@ -505,7 +505,7 @@ public class Facade {
     }
 
     /**
-     * @deprecated use {@link #exportFields(String, Boolean, Boolean, String, Boolean, String, String, String...)}.
+     * @deprecated use {@link #exportFields(String, Boolean, Boolean, String, Boolean, String, Boolean, String, String...)}.
      */
     public static InputStream exportCvsStreaming(String q, String fq, String fields) throws Exception {
         // TODO test only allowed fields are selected!

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -450,7 +450,7 @@ public class Facade {
 
     /**
      * Search images both directly and through webpages. Export the result as WARC entries.
-     * @param avoidDuplicates if true, duplicates are removed.
+     * @param avoidDuplicates if true, duplicates are removed, based on image hash.
      *                        This requires holding a Set with all hashes from the result set in memory.
      * @param gzip if true each entry in the WARC stream is GZIPped.
      * @param query image search query.
@@ -460,12 +460,7 @@ public class Facade {
      * @see Facade#findImages(String, String...)
      */
     public static InputStream exportImages(boolean avoidDuplicates, boolean gzip, String query, String... filterqueries) {
-        Stream<SolrDocument> imageDocs = ContentStreams.findImages(true,50, query, filterqueries);
-
-        if (avoidDuplicates) {
-            Set<Object> hashes = new HashSet<>();
-            imageDocs = imageDocs.filter(solrDoc -> hashes.add(solrDoc.getFieldValue("hash")));
-        }
+        Stream<SolrDocument> imageDocs = ContentStreams.findImages(avoidDuplicates,50, query, filterqueries);
 
         return new StreamingSolrWarcExportBufferedInputStream(imageDocs, Integer.MAX_VALUE, gzip);
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -142,7 +142,7 @@ public class Facade {
 
     /**
      * Search images both directly and through webpages.
-     * Delegates to {@link ContentStreams#findImages(int, String, String...)}.
+     * Delegates to {@link ContentStreams#findImages(boolean, int, String, String...)}.
      * @param query Solr query.
      * @param filterQueries 0 or more Solr filter queries.
      * @return up to 500 images matching the searchText.

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -149,10 +149,15 @@ public class Facade {
      * @see Facade#exportImages(boolean, boolean, String, String...)
      */
     public static ArrayList<ArcEntryDescriptor> findImages(String query, String... filterQueries) {
-        return ContentStreams.findImages(true, 50, query, filterQueries).
-                limit(500).
-                map(SolrUtils::solrDocument2ArcEntryDescriptor).
-                collect(Collectors.toCollection(ArrayList::new));
+        long searchTimeMS = -System.currentTimeMillis();
+        ArrayList<ArcEntryDescriptor> images = ContentStreams.findImages(true, 50, query, filterQueries).
+                        limit(500).
+                        map(SolrUtils::solrDocument2ArcEntryDescriptor).
+                        collect(Collectors.toCollection(ArrayList::new));
+        searchTimeMS += System.currentTimeMillis();
+        log.debug("Found at least {} images in {}ms ({} images/second), searching for '{}'",
+                  images.size(), searchTimeMS, searchTimeMS == 0 ? "N/A" : (images.size()*1000/searchTimeMS), query);
+        return images;
     }
     
     public static ArrayList<ArcEntryDescriptor> oldfindImages(String searchText) throws Exception {

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -142,7 +142,7 @@ public class Facade {
 
     /**
      * Search images both directly and through webpages.
-     * Delegates to {@link ContentStreams#findImages(boolean, int, String, String...)}.
+     * Delegates to {@link ContentStreams#findImages(boolean, boolean, int, String, String...)}.
      * @param query Solr query.
      * @param filterQueries 0 or more Solr filter queries.
      * @return up to 500 images matching the searchText.
@@ -150,7 +150,8 @@ public class Facade {
      */
     public static ArrayList<ArcEntryDescriptor> findImages(String query, String... filterQueries) {
         long searchTimeMS = -System.currentTimeMillis();
-        ArrayList<ArcEntryDescriptor> images = ContentStreams.findImages(true, 50, query, filterQueries).
+        // TODO: This has goFast and will not be accurate. Should it be an option?
+        ArrayList<ArcEntryDescriptor> images = ContentStreams.findImages(true, true, 50, query, filterQueries).
                         limit(500).
                         map(SolrUtils::solrDocument2ArcEntryDescriptor).
                         collect(Collectors.toCollection(ArrayList::new));
@@ -461,11 +462,12 @@ public class Facade {
      * @param query image search query.
      * @param filterqueries Solr filter queries.
      * @return an InputStream where the product is a WARC.
-     * @see ContentStreams#findImages(boolean, int, String, String...) 
+     * @see ContentStreams#findImages(boolean, boolean, int, String, String...)
      * @see Facade#findImages(String, String...)
      */
     public static InputStream exportImages(boolean avoidDuplicates, boolean gzip, String query, String... filterqueries) {
-        Stream<SolrDocument> imageDocs = ContentStreams.findImages(avoidDuplicates,50, query, filterqueries);
+        // TODO: This has goFast==false and will be accurate but slow. Should it be an option?
+        Stream<SolrDocument> imageDocs = ContentStreams.findImages(avoidDuplicates, true,50, query, filterqueries);
 
         return new StreamingSolrWarcExportBufferedInputStream(imageDocs, Integer.MAX_VALUE, gzip);
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SRequest.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SRequest.java
@@ -158,6 +158,8 @@ public class SRequest {
      *                     a memory overhead linear to the number of results.
      * @return the SRequest adjusted with the provided value.
      * @see #maxUnique(Integer)
+     * @see #ensureUnique(Boolean)
+     * @see #uniqueHashing(boolean)
      */
     public SRequest ensureUnique(Boolean ensureUnique) {
         this.ensureUnique = Boolean.TRUE.equals(ensureUnique);
@@ -170,6 +172,8 @@ public class SRequest {
      *                  Default is {@link #DEFAULT_MAX_UNIQUE}.
      * @return the SRequest adjusted with the provided value.
      * @see #ensureUnique(Boolean)
+     * @see #uniqueFields(String...)
+     * @see #maxUnique(Integer)
      */
     public SRequest maxUnique(Integer maxUnique) {
         this.maxUnique = maxUnique;
@@ -178,14 +182,20 @@ public class SRequest {
 
     /**
      * Used for determining uniqueness when {@link #ensureUnique(Boolean)} is true.
+     * <p>
+     * Setting this value automatically sets {@link #ensureUnique(Boolean)} to true.
      * @param fields the fields to use for uniqueness. Default is {@code id}.
      * @return the SRequest adjusted with the provided value.
+     * @see #ensureUnique(Boolean)
+     * @see #uniqueHashing(boolean)
+     * @see #maxUnique(Integer)
      */
     public SRequest uniqueFields(String... fields) {
         if (fields.length == 0) {
             throw new IllegalArgumentException("No fields provided");
         }
         uniqueFields = Arrays.asList(fields);
+        ensureUnique = true;
         return this;
     }
 
@@ -194,6 +204,9 @@ public class SRequest {
      * far lower memory impact (factor 10+), but with the possibility of hash collisions.
      * @param useHashing if true, hashing is used for determining uniqueness. Default is false.
      * @return the SRequest adjusted with the provided value.
+     * @see #ensureUnique(Boolean)
+     * @see #uniqueFields(String...)
+     * @see #maxUnique(Integer)
      */
     public SRequest uniqueHashing(boolean useHashing) {
         useHashingForUnique = useHashing;

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -145,8 +145,9 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
 
   /**
    * The default SolrClient is simple and non-caching as streaming exports typically makes unique requests.
+   * Shared with {@link NetarchiveSolrClient}.
    */
-  static SolrClient defaultSolrClient = new HttpSolrClient.Builder(PropertiesLoader.SOLR_SERVER).build();
+  static SolrClient defaultSolrClient = NetarchiveSolrClient.noCacheSolrServer;
 
 
   /**
@@ -452,6 +453,7 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
 
       // Perform request and update depleted & paging variables
       solrRequests.incrementAndGet();
+      //log.debug("Issuing '{}'", SolrUtils.fieldValueToString(solrQuery));
       QueryResponse rsp = request.solrClient.query(solrQuery, METHOD.POST);
       undelivered = rsp.getResults();
       totalDelivered.addAndGet(undelivered.size());

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -416,6 +416,9 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
       if (queryDepleted) {
         if (request.isMultiQuery() && queries.hasNext()) {
           userQuery = queries.next();
+          if (userQuery.isEmpty()) {
+            continue;
+          }
           solrQuery.setQuery(userQuery);
           queryDepleted = false;
           if (request.usePaging) {

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -121,6 +121,7 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
   public static final String STOP_PAGING = "___STOP_PAGING___";
 
   static final AtomicLong solrRequests = new AtomicLong(0);
+  static final AtomicLong totalDelivered = new AtomicLong(0);
 
   private final SRequest request;
   private final SolrQuery originalSolrQuery; // The original SolrQuery from the SRequest. Never modify this!
@@ -432,7 +433,7 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
         }
       }
 
-      // Handle påaging (cursorMark) setup
+      // Handle paging (cursorMark) setup
       String cursorMark = solrQuery.get(CursorMarkParams.CURSOR_MARK_PARAM, CursorMarkParams.CURSOR_MARK_START);
       if (request.usePaging) {
         if (request.deduplicateField == null) { // Plain cursorMark
@@ -450,6 +451,8 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
       solrRequests.incrementAndGet();
       QueryResponse rsp = request.solrClient.query(solrQuery, METHOD.POST);
       undelivered = rsp.getResults();
+      totalDelivered.addAndGet(undelivered.size());
+      //log.debug("Got " + undelivered.size() + " hits with total delivered counter " + totalDelivered.get());
       if (undelivered.size() < solrQuery.getRows() || rsp.getResults().getNumFound() <= solrQuery.getRows()) {
         queryDepleted = true;
       }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -298,7 +298,7 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
       return;
     }
 
-    log.debug("Enabling group-based deduplication on '{}'", request.deduplicateField);
+    //log.debug("Enabling group-based deduplication on '{}'", request.deduplicateField);
     // group=true&group.field=url_norm&group.limit=1&group.format=simple&group.main=true
     solrQuery.set(GroupParams.GROUP, true);
     solrQuery.set(GroupParams.GROUP_FIELD, request.deduplicateField);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreaming.java
@@ -454,7 +454,14 @@ public class SolrGenericStreaming implements Iterable<SolrDocument> {
       // Perform request and update depleted & paging variables
       solrRequests.incrementAndGet();
       //log.debug("Issuing '{}'", SolrUtils.fieldValueToString(solrQuery));
-      QueryResponse rsp = request.solrClient.query(solrQuery, METHOD.POST);
+
+      QueryResponse rsp;
+      try {
+        rsp = request.solrClient.query(solrQuery, METHOD.POST);
+      } catch (HttpSolrClient.RemoteSolrException e) {
+        log.warn("RemoteSolrException for POST request '" + SolrUtils.fieldValueToString(solrQuery) + "'", e);
+        throw e;
+      }
       undelivered = rsp.getResults();
       totalDelivered.addAndGet(undelivered.size());
       //log.debug("Got " + undelivered.size() + " hits with total delivered counter " + totalDelivered.get());

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/UniqueFilter.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/UniqueFilter.java
@@ -83,12 +83,22 @@ public class UniqueFilter implements Predicate<SolrDocument> {
 
     @Override
     public boolean test(SolrDocument solrDoc) {
+        return test(getUniqueValue(solrDoc));
+    }
+
+    /**
+     * Perform uniqueness test on the given {@code fieldValue}. This is called directly from {@link #test(SolrDocument)}
+     * but can also be used for special processing where the field value has already been determined.
+     * @param fieldValue a values presumable from the configured {@link #fields} in a {@code SolrDocument}.
+     * @return true if the values has not been encountered before.
+     */
+    public synchronized boolean test(String fieldValue) {
         tests++;
         boolean ok;
         if (uniqueValues != null) { // values
-            ok = uniqueValues.add(getUniqueValue(solrDoc));
+            ok = uniqueValues.add(fieldValue);
         } else {
-            ok = uniqueHashes.add(getUniqueValue(solrDoc).hashCode());
+            ok = uniqueHashes.add(fieldValue.hashCode());
         }
         if (uniqueCount() > maxUnique) {
             log.warn("Throwing ArrayIndexOutOfBoundsException as the unique limit of {} has been reached", maxUnique);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/UniqueFilter.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/UniqueFilter.java
@@ -1,0 +1,116 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.solr;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import org.apache.solr.common.SolrDocument;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Acts as a uniqueness filter for a {@code Stream<SolrDocument>}, using the content from given fields as unique values.
+ * This filter holds values for all unique encountered documents in memory and thus does not scale indefinitely.
+ * When constructed, the maximum number of unique values to track is specified. If this limit is reached, an exception
+ * is thrown.
+ */
+public class UniqueFilter implements Predicate<SolrDocument> {
+    private static final Logger log = LoggerFactory.getLogger(UniqueFilter.class);
+
+    private final List<String> fields;
+    private final int maxUnique;
+    private final Set<String> uniqueValues;
+    private final IntSet uniqueHashes;
+
+    /**
+     * @param useHashing true, hashes of the values from the given fields are used for tracking instead of the
+     *                   values themselves. Using hashing vastly (factor 10+) reduce the memory footprint, but
+     *                   introduces the possibility of hash collisions and thereby does not guarantee uniqueness.
+     *                   Hashing is recommended unless there is a strict need for uniqueness.
+     * @param maxUnique the maximum number of unique elements before an exception is thrown.
+     * @param fields the fields to use for uniqueness tracking.
+     */
+    public UniqueFilter(boolean useHashing, int maxUnique, String... fields) {
+        this(useHashing, maxUnique, Arrays.asList(fields));
+    }
+
+    /**
+     * @param useHashing true, hashes of the values from the given fields are used for tracking instead of the
+     *                   values themselves. Using hashing vastly (factor 10+) reduce the memory footprint, but
+     *                   introduces the possibility of hash collisions and thereby does not guarantee uniqueness.
+     *                   Hashing is recommended unless there is a strict need for uniqueness.
+     * @param maxElements the maximum number of unique elements before an exception is thrown.
+     * @param fields the fields to use for uniqueness tracking.
+     */
+    public UniqueFilter(boolean useHashing, int maxElements, List<String> fields) {
+        if (fields.isEmpty()) {
+            throw new IllegalArgumentException("No fields provided");
+        }
+        this.fields = fields;
+        this.maxUnique = maxElements;
+        if (useHashing) {
+            uniqueHashes = new IntOpenHashSet();
+            uniqueValues = null;
+        } else {
+            uniqueHashes = null;
+            uniqueValues = new HashSet<>();
+        }
+    }
+
+    @Override
+    public boolean test(SolrDocument solrDoc) {
+        boolean ok;
+        if (uniqueValues != null) { // values
+            ok = uniqueValues.add(getUniqueValue(solrDoc));
+        } else {
+            ok = uniqueHashes.add(getUniqueValue(solrDoc).hashCode());
+        }
+        if (uniqueCount() > maxUnique) {
+            log.warn("Throwing ArrayIndexOutOfBoundsException as the unique limit of {} has been reached", maxUnique);
+            throw new ArrayIndexOutOfBoundsException(
+                    "The number of elements in the unique tracker exceeded the limit " + maxUnique +
+                    ". Processing has been stopped to avoid Out Of Memory errors");
+        }
+        return ok;
+    }
+
+    /**
+     * @return the number of unique values encountered.
+     */
+    public int uniqueCount() {
+        return uniqueValues != null ? uniqueValues.size() : uniqueHashes.size();
+    }
+
+    /**
+     * Construct the value used to check for uniqueness by concatenating the content from Solr fields.
+     * The fields used are defined as {@link #fields} when constructing the {@code Uniquefilter}.
+     * @param solrDoc a solrDoc containing at least {@link #fields}.
+     * @return concatenation of the field values.
+     */
+    private String getUniqueValue(SolrDocument solrDoc) {
+        return fields.stream().
+                map(field -> solrDoc.getFieldValue(field).toString()).
+                collect(Collectors.joining("_/_"));
+    }
+
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/CollectionUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/CollectionUtils.java
@@ -15,6 +15,8 @@
 package dk.kb.netarchivesuite.solrwayback.util;
 
 import com.google.common.collect.Iterators;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -28,6 +30,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class CollectionUtils {
+    private static final Logger log = LoggerFactory.getLogger(CollectionUtils.class);
 
     /**
      * Interleave the given Streams, passing 1 element from each non-depleted stream then starting over until there

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/Processing.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/Processing.java
@@ -40,8 +40,8 @@ public class Processing {
         final AtomicInteger counter = new AtomicInteger(0);
         @Override
         public Thread newThread(Runnable runnable) {
-            Thread t = new Thread("processing_" +counter.getAndIncrement());
-            t.setDaemon(true);
+            Thread t = new Thread(runnable, "processing_" +counter.getAndIncrement());
+            t.setDaemon(false);
             return t;
         }
     });

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/SolrUtils.java
@@ -9,6 +9,7 @@ import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrClient;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrDocumentList;
+import org.apache.solr.common.params.ModifiableSolrParams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,6 +19,7 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
@@ -323,6 +325,36 @@ public class SolrUtils {
         }
         if (value instanceof Date) {
             return DateUtils.getSolrDate((Date) value);
+        }
+        if (value instanceof String[]) {
+            return Arrays.toString((String[])value);
+        }
+        if (value instanceof int[]) {
+            return Arrays.toString((int[])value);
+        }
+        if (value instanceof long[]) {
+            return Arrays.toString((int[])value);
+        }
+        if (value instanceof float[]) {
+            return Arrays.toString((float[])value);
+        }
+        if (value instanceof double[]) {
+            return Arrays.toString((double[])value);
+        }
+        if (value instanceof ModifiableSolrParams) {
+            return value.getClass().getSimpleName() +
+                   "(" + fieldValueToString(((ModifiableSolrParams)value).getMap()) + ")";
+        }
+        if (value instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>)value;
+            return map.entrySet().stream().
+                    map(SolrUtils::fieldValueToString).
+                    collect(Collectors.joining(", ", "{", "}"));
+        }
+        if (value instanceof Map.Entry) {
+            Map.Entry<?, ?> entry = (Map.Entry<?, ?>)value;
+            return fieldValueToString(entry.getKey()) + "=" +
+                   fieldValueToString(entry.getValue());
         }
         if (value instanceof Collection) {
             return ((Collection<?>)value).stream().

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/ThroughputTracker.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/ThroughputTracker.java
@@ -1,0 +1,73 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.util;
+
+import org.slf4j.Logger;
+
+import java.util.function.Predicate;
+
+/**
+ * Keeps track of objects that passes through the stream and logs performance statistics at given intervals.
+ * <p>
+ * Technically it works as a filter, but it always passes the test. Add to a stream with
+ * {@code myStream.filter(new ThroughputTracker("ImageSearch:", "solrDocs", log, 100))}
+ * which will log statistics about Solrdocuments processes every 100 documents, as part of an image search.
+ * <p>
+ * Note: There is no automatic "final" logging when the stream is depleted. Call {@link #performLog()} for that.
+ */
+public class ThroughputTracker implements Predicate<Object> {
+    private final String prefix;
+    private final String designation;
+    private final Logger log;
+    private final long logInterval;
+
+    private long callCounter = 0;
+    private long nextLog;
+    private final long startTime = System.currentTimeMillis();
+
+    /**
+     * Create a tracker intended as a "side effect only" filter for a Stream.
+     * Every {@code logInterval} objects a message is logged to the given {@code log} at {@code debug} level.
+     * @param prefix      each log message starts with this.
+     * @param designation the object that is lokked, e.g. {@code images} or {@code solrDocs}.
+     * @param log         the Logger to use.
+     * @param logInterval how often statistics is logged.
+     */
+    public ThroughputTracker(String prefix, String designation, Logger log, long logInterval) {
+        this.prefix = prefix == null ? "" : prefix;
+        this.designation = designation == null ? "objects" : designation;
+        this.log = log;
+        this.logInterval = logInterval;
+        nextLog = logInterval;
+    }
+
+    @Override
+    public boolean test(Object o) {
+        if (++callCounter == nextLog) {
+            performLog();
+            nextLog += logInterval;
+        }
+        return true;
+    }
+
+    /**
+     * Trigger statistics logging.
+     */
+    public void performLog() {
+        long ms = System.currentTimeMillis()-startTime;
+        log.debug("{} {} {} encountered in {} ms: {} {}/s",
+                  prefix, callCounter, designation, ms, callCounter*1000/ms, designation);
+    }
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/ThroughputTracker.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/ThroughputTracker.java
@@ -54,7 +54,7 @@ public class ThroughputTracker implements Predicate<Object> {
     }
 
     @Override
-    public boolean test(Object o) {
+    public synchronized boolean test(Object o) {
         if (++callCounter == nextLog) {
             performLog();
             nextLog += logInterval;

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/ThroughputTracker.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/ThroughputTracker.java
@@ -67,7 +67,7 @@ public class ThroughputTracker implements Predicate<Object> {
      */
     public void performLog() {
         long ms = System.currentTimeMillis()-startTime;
-        log.debug("{} {} {} encountered in {} ms: {} {}/s",
+        log.debug("{} {} {} in {} ms: {} {}/s",
                   prefix, callCounter, designation, ms, callCounter*1000/ms, designation);
     }
 }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreamingTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreamingTest.java
@@ -250,6 +250,23 @@ public class SolrGenericStreamingTest {
     }
 
     @Test
+    public void testUnique() {
+        SRequest request = SRequest.builder().
+                query("*:*").
+                fields("id").
+                ensureUnique(true).
+                uniqueFields("url");
+
+        assertEquals("The expected number of documents should be returned when enabling uniqueness on 'url'",
+                     10, request.stream().count());
+
+        assertEquals("The expected number of documents should be returned when using hashing",
+                     10, request.uniqueHashing(true).stream().count());
+
+
+    }
+
+    @Test
     public void testGrouping() {
         List<SolrDocument> docs = SRequest.builder().
                 query("*:*").

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/util/ProcessingTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/util/ProcessingTest.java
@@ -1,15 +1,18 @@
 package dk.kb.netarchivesuite.solrwayback.util;
 
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Spliterators;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static org.junit.Assert.assertEquals;
 
@@ -45,6 +48,65 @@ public class ProcessingTest {
             assertEquals("Result #" + i + " should be as expected",
                          Integer.valueOf(i), results.get((i)));
         }
+    }
+
+    @Test
+    public void triggerEvaluation1() throws InterruptedException {
+        AtomicInteger evaluations = new AtomicInteger(0);
+        Stream<Callable<Stream<Integer>>> callables =
+                IntStream.range(0, 10).boxed().
+                        map(i -> getCallback(evaluations));
+
+        Stream<Stream<Integer>> result = Processing.batch(callables, 3);
+        Thread.sleep(50);
+        assertEquals("The evaluation count should be zero when nothing has been pulled", 0, evaluations.get());
+
+        Iterator<Stream<Integer>> iResult = result.iterator();
+        Iterator<Integer> inner1 = iResult.next().iterator();
+        inner1.next();
+        Thread.sleep(50);
+        assertEquals("The evaluation count should be 1 when first value has been pulled directly",
+                     1, evaluations.get());
+    }
+
+    // Disabled as it does not pass. Why is the evaluation eager (6 evaluations instead of 1)?
+    public void triggerEvaluationFlatmap() throws InterruptedException {
+        AtomicInteger evaluations = new AtomicInteger(0);
+        Stream<Callable<Stream<Integer>>> callables =
+                IntStream.range(0, 10).boxed().
+                        map(i -> getCallback(evaluations));
+
+        Stream<Integer> result = Processing.batch(callables, 3).flatMap(Function.identity());
+        Thread.sleep(50);
+        assertEquals("The evaluation count should be zero when nothing has been pulled", 0, evaluations.get());
+
+        Iterator<Integer> iResults = result.iterator();
+        iResults.next();
+        Thread.sleep(50);
+        assertEquals("The evaluation count should be 1 when first value has been pulled from flatMapped",
+                     1, evaluations.get());
+    }
+
+    private Callable<Stream<Integer>> getCallback(AtomicInteger evaluations) {
+        return () -> streamTwo(evaluations);
+    }
+    // Only evaluates when the stream is pulled
+    private Stream<Integer> streamTwo(AtomicInteger evaluations) {
+        Iterator<Integer> iterator = new Iterator<Integer>() {
+            int delivered = 0;
+            @Override
+            public boolean hasNext() {
+                return delivered != 2;
+            }
+
+            @Override
+            public Integer next() {
+                delivered++;
+                return evaluations.incrementAndGet();
+            }
+        };
+
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, 0), false);
     }
 
     @Test


### PR DESCRIPTION
The streaming implementation of image search did not enforce uniqueness of results. This pull request does that and closes #285.

Uniqueness comes at the cost of a maximum export size of 20M images. Uniqueness is determined by the Solr field `hash`, which is furthermore hashed to an `int`. This ensures a speed- and memory efficient tracker at the cost of possible hash collisions.

The limit of 20M is preliminary. It can probably be higher as an `Intset` from [fastutil](https://fastutil.di.unimi.it/) is used for holding hashes for encountered images.