### PR TITLE
warc.gz export problem extras

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ The default number of 20 results on each page can be changed with this new prope
 
 search.pagination=20
 
+Bugfix: The property key for expanded warc limit was the same as for non-expanded
 
 
 4.4.0

--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@
       <plugin>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
-        <version>10.0.12</version>
+        <version>9.4.51.v20230217</version>
         <!--<version>9.4.30.v20200611</version>-->
         <configuration>
           <useTestScope>true</useTestScope>

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -548,7 +548,7 @@ public class Facade {
         else {
             max= PropertiesLoaderWeb.EXPORT_WARC_EXPANDED_MAXRESULTS;;
             if (results > PropertiesLoaderWeb.EXPORT_WARC_EXPANDED_MAXRESULTS) {
-                throw new InvalidArgumentServiceException("Number of results for warc expanded  export exceeds the configured limit: "+PropertiesLoaderWeb.EXPORT_WARC_EXPANDED_MAXRESULTS);
+                throw new InvalidArgumentServiceException("Number of results for warc expanded export exceeds the configured limit: "+PropertiesLoaderWeb.EXPORT_WARC_EXPANDED_MAXRESULTS);
             }
         }
         SolrGenericStreaming solr = SolrGenericStreaming.create(

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -95,9 +95,6 @@ public class Facade {
         return proxySolrOnlyFacetsLoadMore(query, filterQueries, facetField, revisits);
     }
 
-    
-    
-    
     /*
      * If fieldList is null all fields will be loaded
      * returns json
@@ -106,7 +103,6 @@ public class Facade {
         return NetarchiveSolrClient.getInstance().idLookupResponse(id,PropertiesLoaderWeb.FIELDS);
     }
 
-    
     /*
     //TODO limit fields allowed 
     public  static String getRawSolrQuery(String query,List<String> fq,String fieldList, int rows, int startRow, HashMap<String,String> rawQueryParams)  throws Exception{     
@@ -546,7 +542,7 @@ public class Facade {
             }
         }
         else {
-            max= PropertiesLoaderWeb.EXPORT_WARC_EXPANDED_MAXRESULTS;;
+            max= PropertiesLoaderWeb.EXPORT_WARC_EXPANDED_MAXRESULTS;
             if (results > PropertiesLoaderWeb.EXPORT_WARC_EXPANDED_MAXRESULTS) {
                 throw new InvalidArgumentServiceException("Number of results for warc expanded export exceeds the configured limit: "+PropertiesLoaderWeb.EXPORT_WARC_EXPANDED_MAXRESULTS);
             }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
@@ -42,7 +42,7 @@ public class PropertiesLoaderWeb {
     
     public static final String EXPORT_WARC_MAXRESULTS_PROPERTY = "export.warc.maxresults";
     public static final String EXPORT_CSV_MAXRESULTS_PROPERTY = "export.csv.maxresults";
-    public static final String EXPORT_WARC_EXPANDED_MAXRESULTS_PROPERTY = "export.warc.maxresults";
+    public static final String EXPORT_WARC_EXPANDED_MAXRESULTS_PROPERTY = "export.warc.expanded.maxresults";
 
     public static final String EXPORT_CSV_FIELDS_PROPERTY = "export.csv.fields";
     public static final String ABOUT_TEXT_FILE_PROPERTY = "about.text.file";

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
@@ -134,9 +134,9 @@ public class PropertiesLoaderWeb {
             SEARCH_UPLOADED_FILE_DISABLED = Boolean.parseBoolean(serviceProperties.getProperty(SEARCH_UPLOADED_FILE_DISABLED_PROPERTY));
             EXPORT_CSV_FIELDS = serviceProperties.getProperty(EXPORT_CSV_FIELDS_PROPERTY);
             
-            ABOUT_TEXT_FILE = serviceProperties.getProperty(ABOUT_TEXT_FILE_PROPERTY).trim();
-            SEARCH_HELP_TEXT_FILE = serviceProperties.getProperty(SEARCH_HELP_FILE_PROPERTY).trim();
-            COLLECTION_TEXT_FILE = serviceProperties.getProperty(COLLECTION_TEXT_FILE_PROPERTY).trim();
+            ABOUT_TEXT_FILE = serviceProperties.getProperty(ABOUT_TEXT_FILE_PROPERTY);
+            SEARCH_HELP_TEXT_FILE = serviceProperties.getProperty(SEARCH_HELP_FILE_PROPERTY);
+            COLLECTION_TEXT_FILE = serviceProperties.getProperty(COLLECTION_TEXT_FILE_PROPERTY);
 
             LEAFLET_SOURCE = serviceProperties.getProperty(LEAFLET_SOURCE_PROPERTY);
             LEAFLET_ATTRIBUTION = serviceProperties.getProperty(LEAFLET_ATTRIBUTION_PROPERTY);
@@ -164,17 +164,17 @@ public class PropertiesLoaderWeb {
                 SEARCH_PAGINATION  = Long.parseLong(search_pagination.trim());
             }
 
-            if (ABOUT_TEXT_FILE == null || ABOUT_TEXT_FILE.trim().isEmpty()) {
+            if (ABOUT_TEXT_FILE == null || (ABOUT_TEXT_FILE = ABOUT_TEXT_FILE.trim()).isEmpty()) {
                 ABOUT_TEXT_FILE = "/about_this_archive.txt";
                 log.warn("about.text.file in solrwaybackweb.properties is not set. Using default: /about_this_archive.txt");
             }
 
-            if (SEARCH_HELP_TEXT_FILE == null || SEARCH_HELP_TEXT_FILE.trim().isEmpty()) {
+            if (SEARCH_HELP_TEXT_FILE == null || (SEARCH_HELP_TEXT_FILE = SEARCH_HELP_TEXT_FILE.trim()).isEmpty()) {
                 SEARCH_HELP_TEXT_FILE = "/search_help.txt";
                 log.warn("search.help.text.file in solrwaybackweb.properties is not set. Using default: /search_help.txt");
             }
 
-            if (COLLECTION_TEXT_FILE == null || COLLECTION_TEXT_FILE.trim().isEmpty()) {
+            if (COLLECTION_TEXT_FILE == null || (COLLECTION_TEXT_FILE = COLLECTION_TEXT_FILE.trim()).isEmpty()) {
                 COLLECTION_TEXT_FILE = "/about_collection.txt";
                 log.warn("collection.text.file in solrwaybackweb.properties is not set. Using default: /about_collection.txt");
             }
@@ -246,6 +246,7 @@ public class PropertiesLoaderWeb {
         catch (Exception e) {
             e.printStackTrace();
             log.error("Could not load property file:"+ propertyFile);
+            // TODO: This should be a catastrophic failure as the properties contains security oriented settings
         }
         
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/NamedConsumer.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/NamedConsumer.java
@@ -1,0 +1,45 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.util;
+
+import java.util.function.Consumer;
+
+/**
+ * Wrapper for {@link Consumer} that takes a name and uses it in {@link #toString()}.
+ * Intended for log messages and debugging.
+ */
+public class NamedConsumer<C> implements Consumer<C> {
+    private final String name;
+    private final Consumer<C> inner;
+
+    public NamedConsumer(Consumer<C> inner, String name) {
+        this.name = name;
+        this.inner = inner;
+    }
+
+    @Override
+    public void accept(C c) {
+        inner.accept(c);
+    }
+
+    @Override
+    public Consumer<C> andThen(Consumer<? super C> consumer) {
+        return Consumer.super.andThen(consumer);
+    }
+
+    public String toString() {
+        return "NamedConsumer(" + name + ")";
+    }
+}


### PR DESCRIPTION
Export to `warc.gz` caused truncated files in production: #332 

The cause seems to be #332 + #333 but during the investingation some minor enhancements were introduced to the code base, primarily Exception handling for export. This pull request contains those.

This closes #322 