### PR TITLE
Fixed parsing of content-length in HTTP header if tab/white spaces.

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
@@ -266,7 +266,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
     else if (headerLine.toLowerCase().startsWith("transfer-encoding:")) {                                      
       String transferEncoding=headerLine.substring(18).trim();
       //log.debug("transfer-encoding:"+transferEncoding);
-      if (transferEncoding.equalsIgnoreCase("chunked")) {
+      if (transferEncoding.indexOf("chunked") > 0) { //multivalued
         warcEntry.setChunked(true);
       }
     }    

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
@@ -61,13 +61,11 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
     warcEntry.setFormat(ArcEntry.FORMAT.WARC);
     warcEntry.setSource(arcSource);
     warcEntry.setOffset(warcEntryPosition);
-
+    
     try (InputStream is = arcSource.get()) {
         InputStreamUtils.skipFully(is, warcEntryPosition);
-
         try (BufferedInputStream bis = new BufferedInputStream(is)) {
-            loadWarcHeader(bis, warcEntry);
-
+            loadWarcHeader(bis, warcEntry);            
             //log.debug("Arc entry : totalsize:"+totalSize +" headersize:"+headerSize+" binary size:"+binarySize);
             if (loadBinary) {
                 loadBinary(bis, warcEntry);
@@ -254,7 +252,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
 
     }  //Content-Length: 31131
     else if (headerLine.toLowerCase().startsWith("content-length:")) {
-      String[] contentLine = headerLine.split(" ");
+      String[] contentLine = headerLine.split(":");
       long totalSize = Long.parseLong(contentLine[1].trim());               
       warcEntry.setContentLength(totalSize);                       
     }
@@ -267,7 +265,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
     }
     else if (headerLine.toLowerCase().startsWith("transfer-encoding:")) {                                      
       String transferEncoding=headerLine.substring(18).trim();
-      log.debug("transfer-encoding:"+transferEncoding);
+      //log.debug("transfer-encoding:"+transferEncoding);
       if (transferEncoding.equalsIgnoreCase("chunked")) {
         warcEntry.setChunked(true);
       }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
@@ -15,11 +15,33 @@ import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
 import dk.kb.netarchivesuite.solrwayback.facade.Facade;
 import dk.kb.netarchivesuite.solrwayback.image.ImageUtils;
 import dk.kb.netarchivesuite.solrwayback.parsers.ArcFileParserFactory;
+import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
 
 
 public class WarcGzParserTest  extends UnitTestUtils{
        
+    
+    @Test
+    public void testEvilWarcParser() throws Exception {                      
+        // The binary is not loaded, so content offsets in the WARC-File does not need match
+        // so the WARC file can be edited with further evil header entries.
+        File file = getFile("src/test/resources/example_warc/Evil-Warc-Headers.warc");
+        try {        
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 0,false);  //first entry, no WARC metadata header
+        
+        assertEquals("text/plain", arcEntry.getContentType());
+        assertEquals("robots.txt", arcEntry.getFileName());
+        assertEquals(6000, arcEntry.getWarcEntryContentLength());       
+        assertEquals(200,arcEntry.getStatus_code());
+        assertEquals(5155,arcEntry.getContentLength()); //This entry has a tab/multiple whitespace before size
+        }
+        catch(Exception e) {
+            e.printStackTrace();
+            fail();            
+        }                
+    }
+    
     @Test
     public void testWarcGzParser() throws Exception {
         

--- a/src/test/resources/example_warc/Evil-Warc-Headers.warc
+++ b/src/test/resources/example_warc/Evil-Warc-Headers.warc
@@ -1,0 +1,42 @@
+WARC/0.17
+WARC-Type: response
+WARC-Target-URI: http://www.archive.org/robots.txt
+WARC-Date: 2008-04-30T20:48:25Z
+WARC-Payload-Digest: sha1:SUCGMUVXDKVB5CS2NL4R4JABNX7K466U
+WARC-IP-Address: 207.241.229.39
+WARC-Record-ID: <urn:uuid:e7c9eff8-f5bc-4aeb-b3d2-9d3df99afb30>
+Content-Type: application/http; msgtype=response
+Content-Length: 6000
+Server: BigIP
+Content-Type: text/html; charset=utf-8
+Accept-Ranges: bytes
+Connection: close
+
+HTTP/1.1 200 OK
+Date: Wed, 30 Apr 2008 20:48:24 GMT
+Server: Apache/2.0.54 (Ubuntu) PHP/5.0.5-2ubuntu1.4 mod_ssl/2.0.54 OpenSSL/0.9.7g
+Last-Modified: Sat, 02 Feb 2008 19:40:44 GMT
+ETag: "47c3-1d3-11134700"
+Accept-Ranges: bytes
+Date: Tue, 01 Mar 2022 14:48:02 GMT
+Age:     866
+Content-Length:       5155
+Connection: close
+Content-Type: text/plain; charset=UTF-8
+
+##############################################
+#
+# Welcome to the Archive!
+#
+##############################################
+# Please crawl our files.
+# We appreciate if you can crawl responsibly.
+# Stay open!
+##############################################
+User-agent: *
+Disallow: /nothing---please-crawl-us--
+
+# slow down the ask jeeves crawler which was hitting our SE a little too fast
+# via collection pages.   --Feb2008 tracey--
+User-agent: Teoma
+Crawl-Delay: 10


### PR DESCRIPTION
Added unittest and a new WARC-file to test resources.