### PR TITLE
Refine time frame and time scale on domain stats

### DIFF
--- a/src/js/src/assets/styles/results.scss
+++ b/src/js/src/assets/styles/results.scss
@@ -1185,6 +1185,10 @@ margin-left:40px;
   margin: 0 5px;
 }
 
+.timePeriodRefinerTimeScaleContainer select {
+  margin-left: 0;
+}
+
 .modalContainer .closeButton, .toolboxCloseButton {
   z-index:1;
   right:5px !important;

--- a/src/js/src/assets/styles/search.scss
+++ b/src/js/src/assets/styles/search.scss
@@ -592,12 +592,18 @@ img.imageEntry.noPointer {
 .domainContentContainer {
   padding:5px 15px 5px 15px;
 }
-
-.domainContentContainer input {
-  width:300px;
+.domainContentSettings {
+  display:flex;
 }
 
-.domainContentContainer .domainStatsButton,
+.domainContentContainer input {
+  width:280px;
+}
+
+.refiner {
+  padding-left:5px;
+}
+
 .linkGraphContainer .linkGraphButton {
   float: unset !important;
 	position: relative;

--- a/src/js/src/components/TimePeriodRefiner.vue
+++ b/src/js/src/components/TimePeriodRefiner.vue
@@ -1,14 +1,13 @@
 <template>
   <div class="timePeriodRefinerSettings">
     <div class="timePeriodRefinerPeriodContainer contain">
-      <label class="timePeriodRefinerLabel">Refine:</label>
       <label class="timePeriodRefinerLabel">Time frame:</label>
-      between
+      <span>between</span>
       <input v-model="startDateInput"
              placeholder="YYYY-MM-DD"
              :class="$_checkDate(startDateInput) ? '' : 'urlNotTrue'"
              @input="updateStartDate()">
-      and
+      <span>and</span>
       <input v-model="endDateInput" 
              placeholder="YYYY-MM-DD"
              :class="$_checkDate(endDateInput) ? '' : 'urlNotTrue'"

--- a/src/js/src/components/ToolboxComponents/ToolboxResources/domainStats.js
+++ b/src/js/src/components/ToolboxComponents/ToolboxResources/domainStats.js
@@ -23,7 +23,7 @@ export default {
                 },
                 {
                     data: ingoingLinks,
-                    label: 'Incoming links',
+                    label: 'Ingoing links',
                     fontColor: 'black',
                     yAxisID: 'links',
                     borderColor: '#009900',

--- a/src/js/src/services/RequestService.js
+++ b/src/js/src/services/RequestService.js
@@ -189,12 +189,16 @@ function getHarvestedPageResources(source_file_path, offset) {
   })
 }
 
-function getDomainStatistics(domain) {
-  const url = `services/statistics/domain/?domain=${domain}`
+function getDomainStatistics(domain, startDate, endDate, timeScale) {
+  let settings = ''
+  if (timeScale != null && timeScale != '') {
+      settings = '&startdate=' + startDate +'&enddate='+ endDate + '&scale=' + timeScale
+  }
+  const url = `services/statistics/domain/?domain=${domain + settings}`
   return axios.get(
     url).then(response => {
     return response.data
-  }).catch(error => {
+  }).catch((error) => {
     return Promise.reject(error)
   })
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
@@ -10,6 +10,9 @@ import java.net.URI;
 import java.net.URL;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.Period;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -41,6 +44,7 @@ import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ImageUrl;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
 import dk.kb.netarchivesuite.solrwayback.service.dto.TimestampsForPage;
+import dk.kb.netarchivesuite.solrwayback.service.dto.statistics.DomainStatistics;
 import dk.kb.netarchivesuite.solrwayback.service.dto.statistics.DomainYearStatistics;
 import dk.kb.netarchivesuite.solrwayback.service.exception.InternalServiceException;
 import dk.kb.netarchivesuite.solrwayback.service.exception.InvalidArgumentServiceException;
@@ -106,10 +110,22 @@ public class SolrWaybackResource {
   @GET
   @Path("statistics/domain")
   @Produces({ MediaType.APPLICATION_JSON})
-  public  ArrayList<DomainYearStatistics> statisticsDomain (@QueryParam("domain") String domain) throws SolrWaybackServiceException {
-      try {                                                                                                   
-        return Facade.statisticsDomain(domain);
-      } catch (Exception e) {         
+  public  List<DomainStatistics> statisticsDomain (@QueryParam("domain") String domain, @QueryParam("startdate") String startdate,
+          @QueryParam("enddate") String enddate, @QueryParam("scale") String scale) throws SolrWaybackServiceException {
+      int limit = 90;
+      LocalDate start = LocalDate.parse(startdate, DateTimeFormatter.ISO_DATE);
+      LocalDate end = LocalDate.parse(enddate, DateTimeFormatter.ISO_DATE);
+      
+      // If the period is too big for the scale, block the statistics
+      int buckets = calculateBucket(start, end, scale);
+      if (buckets > limit) {
+          String msg = "The defined period (" + buckets + ") is too large to match with the scale (limit: " + limit + " " + scale.toLowerCase() + "s)";
+          log.error(msg);
+          throw new InvalidArgumentServiceException(msg);
+      }
+      try {
+        return Facade.statisticsDomain(domain, start , end, scale);
+      } catch (Exception e) {
           throw handleServiceExceptions(e);
       }
   }
@@ -1087,6 +1103,36 @@ public class SolrWaybackResource {
     DateFormat formatOut= new SimpleDateFormat("yyyy-MM-dd_HH-mm-ss");
     String dateStr = formatOut.format(new Date());
     return template.replace("$DATETIME", dateStr);
+  }
+  
+
+  /**
+   * Calculate the period between start date and end date. The result is returned in the same unit
+   * as the scale
+   * @param start the start date
+   * @param end the end date
+   * @param scale the time scale (YEAR, MONTH, WEEK, DAY)
+   * @return the period between start date and end date
+   */
+  private int calculateBucket(LocalDate start, LocalDate end, String scale) {
+      Period period = Period.between(start, end);
+      int buckets = 0;
+      switch (scale) {
+          case "YEAR" :
+              buckets = period.getYears();
+              break;
+          case "MONTH" :
+              buckets = period.getYears() * 12 + period.getMonths();
+              break;
+          case "WEEK" :
+              buckets = period.getYears() * 52 + period.getMonths() * 4 + period.getDays() / 7;
+              break;
+          case "DAY" :
+          default :
+              buckets = period.getYears() * 365 + period.getMonths() * 30 + period.getDays();
+              break;
+      }
+      return buckets;
   }
   
   private SolrWaybackServiceException handleServiceExceptions(Exception e) {

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/dto/statistics/DomainStatistics.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/dto/statistics/DomainStatistics.java
@@ -1,0 +1,57 @@
+package dk.kb.netarchivesuite.solrwayback.service.dto.statistics;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+public class DomainStatistics {
+
+  private String date;
+  private int ingoingLinks;
+  private int sizeInKb;
+  private int uniquePages;
+  private String domain;
+  
+  public  DomainStatistics(){
+  }
+
+public String getDate() {
+    return date;
+}
+
+public void setDate(String date) {
+    this.date = date;
+}
+
+public int getIngoingLinks() {
+    return ingoingLinks;
+  }
+
+  public void setIngoingLinks(int ingoingLinks) {
+    this.ingoingLinks = ingoingLinks;
+  }
+
+  public int getSizeInKb() {
+    return sizeInKb;
+  }
+
+  public void setSizeInKb(int sizeInKb) {
+    this.sizeInKb = sizeInKb;
+  }
+
+  public int getTotalPages() {
+    return uniquePages;
+  }
+
+  public void setTotalPages(int totalPages) {
+    this.uniquePages = totalPages;
+  }
+
+  public String getDomain() {
+    return domain;
+  }
+
+  public void setDomain(String domain) {
+    this.domain = domain;
+  }
+
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -45,7 +45,7 @@ import dk.kb.netarchivesuite.solrwayback.service.dto.FacetCount;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
 import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDocShort;
 import dk.kb.netarchivesuite.solrwayback.service.dto.SearchResult;
-import dk.kb.netarchivesuite.solrwayback.service.dto.statistics.DomainYearStatistics;
+import dk.kb.netarchivesuite.solrwayback.service.dto.statistics.DomainStatistics;
 import dk.kb.netarchivesuite.solrwayback.service.exception.InvalidArgumentServiceException;
 import dk.kb.netarchivesuite.solrwayback.util.DateUtils;
 
@@ -1538,10 +1538,10 @@ public class NetarchiveSolrClient {
      * hyperloglog) Total size (of the unique pages). (not so precise due, tests
      * show max 10% error, less for if there are many pages)
      */
-    public DomainYearStatistics domainStatistics(String domain, int year) throws Exception {
+    public DomainStatistics domainStatistics(String domain, String startDate, String endDate) throws Exception {
 
-        DomainYearStatistics stats = new DomainYearStatistics();
-        stats.setYear(year);
+        DomainStatistics stats = new DomainStatistics();
+        stats.setDate(startDate);
         stats.setDomain(domain);
 
         String searchString = "domain:\"" + domain + "\"";
@@ -1551,7 +1551,7 @@ public class NetarchiveSolrClient {
         solrQuery.setQuery(searchString);
         solrQuery.set("facet", "false");
         solrQuery.addFilterQuery("content_type_norm:html AND status_code:200");
-        solrQuery.addFilterQuery("crawl_year:" + year);
+        solrQuery.addFilterQuery("crawl_date:[" + startDate + "T00:00:00Z TO " + endDate + "T00:00:00Z]");
         solrQuery.setRows(0);
         solrQuery.add("fl", "id");
         solrQuery.add("stats", "true");
@@ -1577,7 +1577,7 @@ public class NetarchiveSolrClient {
         solrQuery = new SolrQuery();
         solrQuery.setQuery("links_domains:\"" + domain + "\" -" + searchString); // links to, but not from same domain
         solrQuery.addFilterQuery("content_type_norm:html AND status_code:200");
-        solrQuery.addFilterQuery("crawl_year:" + year);
+        solrQuery.addFilterQuery("crawl_date:[" + startDate + "T00:00:00Z TO " + endDate + "T00:00:00Z]");
         solrQuery.setRows(0);
         solrQuery.add("stats", "true");
         solrQuery.add("fl", "id");


### PR DESCRIPTION
Same principle as for #272, now the user have the possibility to refine the time frame and time scale for the domain statistics.

I added a check : if the time frame contains more than 90 buckets (years, months, weeks, days), the graph is not generated (no solr interrogation) and a message is displayed.
The limit is fixed but can be added as a parameter.