### PR TITLE
Make field pruning of Solrdocuments more generic

### DIFF
--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreamingTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/SolrGenericStreamingTest.java
@@ -262,8 +262,6 @@ public class SolrGenericStreamingTest {
 
         assertEquals("The expected number of documents should be returned when using hashing",
                      10, request.uniqueHashing(true).stream().count());
-
-
     }
 
     @Test


### PR DESCRIPTION
This also fixes the failing unit tests