### PR TITLE
218 implement stats

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
@@ -54,6 +54,7 @@ public class PropertiesLoaderWeb {
     public static final String LEAFLET_ATTRIBUTION_PROPERTY = "leaflet.attribution";
     public static final String TOP_LEFT_LOGO_IMAGE_PROPERTY = "top.left.logo.image";
     public static final String TOP_LEFT_LOGO_IMAGE_LINK_PROPERTY = "top.left.logo.image.link";
+    public static final String STATS_PROPERTY = "stats.fields";
  
     
     
@@ -87,8 +88,11 @@ public class PropertiesLoaderWeb {
 
     private static Properties serviceProperties = null;
     //Default values.
-    public static List<String> FACETS = Arrays.asList("domain", "content_type_norm", "type", "crawl_year", "status_code", "public_suffix"); 
+    public static List<String> FACETS = Arrays.asList("domain", "content_type_norm", "type", "crawl_year", "status_code", "public_suffix");
     public static String FIELDS=null;
+    public static List<String> STATS = Arrays.asList("content_length", "crawl_year", "content_text_length", "image_height", "image_width", "image_size",
+                                                    "links", "domain", "elements_used", "content_type",
+                                                    "content_language", "links_images", "type");
     
     //Default empty if not defined in properties
     public static  List<String> WORDCLOUD_STOPWORDS = new ArrayList<String>();
@@ -121,7 +125,8 @@ public class PropertiesLoaderWeb {
             isr.close();
 
             WAYBACK_SERVER =serviceProperties.getProperty(WAYBACK_SERVER_PROPERTY);
-            FACETS = Arrays.asList(getProperty(FACETS_PROPERTY, StringUtils.join(FACETS, ",")).split(", *"));		
+            FACETS = Arrays.asList(getProperty(FACETS_PROPERTY, StringUtils.join(FACETS, ",")).split(", *"));
+            STATS = Arrays.asList(getProperty(STATS_PROPERTY, StringUtils.join(STATS, ",")).split(", *"));
             WORDCLOUD_STOPWORDS = Arrays.asList(getProperty(WORDCLOUD_STOPWORDS_PROPERTY, StringUtils.join(WORDCLOUD_STOPWORDS, ",")).split(", *"));
             WEBAPP_PREFIX = serviceProperties.getProperty(WEBAPP_PREFIX_PROPERTY,"/solrwayback/"); //Default to /solrwayback/ if not defined
             OPENWAYBACK_SERVER = serviceProperties.getProperty(OPENWAYBACK_SERVER_PROPERTY);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoaderWeb;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,11 +92,15 @@ public class SolrStats {
                 }
             }
 
-            QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
-            Gson gson = new Gson();
-            String stats = gson.toJson(response.getFieldStatsInfo().values());
+            try {
+                QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
+                Gson gson = new Gson();
+                String stats = gson.toJson(response.getFieldStatsInfo().values());
+                return stats;
+            } catch (Exception e){
+                throw new IllegalArgumentException("Percentiles have to be in range [0-100].");
+            }
 
-            return stats;
         }
     }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -1,10 +1,14 @@
 package dk.kb.netarchivesuite.solrwayback.solr;
 
 import com.google.gson.Gson;
+import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoaderWeb;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Get stats through the solr <a href="https://solr.apache.org/guide/8_11/the-stats-component.html">stats component</a>.
@@ -12,10 +16,10 @@ import org.slf4j.LoggerFactory;
  */
 public class SolrStats {
     private static final Logger log = LoggerFactory.getLogger(SolrStats.class);
-    public static final String[] interestingNumericFields =  new String[]{"content_length", "crawl_year", "content_text_length", "image_height", "image_width", "image_size"};
-    final String[] interestingTextFields = new String[]{"links", "domain", "elements_used", "content_type",
-                                                                "content_language", "links_images", "type"};
-    final String[] otherNumericFields = new String[]{"score", "status_code", "source_file_offset", "_version_", "wayback_date"};
+    public static final List<String> interestingNumericFields =  Arrays.asList("content_length", "crawl_year", "content_text_length", "image_height", "image_width", "image_size");
+    final List<String> interestingTextFields = Arrays.asList("links", "domain", "elements_used", "content_type",
+                                                                "content_language", "links_images", "type");
+    final List<String> otherNumericFields = Arrays.asList("score", "status_code", "source_file_offset", "_version_", "wayback_date");
 
     /**
      * Get standard solr stats for all fields given
@@ -25,13 +29,17 @@ public class SolrStats {
      * @param fields  to return stats for.
      * @return all standard stats for all fields from query as a JSON string.
      */
-    public static String getStatsForFields(String query, String[] filters, String... fields){
+    public static String getStatsForFields(String query, List<String> filters, List<String> fields){
         //TODO: Should contain a check, that the values are actually numeric and not anything else.
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(query);
 
         for (String field: fields) {
-            solrQuery.setGetFieldStatistics(field);
+            if (PropertiesLoaderWeb.STATS.contains(field)){
+                solrQuery.setGetFieldStatistics(field);
+            } else {
+                log.warn("Stats can not be shown for field: " + field + " as it is not present in properties.");
+            }
         }
 
         QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -1,0 +1,80 @@
+package dk.kb.netarchivesuite.solrwayback.solr;
+
+import com.google.gson.Gson;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.response.QueryResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Get stats through the solr <a href="https://solr.apache.org/guide/8_11/the-stats-component.html">stats component</a>.
+ * Methods in this class
+ */
+public class SolrStats {
+    private static final Logger log = LoggerFactory.getLogger(SolrStats.class);
+    public static final List<String> interestingNumericFields = Arrays.asList("content_length", "crawl_year", "content_text_length", "image_height", "image_width", "image_size");
+    final List<String> interestingTextFields = Arrays.asList("links", "domain", "elements_used", "content_type",
+                                                                "content_language", "links_images", "type");
+    final List<String> otherNumericFields = Arrays.asList("score", "status_code", "source_file_offset", "_version_", "wayback_date");
+
+    /**
+     * Get standard solr stats for all numeric fields given.
+     * @param query to generate stats for.
+     * @param fields to return stats for.
+     * @return all standard stats for all numeric fields from query as a JSON string.
+     */
+    public static String getStatsForMultipleNumericFields(String query, List<String> fields){
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.setQuery(query);
+
+        for (String field: fields) {
+            solrQuery.setGetFieldStatistics(field);
+        }
+
+        QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
+        Gson gson = new Gson();
+        String stats = gson.toJson(response.getFieldStatsInfo().values());
+        return stats;
+    }
+
+    /**
+     * Get standard solr stats for single numeric field.
+     * @param query to generate stats for.
+     * @param field to return stats for.
+     * @return all standard stats for field as a JSON string.
+     */
+    public static String getStatsForSingleNumericField(String query, String field){
+        SolrQuery solrQuery = new SolrQuery();
+
+        // Get all stats for input field
+        solrQuery.setQuery(query).addGetFieldStatistics(field);
+
+        QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
+        Gson gson = new Gson();
+        String stats = gson.toJson(response.getFieldStatsInfo().values());
+        return stats;
+    }
+
+    /**
+     * Get solr stats for single text field. Only return stats on count and missing values.
+     * @param query to generate stats for.
+     * @param field to return stats for.
+     * @return stats for count and missing as a JSON string.
+     */
+    public static String getStatsForSingleTextField(String query, String field){
+        SolrQuery solrQuery = new SolrQuery();
+        // Get all stats for input field
+        solrQuery.setQuery(query).addGetFieldStatistics("{!count=true missing=true}" + field);
+
+        QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
+        Gson gson = new Gson();
+        String stats = gson.toJson(response.getFieldStatsInfo().values());
+        return stats;
+    }
+
+
+
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -25,7 +25,7 @@ public class SolrStats {
      * Get standard solr stats for all fields given.
      * The solr documentation defines the standard stats <a href="https://solr.apache.org/guide/8_11/the-stats-component.html">here</a>
      * @param query   to generate stats for.
-     * @param filters
+     * @param filters that are to be added to solr query.
      * @param fields  to return stats for.
      * @return all standard stats for all fields from query as a JSON string.
      */
@@ -36,9 +36,12 @@ public class SolrStats {
             SolrQuery solrQuery = new SolrQuery();
             solrQuery.setQuery(query);
 
-            for (String filter: filters) {
-                solrQuery.addFilterQuery(filter);
+            if (!(filters == null)){
+                for (String filter: filters) {
+                    solrQuery.addFilterQuery(filter);
+                }
             }
+
 
             for (String field: fields) {
                 if (PropertiesLoaderWeb.STATS.contains(field)){

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -21,15 +21,15 @@ import java.util.List;
 public class SolrStats {
     private static final Logger log = LoggerFactory.getLogger(SolrStats.class);
     public static final String[] interestingNumericFields =  new String[]{"content_length", "crawl_year", "content_text_length", "image_height", "image_width", "image_size"};
-    final List<String> interestingTextFields = Arrays.asList("links", "domain", "elements_used", "content_type",
-                                                                "content_language", "links_images", "type");
-    final List<String> otherNumericFields = Arrays.asList("score", "status_code", "source_file_offset", "_version_", "wayback_date");
+    final String[] interestingTextFields = new String[]{"links", "domain", "elements_used", "content_type",
+                                                                "content_language", "links_images", "type"};
+    final String[] otherNumericFields = new String[]{"score", "status_code", "source_file_offset", "_version_", "wayback_date"};
 
     /**
-     * Get standard solr stats for all numeric fields given.
+     * Get standard solr stats for all fields given
      * @param query to generate stats for.
      * @param fields to return stats for.
-     * @return all standard stats for all numeric fields from query as a JSON string.
+     * @return all standard stats for all fields from query as a JSON string.
      */
     public static String getStatsForFields(String query, String... fields){
         //TODO: Should contain a check, that the values are actually numeric and not anything else.
@@ -44,18 +44,6 @@ public class SolrStats {
         Gson gson = new Gson();
         String stats = gson.toJson(response.getFieldStatsInfo().values());
         return stats;
-    }
-
-    public static void sendLukeRequest() throws SolrServerException, IOException {
-        LukeRequest lukeRequest = new LukeRequest();
-        lukeRequest.setShowSchema(true);
-        NamedList<Object> response = NetarchiveSolrClient.solrServer.request(lukeRequest);
-        Object schema = response.get("schema");
-
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        String prettyJsonString = gson.toJson(schema);
-
-        System.out.println(prettyJsonString);
     }
 
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -8,6 +8,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -57,7 +58,12 @@ public class SolrStats {
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(query);
 
-        String allPercentiles = StringUtils.join(percentiles, ",");
+        List<Double> parsedPercentiles = new ArrayList<>();
+        for (String percentile: percentiles) {
+            parsedPercentiles.add(Double.parseDouble(percentile));
+        }
+
+        String allPercentiles = StringUtils.join(parsedPercentiles, ",");
         String percentileQuery = "{!percentiles='" + allPercentiles + "'}";
 
         // When giving this a text field it calculates nothing. Should probably throw a warning or something like that

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -33,31 +33,31 @@ public class SolrStats {
     public static String getStatsForFields(String query, List<String> filters, List<String> fields){
         if (fields.isEmpty()){
             throw new IllegalArgumentException("No fields have been specified for stats component.");
-        } else {
-            SolrQuery solrQuery = new SolrQuery();
-            solrQuery.setQuery(query);
-
-            if (!(filters == null)){
-                for (String filter: filters) {
-                    solrQuery.addFilterQuery(filter);
-                }
-            }
-
-
-            for (String field: fields) {
-                if (PropertiesLoaderWeb.STATS.contains(field)){
-                    solrQuery.setGetFieldStatistics(field);
-                } else {
-                    log.warn("Stats can not be shown for field: " + field + " as it is not present in properties.");
-                    throw new IllegalArgumentException("Stats can not be shown for field: '" + field + "' as it is not present in properties.");
-                }
-            }
-
-            QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
-            Gson gson = new Gson();
-            String stats = gson.toJson(response.getFieldStatsInfo().values());
-            return stats;
         }
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.setQuery(query);
+
+        if (!(filters == null)){
+            for (String filter: filters) {
+                solrQuery.addFilterQuery(filter);
+            }
+        }
+
+
+        for (String field: fields) {
+            if (PropertiesLoaderWeb.STATS.contains(field)){
+                solrQuery.setGetFieldStatistics(field);
+            } else {
+                log.warn("Stats can not be shown for field: " + field + " as it is not present in properties.");
+                throw new IllegalArgumentException("Stats can not be shown for field: '" + field + "' as it is not present in properties.");
+            }
+        }
+
+        QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
+        Gson gson = new Gson();
+        String stats = gson.toJson(response.getFieldStatsInfo().values());
+        return stats;
+
     }
 
     /**
@@ -70,38 +70,38 @@ public class SolrStats {
     public static String getPercentilesForFields(String query, List<String> percentiles, List<String> fields){
         if (fields.isEmpty()) {
             throw new IllegalArgumentException("No fields have been specified for stats component.");
-        } else {
-            SolrQuery solrQuery = new SolrQuery();
-            solrQuery.setQuery(query);
-
-            List<Double> parsedPercentiles = new ArrayList<>();
-            for (String percentile : percentiles) {
-                parsedPercentiles.add(Double.parseDouble(percentile));
-            }
-
-            String allPercentiles = StringUtils.join(parsedPercentiles, ",");
-            String percentileQuery = "{!percentiles='" + allPercentiles + "'}";
-
-            // When giving this a text field it calculates nothing. Should probably throw a warning or something like that
-            for (String field : fields) {
-                if (PropertiesLoaderWeb.STATS.contains(field)) {
-                    solrQuery.setGetFieldStatistics(percentileQuery + field);
-                } else {
-                    log.error("Percentiles can not be shown for field: " + field + " as it is not present in properties.");
-                    throw new IllegalArgumentException("Percentiles can not be shown for field: '" + field + "' as it is not present in properties.");
-                }
-            }
-
-            try {
-                QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
-                Gson gson = new Gson();
-                String stats = gson.toJson(response.getFieldStatsInfo().values());
-                return stats;
-            } catch (Exception e){
-                throw new IllegalArgumentException("Percentiles have to be in range [0-100].");
-            }
-
         }
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.setQuery(query);
+
+        List<Double> parsedPercentiles = new ArrayList<>();
+        for (String percentile : percentiles) {
+            parsedPercentiles.add(Double.parseDouble(percentile));
+        }
+
+        String allPercentiles = StringUtils.join(parsedPercentiles, ",");
+        String percentileQuery = "{!percentiles='" + allPercentiles + "'}";
+
+        // When giving this a text field it calculates nothing. Should probably throw a warning or something like that
+        for (String field : fields) {
+            if (PropertiesLoaderWeb.STATS.contains(field)) {
+                solrQuery.setGetFieldStatistics(percentileQuery + field);
+            } else {
+                log.error("Percentiles can not be shown for field: " + field + " as it is not present in properties.");
+                throw new IllegalArgumentException("Percentiles can not be shown for field: '" + field + "' as it is not present in properties.");
+            }
+        }
+
+        try {
+            QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
+            Gson gson = new Gson();
+            String stats = gson.toJson(response.getFieldStatsInfo().values());
+            return stats;
+        } catch (Exception e){
+            throw new IllegalArgumentException("Percentiles have to be in range [0-100].");
+        }
+
+
     }
 
     /**

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -21,9 +21,10 @@ public class SolrStats {
     final List<String> interestingTextFields = Arrays.asList("links", "domain", "elements_used", "content_type",
                                                                 "content_language", "links_images", "type");
     final List<String> otherNumericFields = Arrays.asList("score", "status_code", "source_file_offset", "_version_", "wayback_date");
+
     /**
-     * Get standard solr stats for all fields given
-     *
+     * Get standard solr stats for all fields given.
+     * The solr documentation defines the standard stats <a href="https://solr.apache.org/guide/8_11/the-stats-component.html">here</a>
      * @param query   to generate stats for.
      * @param filters
      * @param fields  to return stats for.
@@ -47,6 +48,13 @@ public class SolrStats {
         return stats;
     }
 
+    /**
+     * Get percentiles for numeric fields
+     * @param query to generate stats for.
+     * @param percentiles to extract values for.
+     * @param fields to return percentiles for.
+     * @return percentiles for specified fields as a JSON string.
+     */
     public static String getPercentilesForFields(String query, List<String> percentiles, List<String> fields){
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(query);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -54,17 +54,19 @@ public class SolrStats {
         String allPercentiles = StringUtils.join(percentiles, ",");
         String percentileQuery = "{!percentiles='" + allPercentiles + "'}";
 
+        // When giving this a text field it calculates nothing. Should probably throw a warning or something like that
         for (String field: fields) {
             if (PropertiesLoaderWeb.STATS.contains(field)){
                 solrQuery.setGetFieldStatistics(percentileQuery + field);
             } else {
-                log.warn("Percentile stats can not be shown for field: " + field + " as it is not present in properties.");
+                log.error("Percentile stats can not be shown for field: " + field + " as it is not present in properties.");
             }
         }
 
         QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
         Gson gson = new Gson();
         String stats = gson.toJson(response.getFieldStatsInfo().values());
+
         return stats;
     }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -1,11 +1,16 @@
 package dk.kb.netarchivesuite.solrwayback.solr;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.client.solrj.request.LukeRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
+import org.apache.solr.common.util.NamedList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -15,7 +20,7 @@ import java.util.List;
  */
 public class SolrStats {
     private static final Logger log = LoggerFactory.getLogger(SolrStats.class);
-    public static final List<String> interestingNumericFields = Arrays.asList("content_length", "crawl_year", "content_text_length", "image_height", "image_width", "image_size");
+    public static final String[] interestingNumericFields =  new String[]{"content_length", "crawl_year", "content_text_length", "image_height", "image_width", "image_size"};
     final List<String> interestingTextFields = Arrays.asList("links", "domain", "elements_used", "content_type",
                                                                 "content_language", "links_images", "type");
     final List<String> otherNumericFields = Arrays.asList("score", "status_code", "source_file_offset", "_version_", "wayback_date");
@@ -26,7 +31,7 @@ public class SolrStats {
      * @param fields to return stats for.
      * @return all standard stats for all numeric fields from query as a JSON string.
      */
-    public static String getStatsForMultipleNumericFields(String query, List<String> fields){
+    public static String getStatsForFields(String query, String... fields){
         //TODO: Should contain a check, that the values are actually numeric and not anything else.
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(query);
@@ -41,40 +46,16 @@ public class SolrStats {
         return stats;
     }
 
-    /**
-     * Get standard solr stats for single numeric field.
-     * @param query to generate stats for.
-     * @param field to return stats for.
-     * @return all standard stats for field as a JSON string.
-     */
-    public static String getStatsForSingleNumericField(String query, String field){
-        //TODO: Should contain a check, that the values are actually numeric and not anything else.
-        SolrQuery solrQuery = new SolrQuery();
+    public static void sendLukeRequest() throws SolrServerException, IOException {
+        LukeRequest lukeRequest = new LukeRequest();
+        lukeRequest.setShowSchema(true);
+        NamedList<Object> response = NetarchiveSolrClient.solrServer.request(lukeRequest);
+        Object schema = response.get("schema");
 
-        // Get all stats for input field
-        solrQuery.setQuery(query).addGetFieldStatistics(field);
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        String prettyJsonString = gson.toJson(schema);
 
-        QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
-        Gson gson = new Gson();
-        String stats = gson.toJson(response.getFieldStatsInfo().values());
-        return stats;
-    }
-
-    /**
-     * Get solr stats for single text field. Only return stats on count and missing values.
-     * @param query to generate stats for.
-     * @param field to return stats for.
-     * @return stats for count and missing as a JSON string.
-     */
-    public static String getStatsForSingleTextField(String query, String field){
-        SolrQuery solrQuery = new SolrQuery();
-        // Get all stats for input field
-        solrQuery.setQuery(query).addGetFieldStatistics("{!count=true missing=true}" + field);
-
-        QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
-        Gson gson = new Gson();
-        String stats = gson.toJson(response.getFieldStatsInfo().values());
-        return stats;
+        System.out.println(prettyJsonString);
     }
 
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -27,6 +27,7 @@ public class SolrStats {
      * @return all standard stats for all numeric fields from query as a JSON string.
      */
     public static String getStatsForMultipleNumericFields(String query, List<String> fields){
+        //TODO: Should contain a check, that the values are actually numeric and not anything else.
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(query);
 
@@ -47,6 +48,7 @@ public class SolrStats {
      * @return all standard stats for field as a JSON string.
      */
     public static String getStatsForSingleNumericField(String query, String field){
+        //TODO: Should contain a check, that the values are actually numeric and not anything else.
         SolrQuery solrQuery = new SolrQuery();
 
         // Get all stats for input field
@@ -74,7 +76,5 @@ public class SolrStats {
         String stats = gson.toJson(response.getFieldStatsInfo().values());
         return stats;
     }
-
-
 
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -2,6 +2,7 @@ package dk.kb.netarchivesuite.solrwayback.solr;
 
 import com.google.gson.Gson;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoaderWeb;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.slf4j.Logger;
@@ -20,7 +21,6 @@ public class SolrStats {
     final List<String> interestingTextFields = Arrays.asList("links", "domain", "elements_used", "content_type",
                                                                 "content_language", "links_images", "type");
     final List<String> otherNumericFields = Arrays.asList("score", "status_code", "source_file_offset", "_version_", "wayback_date");
-
     /**
      * Get standard solr stats for all fields given
      *
@@ -30,7 +30,6 @@ public class SolrStats {
      * @return all standard stats for all fields from query as a JSON string.
      */
     public static String getStatsForFields(String query, List<String> filters, List<String> fields){
-        //TODO: Should contain a check, that the values are actually numeric and not anything else.
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(query);
 
@@ -39,6 +38,27 @@ public class SolrStats {
                 solrQuery.setGetFieldStatistics(field);
             } else {
                 log.warn("Stats can not be shown for field: " + field + " as it is not present in properties.");
+            }
+        }
+
+        QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
+        Gson gson = new Gson();
+        String stats = gson.toJson(response.getFieldStatsInfo().values());
+        return stats;
+    }
+
+    public static String getPercentilesForFields(String query, List<String> percentiles, List<String> fields){
+        SolrQuery solrQuery = new SolrQuery();
+        solrQuery.setQuery(query);
+
+        String allPercentiles = StringUtils.join(percentiles, ",");
+        String percentileQuery = "{!percentiles='" + allPercentiles + "'}";
+
+        for (String field: fields) {
+            if (PropertiesLoaderWeb.STATS.contains(field)){
+                solrQuery.setGetFieldStatistics(percentileQuery + field);
+            } else {
+                log.warn("Percentile stats can not be shown for field: " + field + " as it is not present in properties.");
             }
         }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -36,6 +36,10 @@ public class SolrStats {
             SolrQuery solrQuery = new SolrQuery();
             solrQuery.setQuery(query);
 
+            for (String filter: filters) {
+                solrQuery.addFilterQuery(filter);
+            }
+
             for (String field: fields) {
                 if (PropertiesLoaderWeb.STATS.contains(field)){
                     solrQuery.setGetFieldStatistics(field);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -16,11 +16,9 @@ import java.util.List;
  * Methods in this class
  */
 public class SolrStats {
+    // TODO: Call all methods through facade.
     private static final Logger log = LoggerFactory.getLogger(SolrStats.class);
     public static final List<String> interestingNumericFields =  Arrays.asList("content_length", "crawl_year", "content_text_length", "image_height", "image_width", "image_size");
-    final List<String> interestingTextFields = Arrays.asList("links", "domain", "elements_used", "content_type",
-                                                                "content_language", "links_images", "type");
-    final List<String> otherNumericFields = Arrays.asList("score", "status_code", "source_file_offset", "_version_", "wayback_date");
 
     /**
      * Get standard solr stats for all fields given.

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -1,18 +1,10 @@
 package dk.kb.netarchivesuite.solrwayback.solr;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.client.solrj.SolrServerException;
-import org.apache.solr.client.solrj.request.LukeRequest;
 import org.apache.solr.client.solrj.response.QueryResponse;
-import org.apache.solr.common.util.NamedList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * Get stats through the solr <a href="https://solr.apache.org/guide/8_11/the-stats-component.html">stats component</a>.
@@ -27,11 +19,13 @@ public class SolrStats {
 
     /**
      * Get standard solr stats for all fields given
-     * @param query to generate stats for.
-     * @param fields to return stats for.
+     *
+     * @param query   to generate stats for.
+     * @param filters
+     * @param fields  to return stats for.
      * @return all standard stats for all fields from query as a JSON string.
      */
-    public static String getStatsForFields(String query, String... fields){
+    public static String getStatsForFields(String query, String[] filters, String... fields){
         //TODO: Should contain a check, that the values are actually numeric and not anything else.
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(query);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -78,4 +78,15 @@ public class SolrStats {
         return stats;
     }
 
+    /**
+     * Show which fields it is possible to extract stats for.
+     * @return a JSON array containing fields that can be queried for stats.
+     */
+    public static String getFieldsWithStatsEnabled(){
+        Gson gson = new Gson();
+        List<String> stats = PropertiesLoaderWeb.STATS;
+        String statsAsJson = gson.toJson(stats);
+        return statsAsJson;
+    }
+
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStats.java
@@ -30,21 +30,26 @@ public class SolrStats {
      * @return all standard stats for all fields from query as a JSON string.
      */
     public static String getStatsForFields(String query, List<String> filters, List<String> fields){
-        SolrQuery solrQuery = new SolrQuery();
-        solrQuery.setQuery(query);
+        if (fields.isEmpty()){
+            throw new IllegalArgumentException("No fields have been specified for stats component.");
+        } else {
+            SolrQuery solrQuery = new SolrQuery();
+            solrQuery.setQuery(query);
 
-        for (String field: fields) {
-            if (PropertiesLoaderWeb.STATS.contains(field)){
-                solrQuery.setGetFieldStatistics(field);
-            } else {
-                log.warn("Stats can not be shown for field: " + field + " as it is not present in properties.");
+            for (String field: fields) {
+                if (PropertiesLoaderWeb.STATS.contains(field)){
+                    solrQuery.setGetFieldStatistics(field);
+                } else {
+                    log.warn("Stats can not be shown for field: " + field + " as it is not present in properties.");
+                    throw new IllegalArgumentException("Stats can not be shown for field: '" + field + "' as it is not present in properties.");
+                }
             }
-        }
 
-        QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
-        Gson gson = new Gson();
-        String stats = gson.toJson(response.getFieldStatsInfo().values());
-        return stats;
+            QueryResponse response = NetarchiveSolrClient.query(solrQuery, true);
+            Gson gson = new Gson();
+            String stats = gson.toJson(response.getFieldStatsInfo().values());
+            return stats;
+        }
     }
 
     /**

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
@@ -157,6 +157,16 @@ public class SolrStatsTest {
         JsonObject image_height = extractFirstObjectFromJsonArrayString(stats);
         Assert.assertEquals(800.0, image_height.getAsJsonObject("percentiles").get("25.0").getAsDouble(), 0);
     }
+
+    @Test
+    public void textPercentileTest(){
+        List<String> percentiles = Arrays.asList("25", "50", "75");
+        List<String> fields = Arrays.asList("links");
+        String stats = SolrStats.getPercentilesForFields("*:*", percentiles, fields);
+
+        JsonObject links = extractFirstObjectFromJsonArrayString(stats);
+        Assert.assertNull(links.get("percentiles"));
+    }
     
     private JsonObject extractFirstObjectFromJsonArrayString(String string){
         JsonArray solrStats = new Gson().fromJson(string, JsonArray.class);

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
@@ -1,5 +1,6 @@
 package dk.kb.netarchivesuite.solrwayback;
 
+import com.carrotsearch.randomizedtesting.annotations.TestMethodProviders;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -166,6 +167,14 @@ public class SolrStatsTest {
 
         JsonObject links = extractFirstObjectFromJsonArrayString(stats);
         Assert.assertNull(links.get("percentiles"));
+    }
+
+    @Test
+    public void availableFieldsTest(){
+        String fieldsAvailable = SolrStats.getFieldsWithStatsEnabled();
+
+        JsonArray availableFields = new Gson().fromJson(fieldsAvailable, JsonArray.class);
+        Assert.assertEquals(13, availableFields.size());
     }
     
     private JsonObject extractFirstObjectFromJsonArrayString(String string){

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoaderWeb;
 import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrClient;
 import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrTestClient;
 import dk.kb.netarchivesuite.solrwayback.solr.SolrStats;
@@ -18,6 +19,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class SolrStatsTest {
     private static final Logger log = LoggerFactory.getLogger(SolrStatsTest.class);
@@ -96,9 +99,10 @@ public class SolrStatsTest {
     @Test
     public void singleNumericFieldStatTest(){
         // Testing with hardcoded documents above
-        String stats = SolrStats.getStatsForFields("*:*", null, "crawl_year");
+        List<String> field = Collections.singletonList("crawl_year");
+        String stats = SolrStats.getStatsForFields("*:*", null, field);
 
-        JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
+        JsonObject entryAsJsonObject = extractFirstObjectFromJsonArrayString(stats);
 
         Assert.assertEquals("crawl_year", entryAsJsonObject.get("name").getAsString());
         Assert.assertEquals(2003.0, entryAsJsonObject.get("min").getAsDouble(), 0);
@@ -114,7 +118,7 @@ public class SolrStatsTest {
         // Testing with hardcoded documents above
         String stats = SolrStats.getStatsForFields("*:*", null , SolrStats.interestingNumericFields);
 
-        JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
+        JsonObject entryAsJsonObject = extractFirstObjectFromJsonArrayString(stats);
 
         Assert.assertEquals("content_length", entryAsJsonObject.get("name").getAsString());
         Assert.assertEquals(2.0, entryAsJsonObject.get("min").getAsDouble(), 0);
@@ -128,9 +132,10 @@ public class SolrStatsTest {
     @Test
     public void singleTextFieldStatTest(){
         // Testing with hardcoded documents above
-        String stats = SolrStats.getStatsForFields("*:*", null , "domain");
+        List<String> field = Collections.singletonList("domain");
+        String stats = SolrStats.getStatsForFields("*:*", null , field);
 
-        JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
+        JsonObject entryAsJsonObject = extractFirstObjectFromJsonArrayString(stats);
 
         Assert.assertEquals("domain", entryAsJsonObject.get("name").getAsString());
         Assert.assertEquals(9, entryAsJsonObject.get("count").getAsInt());
@@ -138,7 +143,16 @@ public class SolrStatsTest {
         Assert.assertNull(entryAsJsonObject.get("mean"));
     }
 
-    private JsonObject extractJsonObjectFromJsonArrayString(String string){
+
+    @Test
+    public void defaultFieldsTest(){
+        String stats = SolrStats.getStatsForFields("*:*", null, PropertiesLoaderWeb.STATS);
+        JsonArray solrStats = new Gson().fromJson(stats, JsonArray.class);
+
+        Assert.assertEquals(13, solrStats.size());
+    }
+    
+    private JsonObject extractFirstObjectFromJsonArrayString(String string){
         JsonArray solrStats = new Gson().fromJson(string, JsonArray.class);
         JsonElement singleEntry = solrStats.get(0);
         JsonObject entryAsJsonObject = singleEntry.getAsJsonObject();

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
@@ -1,0 +1,147 @@
+package dk.kb.netarchivesuite.solrwayback;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrClient;
+import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrTestClient;
+import dk.kb.netarchivesuite.solrwayback.solr.SolrStats;
+import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
+import org.apache.solr.common.SolrInputDocument;
+import org.apache.solr.core.CoreContainer;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+
+public class SolrStatsTest {
+    private static final Logger log = LoggerFactory.getLogger(SolrStatsTest.class);
+
+    private static String solr_home= "target/test-classes/solr";
+    private static NetarchiveSolrClient server = null;
+    private static CoreContainer coreContainer= null;
+    private static EmbeddedSolrServer embeddedServer = null;
+
+    @Before
+    public void setUp() throws Exception {
+
+        coreContainer = new CoreContainer(solr_home);
+        coreContainer.load();
+        embeddedServer = new EmbeddedSolrServer(coreContainer,"netarchivebuilder");
+        NetarchiveSolrTestClient.initializeOverLoadUnitTest(embeddedServer);
+        server = NetarchiveSolrClient.getInstance();
+
+        // Remove any items from previous executions:
+        embeddedServer.deleteByQuery("*:*"); //This is not on the NetarchiveSolrClient API!
+
+        String url = "http://testurl.dk/test";
+        String[] links = new String[]{"http://kb.dk/", "http://kb.dk/en"};
+
+        ArrayList<String> crawlTimes = new ArrayList<String>();
+        crawlTimes.add("2018-03-15T12:31:51Z");
+        crawlTimes.add("2018-03-15T12:34:37Z");
+        crawlTimes.add("2018-03-15T12:35:56Z");
+        crawlTimes.add("2018-03-15T12:36:14Z");
+        crawlTimes.add("2018-03-15T12:36:43Z");
+        crawlTimes.add("2018-03-15T12:37:32Z");
+        crawlTimes.add("2018-03-15T12:37:52Z");
+        crawlTimes.add("2018-03-15T12:39:15Z");
+        crawlTimes.add("2018-03-15T12:40:09Z");
+
+        int i =1;
+        for (String crawl : crawlTimes){
+            SolrInputDocument document = new SolrInputDocument();
+            String id = ""+i++;
+            String title = "title "+i;
+            document.addField("source_file_offset", i+"");
+            document.addField("id", id);
+            document.addField("title", title);
+            document.addField("url", url);
+            document.addField("url_norm", url);
+            document.addField("record_type","response");
+            document.addField("source_file_path", "some.warc");
+            document.setField("crawl_date", crawl);
+
+            document.addField("status_code", "200");
+            document.addField("content_length", i);
+            document.addField("crawl_year", 2003);
+            document.addField("content_text_length", i);
+            document.addField("image_height", 800);
+            document.addField("image_width", 600);
+            document.addField("image_size", 480000);
+            document.addField("wayback_date", "20230417100000");
+            document.addField("links", links);
+            document.addField("domain", "www.kb.dk");
+
+            embeddedServer.add(document);
+
+        }
+        embeddedServer.commit();
+    }
+
+    /**
+     * @throws java.lang.Exception
+     */
+    @After
+    public void tearDown() throws Exception {
+        coreContainer.shutdown();
+        embeddedServer.close();
+    }
+
+    @Test
+    public void singleNumericFieldStatTest(){
+        // Testing with hardcoded documents above
+        String stats = SolrStats.getStatsForSingleNumericField("*:*", "crawl_year");
+
+        JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
+
+        Assert.assertEquals("crawl_year", entryAsJsonObject.get("name").getAsString());
+        Assert.assertEquals(2003.0, entryAsJsonObject.get("min").getAsDouble(), 0);
+        Assert.assertEquals(2003.0, entryAsJsonObject.get("max").getAsDouble(), 0);
+        Assert.assertEquals(18027.0, entryAsJsonObject.get("sum").getAsDouble(), 0);
+        Assert.assertEquals(9, entryAsJsonObject.get("count").getAsInt());
+        Assert.assertEquals(0, entryAsJsonObject.get("missing").getAsInt());
+        Assert.assertEquals(2003.0, entryAsJsonObject.get("mean").getAsDouble(), 0);
+    }
+
+    @Test
+    public void multipleNumericFieldStatsTest(){
+        // Testing with hardcoded documents above
+        String stats = SolrStats.getStatsForMultipleNumericFields("*:*", SolrStats.interestingNumericFields);
+
+        JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
+
+        Assert.assertEquals("content_length", entryAsJsonObject.get("name").getAsString());
+        Assert.assertEquals(2.0, entryAsJsonObject.get("min").getAsDouble(), 0);
+        Assert.assertEquals(10.0, entryAsJsonObject.get("max").getAsDouble(), 0);
+        Assert.assertEquals(54.0, entryAsJsonObject.get("sum").getAsDouble(), 0);
+        Assert.assertEquals(9, entryAsJsonObject.get("count").getAsInt());
+        Assert.assertEquals(0, entryAsJsonObject.get("missing").getAsInt());
+        Assert.assertEquals(6.0, entryAsJsonObject.get("mean").getAsDouble(), 0);
+    }
+
+    @Test
+    public void singleTextFieldStatTest(){
+        // Testing with hardcoded documents above
+        String stats = SolrStats.getStatsForSingleTextField("*:*", "domain");
+
+        JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
+
+        Assert.assertEquals("domain", entryAsJsonObject.get("name").getAsString());
+        Assert.assertEquals(9, entryAsJsonObject.get("count").getAsInt());
+        Assert.assertEquals(0, entryAsJsonObject.get("missing").getAsInt());
+        Assert.assertNull(entryAsJsonObject.get("mean"));
+    }
+
+    private JsonObject extractJsonObjectFromJsonArrayString(String string){
+        JsonArray solrStats = new Gson().fromJson(string, JsonArray.class);
+        JsonElement singleEntry = solrStats.get(0);
+        JsonObject entryAsJsonObject = singleEntry.getAsJsonObject();
+        return entryAsJsonObject;
+    }
+}

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
@@ -147,6 +147,16 @@ public class SolrStatsTest {
 
         Assert.assertEquals(13, solrStats.size());
     }
+
+    @Test
+    public void percentileTest(){
+        List<String> percentiles = Arrays.asList("25", "50", "75");
+        List<String> fields = Arrays.asList("image_height", "image_width", "image_size");
+        String stats = SolrStats.getPercentilesForFields("*:*", percentiles, fields);
+
+        JsonObject image_height = extractFirstObjectFromJsonArrayString(stats);
+        Assert.assertEquals(800.0, image_height.getAsJsonObject("percentiles").get("25.0").getAsDouble(), 0);
+    }
     
     private JsonObject extractFirstObjectFromJsonArrayString(String string){
         JsonArray solrStats = new Gson().fromJson(string, JsonArray.class);

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
@@ -7,7 +7,6 @@ import com.google.gson.JsonObject;
 import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrClient;
 import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrTestClient;
 import dk.kb.netarchivesuite.solrwayback.solr.SolrStats;
-import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.CoreContainer;
@@ -18,7 +17,6 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.ArrayList;
 
 public class SolrStatsTest {
@@ -98,7 +96,7 @@ public class SolrStatsTest {
     @Test
     public void singleNumericFieldStatTest(){
         // Testing with hardcoded documents above
-        String stats = SolrStats.getStatsForFields("*:*", "crawl_year");
+        String stats = SolrStats.getStatsForFields("*:*", null, "crawl_year");
 
         JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
 
@@ -114,7 +112,7 @@ public class SolrStatsTest {
     @Test
     public void multipleNumericFieldStatsTest(){
         // Testing with hardcoded documents above
-        String stats = SolrStats.getStatsForFields("*:*", SolrStats.interestingNumericFields);
+        String stats = SolrStats.getStatsForFields("*:*", null , SolrStats.interestingNumericFields);
 
         JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
 
@@ -130,7 +128,7 @@ public class SolrStatsTest {
     @Test
     public void singleTextFieldStatTest(){
         // Testing with hardcoded documents above
-        String stats = SolrStats.getStatsForFields("*:*", "domain");
+        String stats = SolrStats.getStatsForFields("*:*", null , "domain");
 
         JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
 

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
@@ -7,6 +7,7 @@ import com.google.gson.JsonObject;
 import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrClient;
 import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrTestClient;
 import dk.kb.netarchivesuite.solrwayback.solr.SolrStats;
+import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.CoreContainer;
@@ -17,6 +18,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.ArrayList;
 
 public class SolrStatsTest {
@@ -96,7 +98,7 @@ public class SolrStatsTest {
     @Test
     public void singleNumericFieldStatTest(){
         // Testing with hardcoded documents above
-        String stats = SolrStats.getStatsForSingleNumericField("*:*", "crawl_year");
+        String stats = SolrStats.getStatsForFields("*:*", "crawl_year");
 
         JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
 
@@ -112,7 +114,7 @@ public class SolrStatsTest {
     @Test
     public void multipleNumericFieldStatsTest(){
         // Testing with hardcoded documents above
-        String stats = SolrStats.getStatsForMultipleNumericFields("*:*", SolrStats.interestingNumericFields);
+        String stats = SolrStats.getStatsForFields("*:*", SolrStats.interestingNumericFields);
 
         JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
 
@@ -128,7 +130,7 @@ public class SolrStatsTest {
     @Test
     public void singleTextFieldStatTest(){
         // Testing with hardcoded documents above
-        String stats = SolrStats.getStatsForSingleTextField("*:*", "domain");
+        String stats = SolrStats.getStatsForFields("*:*", "domain");
 
         JsonObject entryAsJsonObject = extractJsonObjectFromJsonArrayString(stats);
 
@@ -136,6 +138,11 @@ public class SolrStatsTest {
         Assert.assertEquals(9, entryAsJsonObject.get("count").getAsInt());
         Assert.assertEquals(0, entryAsJsonObject.get("missing").getAsInt());
         Assert.assertNull(entryAsJsonObject.get("mean"));
+    }
+
+    @Test
+    public void testLukeRequest() throws SolrServerException, IOException {
+        SolrStats.sendLukeRequest();
     }
 
     private JsonObject extractJsonObjectFromJsonArrayString(String string){

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
@@ -124,6 +124,7 @@ public class SolrStatsTest {
         for (JsonElement stat: solrStats) {
             Assert.assertFalse(stat.toString().isEmpty());
         }
+        Assert.assertEquals(SolrStats.interestingNumericFields.size(), solrStats.size());
     }
 
     @Test

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
@@ -140,11 +140,6 @@ public class SolrStatsTest {
         Assert.assertNull(entryAsJsonObject.get("mean"));
     }
 
-    @Test
-    public void testLukeRequest() throws SolrServerException, IOException {
-        SolrStats.sendLukeRequest();
-    }
-
     private JsonObject extractJsonObjectFromJsonArrayString(String string){
         JsonArray solrStats = new Gson().fromJson(string, JsonArray.class);
         JsonElement singleEntry = solrStats.get(0);

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -117,16 +118,11 @@ public class SolrStatsTest {
     public void multipleNumericFieldStatsTest(){
         // Testing with hardcoded documents above
         String stats = SolrStats.getStatsForFields("*:*", null , SolrStats.interestingNumericFields);
+        JsonArray solrStats = new Gson().fromJson(stats, JsonArray.class);
 
-        JsonObject entryAsJsonObject = extractFirstObjectFromJsonArrayString(stats);
-
-        Assert.assertEquals("content_length", entryAsJsonObject.get("name").getAsString());
-        Assert.assertEquals(2.0, entryAsJsonObject.get("min").getAsDouble(), 0);
-        Assert.assertEquals(10.0, entryAsJsonObject.get("max").getAsDouble(), 0);
-        Assert.assertEquals(54.0, entryAsJsonObject.get("sum").getAsDouble(), 0);
-        Assert.assertEquals(9, entryAsJsonObject.get("count").getAsInt());
-        Assert.assertEquals(0, entryAsJsonObject.get("missing").getAsInt());
-        Assert.assertEquals(6.0, entryAsJsonObject.get("mean").getAsDouble(), 0);
+        for (JsonElement stat: solrStats) {
+            Assert.assertFalse(stat.toString().isEmpty());
+        }
     }
 
     @Test

--- a/src/test/resources/properties/solrwaybackweb.properties
+++ b/src/test/resources/properties/solrwaybackweb.properties
@@ -42,6 +42,10 @@ export.warc.expanded.maxresults=10000
 # domain, content_type_norm, type, crawl_year, status_code, public_suffix
 facets=domain, content_type_norm, type, crawl_year,status_code,public_suffix,status_code
 
+# Default fields to compute stats for.
+stats.fields=content_length, crawl_year, content_text_length, image_height, image_width, image_size, links, domain, elements_used, content_type, content_language, links_images, type
+
+
 # Define fields to show when clicking "Show Data fields". Will default to all fields
 #fields=id,index_time,author,description,keywords,content_language,content_type_norm,hash
 

--- a/src/test/resources/properties/solrwaybackweb.properties
+++ b/src/test/resources/properties/solrwaybackweb.properties
@@ -42,7 +42,7 @@ export.warc.expanded.maxresults=10000
 # domain, content_type_norm, type, crawl_year, status_code, public_suffix
 facets=domain, content_type_norm, type, crawl_year,status_code,public_suffix,status_code
 
-# Default fields to compute stats for.
+# Allowed fields to compute stats for.
 stats.fields=content_length, crawl_year, content_text_length, image_height, image_width, image_size, links, domain, elements_used, content_type, content_language, links_images, type
 
 


### PR DESCRIPTION
First check-in for implementing the solr stats component as requested in #218.
This PR implements three methods in the java class SolrStats: 

- getStatsForMultipleNumericFields - returns standard stats for a list of numeric fields
- getStatsForSingleNumericField - returns standard stats for a single numeric field
- getStatsForSingleTextField - return stats for count and missing values for single text field


 