### PR TITLE
Harden export and playback against OOM

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ Bugfix: The property key for expanded warc limit was the same as for non-expande
 
 Default log configuration will create and addition log file called solrwayback_error.log. This will only contain log lines of severity 'error'.  
 
+Hardening against Out Of Memory in export and playback of very large webpages
+
 4.4.0
 -----
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,11 @@ Bugfix: The property key for expanded warc limit was the same as for non-expande
 
 Default log configuration will create and addition log file called solrwayback_error.log. This will only contain log lines of severity 'error'.  
 
-Hardening against Out Of Memory in export and playback of very large webpages
+Hardening against Out Of Memory in export and playback of very large webpages. Added new property for max size of HTML that are parsed for export in solrwaybackweb.properties:
+
+warc.entry.text.max.characters=100000000
+
+
 
 4.4.0
 -----

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/export/StreamingSolrWarcExportBufferedInputStream.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/export/StreamingSolrWarcExportBufferedInputStream.java
@@ -250,7 +250,7 @@ public class StreamingSolrWarcExportBufferedInputStream extends InputStream{
 
     // All the providers are added in a single call, so that they will all be processed by the same thread.
     // If they are added one at a time, they will require a thread for each call.
-    log.debug("loadMore() adding " + providers.size() + " lazy resolved records");
+    //log.debug("loadMore() adding " + providers.size() + " lazy resolved records");
     entryStreams.add(StreamBridge.outputToInput(providers));
   }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/export/StreamingSolrWarcExportBufferedInputStream.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/export/StreamingSolrWarcExportBufferedInputStream.java
@@ -16,7 +16,6 @@ import dk.kb.netarchivesuite.solrwayback.util.StatusInputStream;
 import dk.kb.netarchivesuite.solrwayback.util.StreamBridge;
 import org.apache.commons.io.IOUtils;
 import org.apache.solr.common.SolrDocument;
-import org.apache.solr.common.SolrDocumentList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -268,7 +267,7 @@ public class StreamingSolrWarcExportBufferedInputStream extends InputStream{
     try {
       // Retrieve the payload to local cache (heap or storage, depending on size)
       StatusInputStream payload = entryAndHeaders.entry.getBinaryArraySize() > 0 ?
-              StreamBridge.guaranteedStream(entryAndHeaders.entry.getBinaryLazyLoad(), heapCache) :
+              StreamBridge.guaranteedStream(entryAndHeaders.entry.getContentRaw(), heapCache) :
               StreamBridge.guaranteedStream(new ByteArrayInputStream(new byte[0]), heapCache);
       if (payload.getStatus() == StatusInputStream.STATUS.exception) {
         log.warn("getDelayedStream: Exception encountered while caching payload for '{}'. Delivering partial content",

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/export/StreamingSolrWarcExportBufferedInputStream.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/export/StreamingSolrWarcExportBufferedInputStream.java
@@ -267,7 +267,7 @@ public class StreamingSolrWarcExportBufferedInputStream extends InputStream{
     try {
       // Retrieve the payload to local cache (heap or storage, depending on size)
       StatusInputStream payload = entryAndHeaders.entry.getBinaryArraySize() > 0 ?
-              StreamBridge.guaranteedStream(entryAndHeaders.entry.getContentRaw(), heapCache) :
+              StreamBridge.guaranteedStream(entryAndHeaders.entry.getBinaryRaw(), heapCache) :
               StreamBridge.guaranteedStream(new ByteArrayInputStream(new byte[0]), heapCache);
       if (payload.getStatus() == StatusInputStream.STATUS.exception) {
         log.warn("getDelayedStream: Exception encountered while caching payload for '{}'. Delivering partial content",

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -496,7 +496,7 @@ public class Facade {
     /**
     * Important to set the load binary flag to false if not used    
     */    
-    public static ArcEntry getArcEntry(String source_file_path, long offset, boolean loadBinary) throws Exception {      
+    public static ArcEntry getArcEntry(String source_file_path, long offset) throws Exception {
 
        //Validate WARC+offset has been indexed and in the collection.
        //This will prevent url hacking and accessing other WARC-files if you know location on filesystem.
@@ -508,7 +508,7 @@ public class Facade {
             NetarchiveSolrClient.getInstance().getArcEntry(source_file_path, offset); //Call Solr. Correct exception already thrown if not found
         }        
         
-        return ArcParserFileResolver.getArcEntry(source_file_path, offset, loadBinary);
+        return ArcParserFileResolver.getArcEntry(source_file_path, offset);
     }
 
     /**

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/image/ImageUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/image/ImageUtils.java
@@ -20,6 +20,13 @@ public class ImageUtils {
         return image;        
     }
     
+    public static BufferedImage getImageFromBinary(InputStream bytes) throws Exception{
+
+        InputStream maybeDecompress = InputStreamUtils.maybeDecompress(bytes);
+        BufferedImage image = ImageIO.read(maybeDecompress);
+        return image;
+    }
+
     //TODO not sure this is the best/fastest way to do this in Java. For animated images, this will only return the first image
    public static BufferedImage resizeImage(BufferedImage originalImage, int sourceWidth, int sourceHeight, int targetWidth, int targetHeight) {
         double scale = determineImageScale(sourceWidth, sourceHeight, targetWidth, targetHeight);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcSource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcSource.java
@@ -32,6 +32,9 @@ public class ArcSource implements Supplier<InputStream> {
     private final Supplier<InputStream> supplier;
 
     /**
+     * It is highly recommended to ensure that the {@link InputStream} delivered by the {@code supplier} handles
+     * {@link InputStream#skip(long)} effectively as the primary use case of {@code ArcSource} is to extract a single
+     * entry from a (W)ARC by skipping to entry start and reading forward from there.
      * @param source the source (URL, file path or similar) of the ArcData.
      * @return a Supplier that delivers an InputStream for the (w)arc file, positioned at the beginning.
      */
@@ -48,6 +51,9 @@ public class ArcSource implements Supplier<InputStream> {
         return source;
     }
 
+    /**
+     * @return a stream with the full content of an ARC or a WARC file.
+     */
     @Override
     public InputStream get() {
         return supplier.get();

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcFileParserFactory.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcFileParserFactory.java
@@ -12,9 +12,8 @@ public class ArcFileParserFactory {
    * 
    * @param file_path is the file location, the file location must be resolved first. 
    * @param offset offset in the warc file
-   * @param loadBinary will load the byte[] with the content. Do mot use for video/audio etc. Use the InputStream method for this
-   */  
-    public static ArcEntry getArcEntry(ArcSource arcSource, long offset, boolean loadBinary) throws Exception{
+   */
+    public static ArcEntry getArcEntry(ArcSource arcSource, long offset) throws Exception{
         
         if (arcSource == null ){
             throw new IllegalArgumentException("No arcSupplier provided");
@@ -25,11 +24,11 @@ public class ArcFileParserFactory {
 
 
         if (sourceLowercase.endsWith(".warc")  || sourceLowercase.endsWith(".warc.gz") ) {
-            arcEntry = WarcParser.getWarcEntry(arcSource, offset, loadBinary);
+            arcEntry = WarcParser.getWarcEntry(arcSource, offset);
         }
                         
         else if (sourceLowercase.endsWith(".arc") || sourceLowercase.endsWith("arc.gz")){
-            arcEntry = ArcParser.getArcEntry(arcSource, offset,loadBinary);
+            arcEntry = ArcParser.getArcEntry(arcSource, offset);
         }
         else{
             throw new IllegalArgumentException(

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
@@ -33,16 +33,16 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
    *MicrosoftOfficeWebServer: 5.0_Pub
    *X-Powered-By: ASP.NET
    */
-  public static ArcEntry getArcEntry(ArcSource arcSource, long arcEntryPosition, boolean loadBinary) throws Exception {
+  public static ArcEntry getArcEntry(ArcSource arcSource, long arcEntryPosition) throws Exception {
       if (arcSource.getSource().toLowerCase(Locale.ROOT).endsWith(".gz")){ //It is zipped
-        return getArcEntryZipped(arcSource, arcEntryPosition, loadBinary);
+        return getArcEntryZipped(arcSource, arcEntryPosition);
       } else {
-          return getArcEntryNotZipped(arcSource, arcEntryPosition, loadBinary);
+          return getArcEntryNotZipped(arcSource, arcEntryPosition);
       }      
   }
 
   
-  public static ArcEntry getArcEntryNotZipped(ArcSource arcSource, long arcEntryPosition, boolean loadBinary) throws Exception {
+  public static ArcEntry getArcEntryNotZipped(ArcSource arcSource, long arcEntryPosition) throws Exception {
       ArcEntry arcEntry = new ArcEntry();
       arcEntry.setFormat(ArcEntry.FORMAT.ARC);
       arcEntry.setSource(arcSource);
@@ -55,17 +55,12 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
               loadArcHeader(bis, arcEntry);
 
               //log.debug("Arc entry : totalsize:"+totalSize +" headersize:"+headerSize+" binary size:"+binarySize);
-              if (loadBinary) {
-                  log.debug("loadBinary==true ignored for {}#{}", arcSource, arcEntryPosition);
-                  // TODO: Remove the loadBinary parameter fully
-                  //loadBinary(bis, warcEntry);
-             }
           }
           return arcEntry;
       }
   }
 
-  public static ArcEntry getArcEntryZipped(ArcSource arcSource, long arcEntryPosition, boolean loadBinary) throws Exception {
+  public static ArcEntry getArcEntryZipped(ArcSource arcSource, long arcEntryPosition) throws Exception {
 
     ArcEntry arcEntry = new ArcEntry();
     arcEntry.setFormat(ArcEntry.FORMAT.ARC);
@@ -82,11 +77,6 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
             loadArcHeader(bis, arcEntry);
 
             //System.out.println("Arc entry : totalsize:"+totalSize +" binary size:"+binarySize +" firstHeadersize:"+byteCount);
-            if (loadBinary) {
-                log.debug("loadBinary==true ignored for {}#{}", arcSource, arcEntryPosition);
-                // TODO: Remove the loadBinary parameter fully
-                //loadBinary(bis, warcEntry);
-            }
         }
     }
     return arcEntry;

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
@@ -1,18 +1,18 @@
 package dk.kb.netarchivesuite.solrwayback.parsers;
 
-import java.io.*;
-import java.util.Locale;
-import java.util.zip.GZIPInputStream;
-
 import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
+import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
+import dk.kb.netarchivesuite.solrwayback.util.DateUtils;
 import dk.kb.netarchivesuite.solrwayback.util.InputStreamUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.input.BoundedInputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
-import dk.kb.netarchivesuite.solrwayback.util.DateUtils;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Locale;
+import java.util.zip.GZIPInputStream;
 
 public class ArcParser extends  ArcWarcFileParserAbstract{
 
@@ -89,14 +89,18 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
   }
 
 
-  /*
-   * Will load the header information into the warcEntry
-   * warcEntry will have binaryArraySize defined
-   * 
+  /**
+   * ARC files does not have multiple ARC headers for entries.
+   * ARC entries start with {@code URL timestamp mime length} followed directly by HTTP-headers.
+   * <p>
+   * This method populated the given {@code arcEntry} with information from the single ARC-specific line as well
+   * as information from the HTTP-headers.
+   * @param bis stream positioned at the start of an ARC-entry. Afterwards it will be positioned at the start of content.
+   * @param arcEntry the ARC entry representation to populate.
    */
-  private static void loadArcHeader(BufferedInputStream bis, ArcEntry arcEntry) throws Exception{
+  private static void loadArcHeader(BufferedInputStream bis, ArcEntry arcEntry) throws IOException{
 
-    StringBuffer headerLinesBuffer = new StringBuffer();
+    StringBuilder headerLinesBuffer = new StringBuilder();
 
     String line = readLine(bis); // First line
     headerLinesBuffer.append(line+newLineChar);
@@ -112,6 +116,7 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
     arcEntry.setWaybackDate(waybackDate);
     arcEntry.setUrl(getArcUrl(line));
     arcEntry.setIp(getIp(line));            
+      System.out.println(line);
 
     String[] split = line.split(" ");
     int totalSize = Integer.parseInt(split[split.length - 1]);
@@ -121,11 +126,10 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
     LineAndByteCount lc =readLineCount(bis);
     line=lc.getLine();
     arcEntry.setStatus_code(getStatusCode(line));
-    
     headerLinesBuffer.append(line+newLineChar);
     byteCount +=lc.getByteCount();                    
 
-    while (!"".equals(line)) { // End of warc second header block is an empty line              
+    while (!"".equals(line)) { // End of warc second header block is an empty line
       lc =readLineCount(bis);
       line=lc.getLine();
       headerLinesBuffer.append(line+newLineChar);
@@ -139,9 +143,22 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
     arcEntry.setContentLength(binarySize); //trust the load, not the http-header for arc-files
     arcEntry.setBinaryArraySize(binarySize);      
   }
-  
 
-  public static BufferedInputStream lazyLoadBinary(ArcSource arcSource, long arcEntryPosition) throws Exception {
+
+    /**
+     * Constructs an ARC neutral {@code InputStream} that delivers the binary content for a ARC entry.
+     * If the ARC is marked as gzip-compressed, the content will be automatically gzip-uncompressed.
+     * <p>
+     * This method does not handle decompression or dechunking outside of basic ARC compression.
+     * <p>
+     * This method does not cache the binary and the caller should take care to close the returned {@code InputStream}
+     * after use as failing to do so might cause resource leaks.
+     * @param arcSource        source of the raw ARC.
+     * @param arcEntryPosition where in the ARC the entry is positioned.
+     * @return a stream with the binary content from a ARC entry.
+     * @throws IOException if the binary could not be read.
+     */
+  public static BufferedInputStream lazyLoadContent(ArcSource arcSource, long arcEntryPosition) throws IOException {
       ArcEntry arcEntry = new ArcEntry(); // We just throw away the header info anyway 
 
       InputStream is = arcSource.get();
@@ -165,7 +182,7 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
       
   }
 
-    public static String readLine(BufferedInputStream bis) throws Exception{
+    public static String readLine(BufferedInputStream bis) throws IOException{
       StringBuffer buf = new StringBuffer();
       int current = 0; // CRLN || LN
       while ((current = bis.read()) != '\r' && current != '\n') {
@@ -180,7 +197,7 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
 
     }
 
-    public static LineAndByteCount readLineCount(BufferedInputStream  bis) throws Exception{
+    public static LineAndByteCount readLineCount(BufferedInputStream  bis) throws IOException {
     int count = 0;
     StringBuffer buf = new StringBuffer();
     int current = 0; // CRLN || LN
@@ -226,7 +243,7 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
     return split[1];
   }
 
-  private static String getWaybackDate(String arcHeaderLine) throws Exception {
+  private static String getWaybackDate(String arcHeaderLine) {
     String[] split = arcHeaderLine.split(" ");
     return split[2];                                
   }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParser.java
@@ -56,8 +56,10 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
 
               //log.debug("Arc entry : totalsize:"+totalSize +" headersize:"+headerSize+" binary size:"+binarySize);
               if (loadBinary) {
-                  loadBinary(bis, arcEntry);
-              }
+                  log.debug("loadBinary==true ignored for {}#{}", arcSource, arcEntryPosition);
+                  // TODO: Remove the loadBinary parameter fully
+                  //loadBinary(bis, warcEntry);
+             }
           }
           return arcEntry;
       }
@@ -81,7 +83,9 @@ public class ArcParser extends  ArcWarcFileParserAbstract{
 
             //System.out.println("Arc entry : totalsize:"+totalSize +" binary size:"+binarySize +" firstHeadersize:"+byteCount);
             if (loadBinary) {
-                loadBinary(bis, arcEntry);
+                log.debug("loadBinary==true ignored for {}#{}", arcSource, arcEntryPosition);
+                // TODO: Remove the loadBinary parameter fully
+                //loadBinary(bis, warcEntry);
             }
         }
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParserFileResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParserFileResolver.java
@@ -38,24 +38,8 @@ public class ArcParserFileResolver {
    * first.
    * 
    * @param offset offset in the warc file
-   * 
-   * The binary will be loaded. If binary is not needed use the other method.
    */
-  public static ArcEntry getArcEntry(String source_file_path, long offset) throws Exception {
-    return getArcEntry(source_file_path, offset, true);
-  }
-
-  /*
-   * 
-   * @param file_path is the file location, the file location must be resolved
-   * first.
-   * 
-   * @param offset offset in the warc file
-   * 
-   * @param loadBinary will load the byte[] with the content. Do mot use for
-   * video/audio etc. Use the InputStream method for this
-   */
-  public static ArcEntry getArcEntry(String source_file_path_org, long offset, boolean loadBinary) throws Exception {
+  public static ArcEntry getArcEntry(String source_file_path_org, long offset) throws Exception {
 
     // Maybe this will stop code scan think parameter is used unvalidated.
     // It is validated later to be .warc/.warcs.gz/.arc/.arc.gz
@@ -69,7 +53,7 @@ public class ArcParserFileResolver {
         cache.put(source_file_path, arcSource);
       }
 
-      return ArcFileParserFactory.getArcEntry(arcSource, offset, loadBinary);
+      return ArcFileParserFactory.getArcEntry(arcSource, offset);
 
     } catch (Exception e) {
       // It CAN happen, but crazy unlikely, and not critical at all... (took 10

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
@@ -1,6 +1,7 @@
 package dk.kb.netarchivesuite.solrwayback.parsers;
 
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
+import it.unimi.dsi.fastutil.Arrays;
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +23,7 @@ public class ArcWarcFileParserAbstract {
   protected static void loadBinary(InputStream is, ArcEntry arcEntry) throws IOException {
       long binarySize = arcEntry.getBinaryArraySize();
 
-      if (binarySize > Integer.MAX_VALUE) {
+      if (binarySize > Arrays.MAX_ARRAY_SIZE) {
           String message = "Binary size too large for java byte[]. Size:" + binarySize +
                            ", source='" + arcEntry.getArcSource().getSource() + "'";
         log.error(message);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
@@ -20,6 +20,10 @@ public class ArcWarcFileParserAbstract {
     
   }
 
+    /**
+     * @deprecated on heap caching of full binary content should be avoided.
+     */
+  @Deprecated
   protected static void loadBinary(InputStream is, ArcEntry arcEntry) throws IOException {
       long binarySize = arcEntry.getBinaryArraySize();
 
@@ -27,7 +31,7 @@ public class ArcWarcFileParserAbstract {
           String message = "Binary size too large for java byte[]. Size:" + binarySize +
                            ", source='" + arcEntry.getArcSource().getSource() + "'";
         log.error(message);
-        throw new IllegalArgumentException(message);
+        throw new ArrayIndexOutOfBoundsException(message);
       }
 
       byte[] bytes = new byte[(int) binarySize];

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcWarcFileParserAbstract.java
@@ -1,51 +1,14 @@
 package dk.kb.netarchivesuite.solrwayback.parsers;
 
-import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
-import it.unimi.dsi.fastutil.Arrays;
-import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-
 public class ArcWarcFileParserAbstract {
   private static final Logger log = LoggerFactory.getLogger(ArcWarcFileParserAbstract.class);
-
 
   public static int getStatusCode(String line){//HTTP/1.1 302 Object moved      
     String[] tokens = line.split(" ");
     String status = tokens[1];
     return Integer.parseInt(status);     
-    
   }
-
-    /**
-     * @deprecated on heap caching of full binary content should be avoided.
-     */
-  @Deprecated
-  protected static void loadBinary(InputStream is, ArcEntry arcEntry) throws IOException {
-      long binarySize = arcEntry.getBinaryArraySize();
-
-      if (binarySize > Arrays.MAX_ARRAY_SIZE) {
-          String message = "Binary size too large for java byte[]. Size:" + binarySize +
-                           ", source='" + arcEntry.getArcSource().getSource() + "'";
-        log.error(message);
-        throw new ArrayIndexOutOfBoundsException(message);
-      }
-
-      byte[] bytes = new byte[(int) binarySize];
-
-      // we are not using IOUtils.readFully as we'd rather return non-complete data than nothing
-      int read = IOUtils.read(is, bytes);
-      if (read == -1) {
-          log.warn("Attempted to load binary for {}#{} but got EOF immediately",
-                   arcEntry.getArcSource().getSource(), arcEntry.getOffset());
-      } else if (read < bytes.length) {
-          log.warn("Incomplete binary for {}#{}: {}/{} bytes read",
-                   arcEntry.getArcSource().getSource(), arcEntry.getOffset(), read, bytes.length);
-      }
-      arcEntry.setBinary(bytes);
-  }
-
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriter.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriter.java
@@ -90,7 +90,7 @@ public class HtmlParserUrlRewriter {
 	public static String replaceLinksCss(ArcEntry arc) throws Exception{
 
 		String type="downloadRaw"; //not supporting nested @imports...        		
-		String css = arc.getBinaryContentAsStringUnCompressed();		
+		String css = arc.getStringContentSafe();
 		String url=arc.getUrl();
 
 		String[] result = css.split("\n", 100); //Doubt there will be more than 100 of these.
@@ -135,7 +135,7 @@ public class HtmlParserUrlRewriter {
 	public static ParseResult replaceLinks(ArcEntry arc, boolean lenient) throws Exception{
 		final long startMS = System.currentTimeMillis();
 		return replaceLinks(
-				arc.getBinaryContentAsStringUnCompressed(), arc.getUrl(), arc.getCrawlDate(),
+				arc.getStringContentSafe(), arc.getUrl(), arc.getCrawlDate(),
 				(urls, timeStamp) -> NetarchiveSolrClient.getInstance().findNearestUrlsShort(urls, timeStamp, lenient),
 				startMS);
 	}
@@ -365,11 +365,11 @@ public class HtmlParserUrlRewriter {
   
 	public static HashSet<String> getResourceLinksForHtmlFromArc(ArcEntry arc) throws Exception{
 
-      String html = arc.getBinaryContentAsStringUnCompressed();
+      String html = arc.getStringContentSafe();
 
       String url=arc.getUrl();
 
-
+		// TODO: Switch to streaming based parsing with limit on input size
       Document doc = Jsoup.parse(html,url);
 
       

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriter.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriter.java
@@ -90,7 +90,7 @@ public class HtmlParserUrlRewriter {
 	public static String replaceLinksCss(ArcEntry arc) throws Exception{
 
 		String type="downloadRaw"; //not supporting nested @imports...        		
-		String css = arc.getStringContentSafe();
+		String css = arc.getStringContentAsStringSafe();
 		String url=arc.getUrl();
 
 		String[] result = css.split("\n", 100); //Doubt there will be more than 100 of these.
@@ -135,7 +135,7 @@ public class HtmlParserUrlRewriter {
 	public static ParseResult replaceLinks(ArcEntry arc, boolean lenient) throws Exception{
 		final long startMS = System.currentTimeMillis();
 		return replaceLinks(
-				arc.getStringContentSafe(), arc.getUrl(), arc.getCrawlDate(),
+				arc.getStringContentAsStringSafe(), arc.getUrl(), arc.getCrawlDate(),
 				(urls, timeStamp) -> NetarchiveSolrClient.getInstance().findNearestUrlsShort(urls, timeStamp, lenient),
 				startMS);
 	}
@@ -339,13 +339,13 @@ public class HtmlParserUrlRewriter {
 	public static String generatePwid(ArcEntry arc) throws Exception{
 
       long start = System.currentTimeMillis();
-      String html = new String(arc.getBinary(),arc.getContentEncoding());
+      String html = arc.getStringContentAsStringSafe();
       String url=arc.getUrl();
 
        String collectionName = PropertiesLoader.PID_COLLECTION_NAME;
-      Document doc = Jsoup.parse(html,url);
+		// TODO: Switch to streaming based parsing with limit on input size
+      Document doc = Jsoup.parse(html, url);
 
-     
        HashSet<String> urlSet =  getUrlResourcesForHtmlPage(doc, url);
            
       log.info("#unique urlset to resolve:"+urlSet.size());
@@ -365,7 +365,7 @@ public class HtmlParserUrlRewriter {
   
 	public static HashSet<String> getResourceLinksForHtmlFromArc(ArcEntry arc) throws Exception{
 
-      String html = arc.getStringContentSafe();
+      String html = arc.getStringContentAsStringSafe();
 
       String url=arc.getUrl();
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriterBase.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriterBase.java
@@ -134,7 +134,7 @@ public abstract class RewriterBase {
     	ParseResult parseResult = new ParseResult();
 
    		final long startgetContentMS = System.currentTimeMillis();
-   		String content = arc.getStringContentSafe();
+   		String content = arc.getStringContentAsStringSafe();
    		parseResult.addTiming("getContent", System.currentTimeMillis()-startgetContentMS);
 
 		replaceLinks(

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriterBase.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/RewriterBase.java
@@ -134,7 +134,7 @@ public abstract class RewriterBase {
     	ParseResult parseResult = new ParseResult();
 
    		final long startgetContentMS = System.currentTimeMillis();
-   		String content = arc.getBinaryContentAsStringUnCompressed();
+   		String content = arc.getStringContentSafe();
    		parseResult.addTiming("getContent", System.currentTimeMillis()-startgetContentMS);
 
 		replaceLinks(

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
@@ -69,7 +69,9 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
             loadWarcHeader(bis, warcEntry);            
             //log.debug("Arc entry : totalsize:"+totalSize +" headersize:"+headerSize+" binary size:"+binarySize);
             if (loadBinary) {
-                loadBinary(bis, warcEntry);
+                log.debug("loadBinary==true ignored for {}#{}", arcSource, warcEntryPosition);
+                // TODO: Remove the loadBinary parameter fully
+                //loadBinary(bis, warcEntry);
             }
         }
         return warcEntry;
@@ -147,7 +149,9 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
 
             //System.out.println("Arc entry : totalsize:"+totalSize +" binary size:"+binarySize +" firstHeadersize:"+byteCount);
             if (loadBinary) {
-                loadBinary(bis, warcEntry);
+                log.debug("loadBinary==true ignored for {}#{}", arcSource, warcEntryPosition);
+                // TODO: Remove the loadBinary parameter fully
+                //loadBinary(bis, warcEntry);
             }
         }
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
@@ -46,17 +46,17 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
    *Connection: close
    *Content-Length: 7178
    */
-  public static ArcEntry getWarcEntry(ArcSource arcSource, long warcEntryPosition, boolean loadBinary) throws Exception {
+  public static ArcEntry getWarcEntry(ArcSource arcSource, long warcEntryPosition) throws Exception {
 
     if (arcSource.getSource().toLowerCase(Locale.ROOT).endsWith(".gz")){ //It is zipped
-      return getWarcEntryZipped(arcSource, warcEntryPosition, loadBinary);
+      return getWarcEntryZipped(arcSource, warcEntryPosition);
     }
     else {
-      return getWarcEntryNotZipped(arcSource, warcEntryPosition, loadBinary);
+      return getWarcEntryNotZipped(arcSource, warcEntryPosition);
     }          
   }
 
-  public static ArcEntry getWarcEntryNotZipped(ArcSource arcSource, long warcEntryPosition,boolean loadBinary) throws Exception {
+  public static ArcEntry getWarcEntryNotZipped(ArcSource arcSource, long warcEntryPosition) throws Exception {
 
     ArcEntry warcEntry = new ArcEntry();
     warcEntry.setFormat(ArcEntry.FORMAT.WARC);
@@ -68,11 +68,6 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
         try (BufferedInputStream bis = new BufferedInputStream(is)) {
             loadWarcHeader(bis, warcEntry);            
             //log.debug("Arc entry : totalsize:"+totalSize +" headersize:"+headerSize+" binary size:"+binarySize);
-            if (loadBinary) {
-                log.debug("loadBinary==true ignored for {}#{}", arcSource, warcEntryPosition);
-                // TODO: Remove the loadBinary parameter fully
-                //loadBinary(bis, warcEntry);
-            }
         }
         return warcEntry;
     }
@@ -131,7 +126,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
     warcEntry.setBinaryArraySize(binarySize);
   }
 
-  public static ArcEntry getWarcEntryZipped(ArcSource arcSource, long warcEntryPosition, boolean loadBinary) throws Exception {
+  public static ArcEntry getWarcEntryZipped(ArcSource arcSource, long warcEntryPosition) throws Exception {
 
     ArcEntry warcEntry = new ArcEntry();
     warcEntry.setFormat(ArcEntry.FORMAT.WARC);
@@ -148,11 +143,6 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
             loadWarcHeader(bis, warcEntry);
 
             //System.out.println("Arc entry : totalsize:"+totalSize +" binary size:"+binarySize +" firstHeadersize:"+byteCount);
-            if (loadBinary) {
-                log.debug("loadBinary==true ignored for {}#{}", arcSource, warcEntryPosition);
-                // TODO: Remove the loadBinary parameter fully
-                //loadBinary(bis, warcEntry);
-            }
         }
     }
     return warcEntry;

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/WarcParser.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
 import java.util.zip.GZIPInputStream;
@@ -81,7 +82,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
    * warcEntry will have binaryArraySize defined
    * 
    */
-  private static void loadWarcHeader(BufferedInputStream bis, ArcEntry warcEntry) throws Exception{
+  private static void loadWarcHeader(BufferedInputStream bis, ArcEntry warcEntry) throws IOException {
 
     StringBuffer headerLinesBuffer = new StringBuffer();
     String line = readLine(bis); // First line
@@ -159,7 +160,20 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
   }
 
 
-  public static BufferedInputStream lazyLoadBinary(ArcSource arcSource, long arcEntryPosition) throws Exception{
+    /**
+     * Constructs a (W)ARC neutral {@code InputStream} that delivers the binary content for a WARC entry.
+     * If the WARC is marked as gzip-compressed, the content will be automatically gzip-uncompressed.
+     * <p>
+     * This method does not handle decompression or dechunking outside of basic WARC compression.
+     * <p>
+     * This method does not cache the binary and the caller should take care to close the returned {@code InputStream}
+     * after use as failing to do so might cause resource leaks.
+     * @param arcSource        source of the raw WARC.
+     * @param arcEntryPosition where in the WARC the entry is positioned.
+     * @return a stream with the binary content from a WARC entry.
+     * @throws IOException if the binary could not be read.
+     */
+  public static BufferedInputStream lazyLoadBinary(ArcSource arcSource, long arcEntryPosition) throws IOException{
     ArcEntry arcEntry = new ArcEntry(); // We just throw away the header info anyway 
 
     InputStream is = arcSource.get();
@@ -276,7 +290,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
 
   }
 
-  public static String readLine(BufferedInputStream  bis) throws Exception{
+  public static String readLine(BufferedInputStream  bis) throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     int current = 0; // CRLN || LN
     while ((current = bis.read()) != '\r' && current != '\n') {             
@@ -289,7 +303,7 @@ public class WarcParser extends  ArcWarcFileParserAbstract {
     return baos.toString(WARC_HEADER_ENCODING);
   }
 
-  public static LineAndByteCount readLineCount(BufferedInputStream  bis) throws Exception{
+  public static LineAndByteCount readLineCount(BufferedInputStream  bis) throws IOException {
     int count = 0;
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/CssPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/CssPlayback.java
@@ -20,7 +20,8 @@ public class CssPlayback  extends PlaybackHandler{
   @Override
   public ArcEntry playback(boolean lenient) throws Exception{
     //Never show the toolbar.
-      arc.setBinary(IOUtils.toByteArray(arc.getBinaryContentAsStringUnCompressed())); //TODO charset;          
+      // TODO: What is the purpose of this round trip?
+      arc.setBinary(IOUtils.toByteArray(arc.getStringContentSafe())); //TODO charset;
       
     String textReplaced = HtmlParserUrlRewriter.replaceLinksCss(arc);                
     if (!"gzip".equalsIgnoreCase(arc.getContentEncoding())){ 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/CssPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/CssPlayback.java
@@ -20,16 +20,13 @@ public class CssPlayback  extends PlaybackHandler{
   @Override
   public ArcEntry playback(boolean lenient) throws Exception{
     //Never show the toolbar.
-      // TODO: What is the purpose of this round trip?
-      arc.setBinary(IOUtils.toByteArray(arc.getStringContentSafe())); //TODO charset;
+      // TODO: What was the purpose of this round trip? If re-enabled, please state why in a comment
+    //  arc.setBinary(IOUtils.toByteArray(arc.getStringContentAsStringSafe())); //TODO charset;
       
-    String textReplaced = HtmlParserUrlRewriter.replaceLinksCss(arc);                
-    if (!"gzip".equalsIgnoreCase(arc.getContentEncoding())){ 
-      arc.setBinary(textReplaced.getBytes(arc.getContentCharset()));
-      }
-      else{
-       arc.setBinary(textReplaced.getBytes("UTF-8"));  
-      }    
+    String textReplaced = HtmlParserUrlRewriter.replaceLinksCss(arc);
+    // content-encoding is about compression; not relevant for charset
+    // if (!"gzip".equalsIgnoreCase(arc.getContentEncoding())){
+    arc.setStringContent(textReplaced);
     return arc;
   }
   

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/HtmlPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/HtmlPlayback.java
@@ -25,17 +25,7 @@ public class HtmlPlayback  extends PlaybackHandler{
               doc.getSource_file_path(), doc.getOffset(), arc.getContentEncoding(), lenient);
     long start = System.currentTimeMillis();
     
-     String raw = arc.getStringContentSafe();
-    
-      String charset = arc.getContentCharset();
-      if (charset== null){
-          charset="UTF-8";
-          log.warn("no charset, default to UTF-8");
-      }
-      // TODO: What is the purpose of this round trip?
-      arc.setBinary(raw.getBytes(Charset.forName(charset)));
-         
-    
+
      ParseResult htmlReplaced = HtmlParserUrlRewriter.replaceLinks(arc, lenient);
       String textReplaced=htmlReplaced.getReplaced();
 
@@ -44,20 +34,8 @@ public class HtmlPlayback  extends PlaybackHandler{
      if (showToolbar ){ //If true or null. 
         textReplaced = WaybackToolbarInjecter.injectWaybacktoolBar(doc.getSource_file_path(),doc.getOffset(),htmlReplaced , xhtml);
      }
-    
-     try{
-     if (!"gzip".equalsIgnoreCase(arc.getContentEncoding())){ //TODO x-gzip brotli
-       arc.setBinary(textReplaced.getBytes(arc.getContentCharset()));
-       }
-       else{
-        arc.setBinary(textReplaced.getBytes("UTF-8"));  
-       }
-      
-     }
-     catch(Exception e){       
-       log.warn("unknown encoding, defaulting to utf-8:'"+arc.getContentEncoding()+"' . file:"+doc.getSource_file_path() +" offset:"+doc.getOffset());
-       arc.setBinary(textReplaced.getBytes("UTF-8"));
-     }
+
+     arc.setStringContent(textReplaced);
 
      log.info("Generating webpage total processing:"+(System.currentTimeMillis()-start) + " "+doc.getSource_file_path()+ " "+ doc.getOffset() +" "+arc.getUrl());
      arc.setHasBeenDecompressed(true);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/HtmlPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/HtmlPlayback.java
@@ -25,14 +25,14 @@ public class HtmlPlayback  extends PlaybackHandler{
               doc.getSource_file_path(), doc.getOffset(), arc.getContentEncoding(), lenient);
     long start = System.currentTimeMillis();
     
-     String raw = arc.getBinaryContentAsStringUnCompressed();
+     String raw = arc.getStringContentSafe();
     
       String charset = arc.getContentCharset();
       if (charset== null){
           charset="UTF-8";
           log.warn("no charset, default to UTF-8");
       }
-      
+      // TODO: What is the purpose of this round trip?
       arc.setBinary(raw.getBytes(Charset.forName(charset)));
          
     

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/JavascriptPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/JavascriptPlayback.java
@@ -20,11 +20,14 @@ public class JavascriptPlayback  extends PlaybackHandler{
   @Override
   public ArcEntry playback(boolean lenient) throws Exception{
     //Never show the toolbar.
-      arc.setBinary(IOUtils.toByteArray(arc.getBinaryContentAsStringUnCompressed())); //TODO charset;
+      // TODO: What is the purpose of this round trip?
+      arc.setBinary(IOUtils.toByteArray(arc.getStringContentSafe())); //TODO charset;
       //log.debug("javascript playback");
       
       
-    String textReplaced = HtmlParserUrlRewriter.replaceLinksCss(arc);                
+    String textReplaced = HtmlParserUrlRewriter.replaceLinksCss(arc);
+    // TODO: This logic is wrong. Content Encoding states compression and is independent of Content Charset
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
     if (!"gzip".equalsIgnoreCase(arc.getContentEncoding())){ 
       arc.setBinary(textReplaced.getBytes(arc.getContentCharset()));
       }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/JavascriptPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/JavascriptPlayback.java
@@ -20,20 +20,15 @@ public class JavascriptPlayback  extends PlaybackHandler{
   @Override
   public ArcEntry playback(boolean lenient) throws Exception{
     //Never show the toolbar.
-      // TODO: What is the purpose of this round trip?
-      arc.setBinary(IOUtils.toByteArray(arc.getStringContentSafe())); //TODO charset;
+    // TODO: What was the purpose of this round trip? If re-enabled, please state why in a comment
+      //arc.setBinary(IOUtils.toByteArray(arc.getStringContentAsStringSafe())); //TODO charset;
       //log.debug("javascript playback");
       
       
     String textReplaced = HtmlParserUrlRewriter.replaceLinksCss(arc);
-    // TODO: This logic is wrong. Content Encoding states compression and is independent of Content Charset
+    // TODO: This logic was wrong. Content Encoding states compression and is independent of Content Charset
     // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
-    if (!"gzip".equalsIgnoreCase(arc.getContentEncoding())){ 
-      arc.setBinary(textReplaced.getBytes(arc.getContentCharset()));
-      }
-      else{
-       arc.setBinary(textReplaced.getBytes("UTF-8"));  
-      }    
+    arc.setStringContent(textReplaced);
     return arc;
   }
   

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/JodelPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/JodelPlayback.java
@@ -25,10 +25,9 @@ public class JodelPlayback extends PlaybackHandler{
     log.debug(" Generate Jodel post from FilePath:" + doc.getSource_file_path() + " offset:" + doc.getOffset());
     //Fake html into arc.
 
-    String encoding=arc.getContentEncoding();
-    String json = new String(arc.getBinary(), encoding);
+    String json = arc.getStringContentAsStringSafe();
     String html = "TODO";//Jodel2Html.render(json, arc.getCrawlDate());
-    arc.setBinary(html.getBytes());        
+    arc.setStringContent(html);
     arc.setContentType("text/html");
     ParseResult htmlReplaced = new ParseResult(); //Do not parse.
     htmlReplaced.setReplaced(html);
@@ -38,9 +37,9 @@ public class JodelPlayback extends PlaybackHandler{
     if (showToolbar){ //If true or null.
        textReplaced = WaybackToolbarInjecter.injectWaybacktoolBar(doc,htmlReplaced, false);
     }
-    encoding="UTF-8"; // hack, since the HTML was generated as UTF-8.
+    String encoding="UTF-8"; // hack, since the HTML was generated as UTF-8.
     arc.setContentEncoding(encoding);
-    arc.setBinary(textReplaced.getBytes(encoding));  //can give error. uses UTF-8 (from index) instead of ISO-8859-1
+    arc.setStringContent(textReplaced);  //can give error. uses UTF-8 (from index) instead of ISO-8859-1
     
     return arc;
   }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/TwitterPlayback.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/playback/TwitterPlayback.java
@@ -26,10 +26,8 @@ public class TwitterPlayback extends PlaybackHandler{
         log.debug(" Generate twitter webpage from FilePath:" + doc.getSource_file_path() + " offset:" + doc.getOffset());
         // Fake html into arc.
         String encoding = "UTF-8"; // Why does encoding say ISO ? This seems to fix the bug
-        String json = new String(arc.getBinary(), encoding);
-        Twitter2Html parser = new Twitter2Html(json, arc.getCrawlDate());
+        Twitter2Html parser = new Twitter2Html(arc.getStringContentSafe(), arc.getCrawlDate());
         String html = parser.getHtmlFromJson();
-        arc.setBinary(html.getBytes());
         arc.setContentType("text/html");
         ParseResult htmlReplaced = new ParseResult(); // Do not parse.
         htmlReplaced.setReplaced(html);
@@ -40,7 +38,7 @@ public class TwitterPlayback extends PlaybackHandler{
             textReplaced = WaybackToolbarInjecter.injectWaybacktoolBar(doc, htmlReplaced, false);
         }
         arc.setContentEncoding(encoding);
-        arc.setBinary(textReplaced.getBytes(encoding)); // Can give error. Uses UTF-8 (from index) instead of ISO-8859-1
+        arc.setStringContent(textReplaced);
 
         return arc;
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoaderWeb.java
@@ -40,6 +40,8 @@ public class PropertiesLoaderWeb {
     public static final String SEARCH_UPLOADED_FILE_DISABLED_PROPERTY="search.uploaded.file.disabled";
     public static final String SEARCH_PAGINATION_PROPERTY = "search.pagination";
     
+    public static final String WARC_ENTRY_TEXT_MAX_CHARACTERS_PROPERTY = "warc.entry.text.max.characters";
+
     public static final String EXPORT_WARC_MAXRESULTS_PROPERTY = "export.warc.maxresults";
     public static final String EXPORT_CSV_MAXRESULTS_PROPERTY = "export.csv.maxresults";
     public static final String EXPORT_WARC_EXPANDED_MAXRESULTS_PROPERTY = "export.warc.expanded.maxresults";
@@ -68,7 +70,9 @@ public class PropertiesLoaderWeb {
     public static String MAPS_LATITUDE;
     public static String MAPS_LONGITUDE;
     public static String MAPS_RADIUS;
-    
+
+    public static int WARC_ENTRY_TEXT_MAX_CHARACTERS = 100*1024*1024; // 100 MB
+
     public static long EXPORT_CSV_MAXRESULTS=10000000;// 10M default
     public static long EXPORT_WARC_MAXRESULTS=1000000; // 1M default
     public static long EXPORT_WARC_EXPANDED_MAXRESULTS=100000; // 500K default   
@@ -147,7 +151,9 @@ public class PropertiesLoaderWeb {
             LEAFLET_ATTRIBUTION = serviceProperties.getProperty(LEAFLET_ATTRIBUTION_PROPERTY);
             TOP_LEFT_LOGO_IMAGE = serviceProperties.getProperty(TOP_LEFT_LOGO_IMAGE_PROPERTY);
             TOP_LEFT_LOGO_IMAGE_LINK = serviceProperties.getProperty(TOP_LEFT_LOGO_IMAGE_LINK_PROPERTY);
-                        
+
+            WARC_ENTRY_TEXT_MAX_CHARACTERS = getInt(WARC_ENTRY_TEXT_MAX_CHARACTERS_PROPERTY, WARC_ENTRY_TEXT_MAX_CHARACTERS);
+
             String csv_max_results= serviceProperties.getProperty(EXPORT_CSV_MAXRESULTS_PROPERTY);
             String warc_max_results= serviceProperties.getProperty(EXPORT_WARC_MAXRESULTS_PROPERTY);
             String warc_expanded_max_results= serviceProperties.getProperty(EXPORT_WARC_EXPANDED_MAXRESULTS_PROPERTY);
@@ -219,6 +225,7 @@ public class PropertiesLoaderWeb {
             log.info("Property:"+ OPENWAYBACK_SERVER_PROPERTY +" = " + OPENWAYBACK_SERVER);
             log.info("Property:"+ ALLOW_EXPORT_WARC_PROPERTY +" = " + ALLOW_EXPORT_WARC);
             log.info("Property:"+ ALLOW_EXPORT_CSV_PROPERTY +" = " + ALLOW_EXPORT_CSV);
+            log.info("Property:"+ WARC_ENTRY_TEXT_MAX_CHARACTERS_PROPERTY +" = " + WARC_ENTRY_TEXT_MAX_CHARACTERS);
             log.info("Property:"+ EXPORT_CSV_MAXRESULTS_PROPERTY +" = " + EXPORT_CSV_MAXRESULTS);
             log.info("Property:"+ EXPORT_WARC_MAXRESULTS_PROPERTY +" = " + EXPORT_WARC_MAXRESULTS);
             log.info("Property:"+ EXPORT_WARC_EXPANDED_MAXRESULTS_PROPERTY +" = " + EXPORT_WARC_EXPANDED_MAXRESULTS);
@@ -254,6 +261,17 @@ public class PropertiesLoaderWeb {
             // TODO: This should be a catastrophic failure as the properties contains security oriented settings
         }
         
+    }
+
+    private static int getInt(String key, int defaultValue) {
+        if (serviceProperties == null) {
+            initProperties();
+        }
+        String raw = serviceProperties.getProperty(key);
+        if (raw == null || raw.isEmpty()) {
+            return defaultValue;
+        }
+        return Integer.parseInt(raw.trim());
     }
 
     public static String getProperty(String key, String defaultValue) {

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
@@ -69,7 +69,7 @@ public class SolrWaybackResource {
   @Produces(MediaType.APPLICATION_JSON +"; charset=UTF-8")
   public ArcEntry getArcEntry(@QueryParam("source_file_path") String source_file_path, @QueryParam("offset") long offset) throws SolrWaybackServiceException {
       try {                                                                                      
-        ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset,false);
+        ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset);
         return arcEntry;                              
       } catch (Exception e) {         
           throw handleServiceExceptions(e);
@@ -82,7 +82,7 @@ public class SolrWaybackResource {
   @Produces({ MediaType.TEXT_PLAIN})
   public String getWarcHeader( @QueryParam("source_file_path") String source_file_path, @QueryParam("offset") long offset) throws SolrWaybackServiceException {
       try {                                                                                      
-        ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset,false);
+        ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset);
         return arcEntry.getHeader();                              
       } catch (Exception e) {         
           throw handleServiceExceptions(e);
@@ -94,7 +94,7 @@ public class SolrWaybackResource {
   @Produces(MediaType.APPLICATION_JSON +"; charset=UTF-8")
   public ArcEntry getWarcParsed( @QueryParam("source_file_path") String source_file_path, @QueryParam("offset") long offset) throws SolrWaybackServiceException {
       try {                                                                                      
-        ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset,true);
+        ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset);
          return arcEntry;                              
       } catch (Exception e) {         
           throw handleServiceExceptions(e);
@@ -174,10 +174,10 @@ public class SolrWaybackResource {
 
       //log.debug("Getting image from source_file_path:" + source_file_path + " offset:" + offset + " targetWidth:" + width + " targetHeight:" + height);
 
-      ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset,true);
+      ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset);
 
-      // TODO: This is prone to OOM for large images. There should be a sanity check that checks width & height first
-      BufferedImage image = ImageUtils.getImageFromBinary(arcEntry.getBinaryRaw());
+      // TODO: This is prone to OOM for large images. There should be a sanity check of width & height first
+      BufferedImage image = ImageUtils.getImageFromBinary(arcEntry.getBinaryDecoded());
 
       if (image== null){
         // java does not support ico format. Just serve it RAW... 
@@ -234,7 +234,7 @@ public class SolrWaybackResource {
         }
         
   //  log.debug("Download from FilePath:" + source_file_path + " offset:" + offset);
-      ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset,false); //DO not load binary in memory
+      ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset);
       
       //Only solr lookup if redirect.
       if (arcEntry.getStatus_code() >= 300 &&  arcEntry.getStatus_code() <= 399 ){
@@ -1050,7 +1050,7 @@ public class SolrWaybackResource {
       ResponseBuilder response = Response.status(status);
       
       if(arc == null){
-        arc = Facade.getArcEntry(doc.getSource_file_path(), doc.getOffset(),false); //Do not load binary
+        arc = Facade.getArcEntry(doc.getSource_file_path(), doc.getOffset());
       }      
       response.status(status); // jersey require a legal status code.
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
@@ -243,7 +243,7 @@ public class SolrWaybackResource {
         return responseRedirect;
       }
       
-      InputStream in = arcEntry.getBinaryNoChucking(); //Stream entry. Dechucking require as tomcat/apache also chunks.
+      InputStream in = arcEntry.getBinaryNoChunking(); //Stream entry. Dechucking require as tomcat/apache also chunks.
       
       ResponseBuilder response = null;
       try{        

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
@@ -11,7 +11,6 @@ import java.net.URL;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.time.LocalDate;
-import java.time.Period;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
@@ -244,7 +243,7 @@ public class SolrWaybackResource {
         return responseRedirect;
       }
       
-      InputStream in = arcEntry.getBinaryLazyLoadNoChucking(); //Stream entry. Dechucking require as tomcat/apache also chunks.
+      InputStream in = arcEntry.getBinaryNoChucking(); //Stream entry. Dechucking require as tomcat/apache also chunks.
       
       ResponseBuilder response = null;
       try{        

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
@@ -176,7 +176,8 @@ public class SolrWaybackResource {
 
       ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset,true);
 
-      BufferedImage image = ImageUtils.getImageFromBinary(arcEntry.getBinary());
+      // TODO: This is prone to OOM for large images. There should be a sanity check that checks width & height first
+      BufferedImage image = ImageUtils.getImageFromBinary(arcEntry.getBinaryRaw());
 
       if (image== null){
         // java does not support ico format. Just serve it RAW... 
@@ -935,8 +936,7 @@ public class SolrWaybackResource {
    //log.debug("setting contentype:"+contentType);
 //          
    
-   InputStream in = new ByteArrayInputStream(arcEntry.getBinary());
-   ResponseBuilder response = Response.ok(in).type(contentType );                    
+   ResponseBuilder response = Response.ok(arcEntry.getBinaryRaw()).type(contentType );
 
    
     if (arcEntry.isHasBeenDecompressed()){     

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
@@ -623,7 +623,7 @@ public class SolrWaybackResourceWeb {
       try {
 
         log.debug("Download from FilePath:" + source_file_path + " offset:" + offset);
-        ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset,true);
+        ArcEntry arcEntry= Facade.getArcEntry(source_file_path, offset);
         
         //Only solr lookup if redirect.
         if (arcEntry.getStatus_code() >= 300 &&  arcEntry.getStatus_code() <= 399 ){
@@ -636,6 +636,7 @@ public class SolrWaybackResourceWeb {
         //temp dirty hack to see if it fixes brotli
         InputStream in;
         if ("br".equalsIgnoreCase(arcEntry.getContentEncoding())){
+            // TODO: Shouldn't this be the NoChunking version?
         in = new BrotliInputStream(arcEntry.getBinaryRaw());
         arcEntry.setContentEncoding(null); //Clear encoding.
         arcEntry.setHasBeenDecompressed(true);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
@@ -636,12 +636,12 @@ public class SolrWaybackResourceWeb {
         //temp dirty hack to see if it fixes brotli
         InputStream in;
         if ("br".equalsIgnoreCase(arcEntry.getContentEncoding())){
-        in = new BrotliInputStream(new ByteArrayInputStream(arcEntry.getBinary()));
+        in = new BrotliInputStream(arcEntry.getBinaryRaw());
         arcEntry.setContentEncoding(null); //Clear encoding.
         arcEntry.setHasBeenDecompressed(true);
         }
         else{      
-         in = new ByteArrayInputStream(arcEntry.getBinary());
+         in = arcEntry.getBinaryRaw();
          
         }
         ResponseBuilder response = null;

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/dto/ArcEntry.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/dto/ArcEntry.java
@@ -63,7 +63,6 @@ public class ArcEntry {
   private long offset;  
   private boolean hasBeenDecompressed=false;
   private boolean chunked=false;
-  private byte[] binary;
   private byte[] cachedBinary;
   private long binaryTrueSize;
   private int status_code;
@@ -97,16 +96,6 @@ public void setOffset(long offset) {
     this.offset = offset;
 }
 
-/*
- * Will only be loaded if specificed when constructed
- */
- public byte[] getBinaryDisabled() {
-    return binary;
-  }
-  public void setBinaryDisabled(byte[] binary) {
-    //very dirty hack for now.          
-    this.binary = binary;
-  }
   public long getContentLength() {
     return contentLength;
   }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/DateUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/DateUtils.java
@@ -27,7 +27,7 @@ public class DateUtils {
     dateMillisecond.setTimeZone(TimeZone.getTimeZone("UTC"));
   }
 
-   public static String  convertWaybackDate2SolrDate(String waybackdate) throws Exception {
+   public static String  convertWaybackDate2SolrDate(String waybackdate) {
     
     SimpleDateFormat dForm = null;    
     DateFormat solrDateFormat =  new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/InputStreamUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/InputStreamUtils.java
@@ -48,7 +48,7 @@ public class InputStreamUtils {
 
     /**
      * Re-implementation of {@link org.apache.commons.io.IOUtils#skipFully} using {@link InputStream#skip} instead of
-     * {@link InputStream#skip} to allow for efficient skipping.
+     * {@link InputStream#read} to allow for efficient skipping.
      * @param input stream to skip.
      * @param toSkip the number of bytes to skip.
      * @return the number of bytes skipped. This will always be equal to toSkip as everything else raises an Exception.

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/LimitedReader.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/LimitedReader.java
@@ -1,0 +1,50 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.util;
+
+import java.io.IOException;
+import java.io.Reader;
+
+/**
+ * Wrapper for a {@link Reader} that limits the amount of characters that are delivered.
+ * Excess characters are ignored.
+ */
+public class LimitedReader extends Reader {
+    private final Reader source;
+    private long charactersLeft;
+
+    public LimitedReader(Reader source, long maxCharacters) {
+        this.source = source;
+        charactersLeft = maxCharacters;
+    }
+
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        if (charactersLeft == 0) {
+            return -1;
+        }
+        int newLen = (int) Math.min(charactersLeft, len);
+        int read = source.read(cbuf, off, newLen);
+        if (read != -1) {
+            charactersLeft -= read;
+        }
+        return read;
+    }
+
+    @Override
+    public void close() throws IOException {
+        source.close();
+    }
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/StreamBridge.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/StreamBridge.java
@@ -371,7 +371,7 @@ public class StreamBridge {
                 read += r;
             } catch (IOException e) {
                 // Fail read
-                log.info("guaranteedStream: Exception reading from input stream", e);
+                log.warn("guaranteedStream: Exception reading from input stream", e);
                 return new StatusInputStream(new ByteArrayInputStream(bos.toByteArray()), e, read);
             } catch (OutOfMemoryError e) {
                 log.error("OutOfMemoryError while buffering stream to memory", e);

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/compression/WarcBinaryCompressionTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/compression/WarcBinaryCompressionTest.java
@@ -32,7 +32,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsNoneGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_none.warc.gz");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 881,true ); //HTML entry
-        String content = arcEntry.getBinaryContentAsStringUnCompressed();
+        String content = arcEntry.getStringContentSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
     
@@ -40,7 +40,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsNone() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_none.warc");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1198 ,true ); //HTML entry
-        String content = arcEntry.getBinaryContentAsStringUnCompressed();
+        String content = arcEntry.getStringContentSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
 
@@ -48,7 +48,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsZipGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_gzip.warc.gz");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 899  ,true); //HTML entry
-        String content = arcEntry.getBinaryContentAsStringUnCompressed();
+        String content = arcEntry.getStringContentSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
 
@@ -56,7 +56,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsZip() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_gzip.warc");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1227 ,true); //HTML entry
-        String content = arcEntry.getBinaryContentAsStringUnCompressed();
+        String content = arcEntry.getStringContentSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
 
@@ -66,7 +66,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsBrotli() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_brotli.warc");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1227 ,true); //HTML entry
-        String content = arcEntry.getBinaryContentAsStringUnCompressed();
+        String content = arcEntry.getStringContentSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);    
         //System.out.println(content);
     }
@@ -76,7 +76,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsBrotliGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_brotli.warc.gz");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 898  ,true); //HTML entry
-        String content = arcEntry.getBinaryContentAsStringUnCompressed();
+        String content = arcEntry.getStringContentSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);    
         //System.out.println(content);
     }
@@ -87,7 +87,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsZipChunkedGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_gzip_chunked.warc.gz");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 275 ,true); //HTML entry
-        String content = arcEntry.getBinaryContentAsStringUnCompressed();
+        String content = arcEntry.getStringContentSafe();
             
        // System.out.println(content);
     }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/compression/WarcBinaryCompressionTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/compression/WarcBinaryCompressionTest.java
@@ -32,7 +32,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsNoneGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_none.warc.gz");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 881,true ); //HTML entry
-        String content = arcEntry.getStringContentSafe();
+        String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
     
@@ -40,7 +40,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsNone() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_none.warc");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1198 ,true ); //HTML entry
-        String content = arcEntry.getStringContentSafe();
+        String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
 
@@ -48,7 +48,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsZipGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_gzip.warc.gz");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 899  ,true); //HTML entry
-        String content = arcEntry.getStringContentSafe();
+        String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
 
@@ -56,7 +56,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsZip() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_gzip.warc");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1227 ,true); //HTML entry
-        String content = arcEntry.getStringContentSafe();
+        String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
 
@@ -66,7 +66,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsBrotli() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_brotli.warc");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1227 ,true); //HTML entry
-        String content = arcEntry.getStringContentSafe();
+        String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);    
         //System.out.println(content);
     }
@@ -76,7 +76,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsBrotliGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_brotli.warc.gz");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 898  ,true); //HTML entry
-        String content = arcEntry.getStringContentSafe();
+        String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);    
         //System.out.println(content);
     }
@@ -87,7 +87,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     public void testCompressionsZipChunkedGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_gzip_chunked.warc.gz");        
         ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 275 ,true); //HTML entry
-        String content = arcEntry.getStringContentSafe();
+        String content = arcEntry.getStringContentAsStringSafe();
             
        // System.out.println(content);
     }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/compression/WarcBinaryCompressionTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/compression/WarcBinaryCompressionTest.java
@@ -31,7 +31,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     @Test
     public void testCompressionsNoneGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_none.warc.gz");        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 881,true ); //HTML entry
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 881); //HTML entry
         String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
@@ -39,7 +39,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     @Test
     public void testCompressionsNone() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_none.warc");        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1198 ,true ); //HTML entry
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1198); //HTML entry
         String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
@@ -47,7 +47,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     @Test
     public void testCompressionsZipGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_gzip.warc.gz");        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 899  ,true); //HTML entry
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 899); //HTML entry
         String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
@@ -55,7 +55,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     @Test
     public void testCompressionsZip() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_gzip.warc");        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1227 ,true); //HTML entry
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1227); //HTML entry
         String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);                         
     }
@@ -65,7 +65,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     @Test
     public void testCompressionsBrotli() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_brotli.warc");        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1227 ,true); //HTML entry
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1227); //HTML entry
         String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);    
         //System.out.println(content);
@@ -75,7 +75,7 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     @Test
     public void testCompressionsBrotliGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_brotli.warc.gz");        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 898  ,true); //HTML entry
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 898); //HTML entry
         String content = arcEntry.getStringContentAsStringSafe();
         assertTrue(content.indexOf(HTML_TEXT_PART)> 0);    
         //System.out.println(content);
@@ -86,16 +86,10 @@ public class WarcBinaryCompressionTest extends UnitTestUtils{
     @Test
     public void testCompressionsZipChunkedGz() throws Exception {        
         File file = getFile("compressions_warc/transfer_compression_gzip_chunked.warc.gz");        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 275 ,true); //HTML entry
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 275); //HTML entry
         String content = arcEntry.getStringContentAsStringSafe();
             
        // System.out.println(content);
     }
-
     
-    
-    
-    
-    
-
 }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/encoders/SHA1Test.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/encoders/SHA1Test.java
@@ -36,7 +36,7 @@ public class SHA1Test extends UnitTestUtils{
   			  
   	        File file = getFile("src/test/resources/example_warc/IAH-20080430204825-00000-blackbook.warc");  	        
   	        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 181688,true); //Image entry  			      		
-  			byte[] bytes = arcEntry.getBinary();    			
+  			byte[] bytes = arcEntry.getBinaryDecodedBytes();
   		    InputStream is = new ByteArrayInputStream(bytes);                       
   		    String hash= Sha1Hash.createSha1(is);
             assertEquals("sha1:5NAYYF4QDMNTCMGOQUJ6DQTCEIB7QKFS", hash); //This is the sha1 value in the warc file. See warc header above     

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/encoders/SHA1Test.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/encoders/SHA1Test.java
@@ -35,7 +35,7 @@ public class SHA1Test extends UnitTestUtils{
   			   */  			  
   			  
   	        File file = getFile("src/test/resources/example_warc/IAH-20080430204825-00000-blackbook.warc");  	        
-  	        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 181688,true); //Image entry  			      		
+  	        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 181688); //Image entry
   			byte[] bytes = arcEntry.getBinaryDecodedBytes();
   		    InputStream is = new ByteArrayInputStream(bytes);                       
   		    String hash= Sha1Hash.createSha1(is);

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterFromWarcTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterFromWarcTest.java
@@ -16,7 +16,7 @@ public class HtmlParserUrlRewriterFromWarcTest {
         long offset=2691693;
         
         ArcEntry arc=ArcParserFileResolver.getArcEntry(warcFile, offset);
-        String html = arc.getStringContentSafe();
+        String html = arc.getStringContentAsStringSafe();
                
         
         ParseResult rewritten = HtmlParserUrlRewriter.replaceLinks(

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterFromWarcTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterFromWarcTest.java
@@ -16,7 +16,7 @@ public class HtmlParserUrlRewriterFromWarcTest {
         long offset=2691693;
         
         ArcEntry arc=ArcParserFileResolver.getArcEntry(warcFile, offset);
-        String html = arc.getBinaryContentAsStringUnCompressed();
+        String html = arc.getStringContentSafe();
                
         
         ParseResult rewritten = HtmlParserUrlRewriter.replaceLinks(

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportArc.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportArc.java
@@ -1,19 +1,13 @@
 package dk.kb.netarchivesuite.solrwayback.parsers;
 
-import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
-import java.util.List;
 
 import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
 import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
-import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
-import dk.kb.netarchivesuite.solrwayback.service.dto.SearchResult;
-import dk.kb.netarchivesuite.solrwayback.solr.NetarchiveSolrClient;
 
 public class TestExportArc {
 
@@ -45,8 +39,8 @@ public class TestExportArc {
     System.out.println("-----");
     System.out.println(warcHeader);
     
-    Files.write(exportPath, warcHeader.getBytes(WarcParser.WARC_HEADER_ENCODING), StandardOpenOption.APPEND);           
-    Files.write(exportPath, arcEntry.getBinary(), StandardOpenOption.APPEND);
+    Files.write(exportPath, warcHeader.getBytes(WarcParser.WARC_HEADER_ENCODING), StandardOpenOption.APPEND);
+    Files.write(exportPath, arcEntry.getBinaryDecodedBytes(), StandardOpenOption.APPEND);
     Files.write(exportPath, "\r\n\r\n".getBytes(WarcParser.WARC_HEADER_ENCODING), StandardOpenOption.APPEND); // separator
     
   }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportArc.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportArc.java
@@ -21,7 +21,7 @@ public class TestExportArc {
     
 
     
-    ArcEntry arcEntry = ArcParser.getArcEntry(ArcSource.fromFile(arcFile), offset, true);
+    ArcEntry arcEntry = ArcParser.getArcEntry(ArcSource.fromFile(arcFile), offset);
     
     String warcHeader = ArcHeader2WarcHeader.arcHeader2WarcHeader(arcEntry);
     

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarc.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarc.java
@@ -48,7 +48,7 @@ public class TestExportWarc {
       }
       System.out.println(source_file_path);
       System.out.println(offset);
-      ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(source_file_path), offset, true);
+      ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(source_file_path), offset);
       String warc2HeaderEncoding = warcEntry.getContentEncoding();
       Charset charset = Charset.forName(WarcParser.WARC_HEADER_ENCODING); //Default if none define or illegal charset
  

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarc.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarc.java
@@ -64,8 +64,8 @@ public class TestExportWarc {
       }
       
       Files.write(exportPath, warcEntry.getHeader().getBytes(charset), StandardOpenOption.APPEND);           
-      System.out.println(warcEntry.getBinary().length);
-      Files.write(exportPath, warcEntry.getBinary(), StandardOpenOption.APPEND);
+      System.out.println(warcEntry.getBinaryDecodedBytes().length);
+      Files.write(exportPath, warcEntry.getBinaryDecodedBytes(), StandardOpenOption.APPEND);
       Files.write(exportPath, "\r\n\r\n".getBytes(WarcParser.WARC_HEADER_ENCODING), StandardOpenOption.APPEND); // separator
       
     }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarcStreaming.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarcStreaming.java
@@ -48,7 +48,7 @@ public class TestExportWarcStreaming extends UnitTestUtils {
 
     byte[] upFrontBinary;
     {
-      ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(WARC), OFFSET, true);
+      ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(WARC), OFFSET);
       upFrontBinary = warcEntry.getBinaryDecodedBytes();
       assertEquals("Length for up front load should be as expected", EXPECTED_CONTENT_LENGTH, upFrontBinary.length);
     }
@@ -115,7 +115,7 @@ public class TestExportWarcStreaming extends UnitTestUtils {
 
         byte[] upFrontBinary;
         {
-          ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(warc), offset, true);
+          ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(warc), offset);
           upFrontBinary = warcEntry.getBinaryDecodedBytes();
           assertEquals("Length for up front load should be as expected", expectedContentLength, upFrontBinary.length);
         }
@@ -271,7 +271,7 @@ public class TestExportWarcStreaming extends UnitTestUtils {
     PropertiesLoader.initProperties();
     String source_file_path="/home/teg/workspace/solrwayback/storedanske_export-00000.warc";
     int offset = 515818793;
-    ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(source_file_path),offset,true);
+    ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(source_file_path),offset);
     
     byte[] bytes = warcEntry.getBinaryDecodedBytes(); // <--------- The binary
     String fileFromBytes = "image1.jpg";

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarcStreaming.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/TestExportWarcStreaming.java
@@ -49,7 +49,7 @@ public class TestExportWarcStreaming extends UnitTestUtils {
     byte[] upFrontBinary;
     {
       ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(WARC), OFFSET, true);
-      upFrontBinary = warcEntry.getBinary();
+      upFrontBinary = warcEntry.getBinaryDecodedBytes();
       assertEquals("Length for up front load should be as expected", EXPECTED_CONTENT_LENGTH, upFrontBinary.length);
     }
 
@@ -116,7 +116,7 @@ public class TestExportWarcStreaming extends UnitTestUtils {
         byte[] upFrontBinary;
         {
           ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(warc), offset, true);
-          upFrontBinary = warcEntry.getBinary();
+          upFrontBinary = warcEntry.getBinaryDecodedBytes();
           assertEquals("Length for up front load should be as expected", expectedContentLength, upFrontBinary.length);
         }
 
@@ -151,12 +151,20 @@ public class TestExportWarcStreaming extends UnitTestUtils {
     }
 
     @Test
+  public void testNoCompressionTruncated() throws Exception {
+    final String[][] ENTRIES = new String[][]{
+            {"compressions_warc/transfer_compression_none_truncated.warc.gz", "881"} // Expected 856
+    };
+    assertExportSize(ENTRIES, 856, true);
+  }
+
+    @Test
   public void testGzipExportTruncated() throws Exception {
     final String[][] ENTRIES = new String[][]{
-            {"compressions_warc/transfer_compression_none_truncated.warc.gz", "881"},
-            {"compressions_warc/transfer_compression_none.warc.gz", "881"}
+            {"compressions_warc/transfer_compression_none_truncated.warc.gz", "881"}, // expected export 856
+            {"compressions_warc/transfer_compression_none.warc.gz", "881"} // expected export 1102
     };
-    assertExportSize(ENTRIES, 1102, true);
+    assertExportSize(ENTRIES, 856+1102, true);
   }
 
   @Test
@@ -265,7 +273,7 @@ public class TestExportWarcStreaming extends UnitTestUtils {
     int offset = 515818793;
     ArcEntry warcEntry = WarcParser.getWarcEntry(ArcSource.fromFile(source_file_path),offset,true);
     
-    byte[] bytes = warcEntry.getBinary(); // <--------- The binary
+    byte[] bytes = warcEntry.getBinaryDecodedBytes(); // <--------- The binary
     String fileFromBytes = "image1.jpg";
     String fileFromBytesStream = "image2.jpg";
     String fileFromBytesWarcInputStream = "image3.jpg";

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcGzParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcGzParserTest.java
@@ -52,7 +52,7 @@ public class ArcGzParserTest extends UnitTestUtils {
         assertNull(arcEntry.getBinary());
         arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 7733,true); 
         byte[] orgBinary = arcEntry.getBinary();        
-        try (BufferedInputStream buf = arcEntry.getContentRaw()) {
+        try (BufferedInputStream buf = arcEntry.getBinaryRaw()) {
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",
                          newBinary.length, IOUtils.read(buf, newBinary));

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcGzParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcGzParserTest.java
@@ -20,7 +20,7 @@ public class ArcGzParserTest extends UnitTestUtils {
         
         File file = getFile("src/test/resources/example_arc/IAH-20080430204825-00000-blackbook.arc.gz");
         
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1306,true); //HTML entry
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 1306); //HTML entry
         assertEquals("text/html", arcEntry.getContentType());
         assertEquals("www.archive.org", arcEntry.getFileName());
         assertEquals(366, arcEntry.getContentLength()); //From header        
@@ -35,7 +35,7 @@ public class ArcGzParserTest extends UnitTestUtils {
         
         File file = getFile("src/test/resources/example_arc/IAH-20080430204825-00000-blackbook.arc.gz");
         
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 7733 ,true); //Image entry (or   9699) 
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 7733); //Image entry (or   9699)
         assertEquals("image/jpeg", arcEntry.getContentType());
         assertEquals("logoc.jpg", arcEntry.getFileName());
         assertEquals(1662, arcEntry.getContentLength()); //From header        

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcGzParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcGzParserTest.java
@@ -24,7 +24,7 @@ public class ArcGzParserTest extends UnitTestUtils {
         assertEquals("text/html", arcEntry.getContentType());
         assertEquals("www.archive.org", arcEntry.getFileName());
         assertEquals(366, arcEntry.getContentLength()); //From header        
-        assertEquals(366,arcEntry.getBinary().length); //Actually loaded in binary
+        assertEquals(366,arcEntry.getBinaryDecodedBytes().length); //Actually loaded in binary
         assertEquals(200,arcEntry.getStatus_code());
        //System.out.println(new String(arcEntry.getBinary())); //from <html> to </html>
     }
@@ -39,29 +39,6 @@ public class ArcGzParserTest extends UnitTestUtils {
         assertEquals("image/jpeg", arcEntry.getContentType());
         assertEquals("logoc.jpg", arcEntry.getFileName());
         assertEquals(1662, arcEntry.getContentLength()); //From header        
-        assertEquals(1662,arcEntry.getBinary().length); //Actually loaded in binary
+        assertEquals(1662,arcEntry.getBinaryDecodedBytes().length); //Actually loaded in binary
     }
-    
- 
-    @Test
-    public void testLazyLoadBinary() throws Exception {
-        
-        File file = getFile("src/test/resources/example_arc/IAH-20080430204825-00000-blackbook.arc.gz");        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(),7733, false); //Image entry
-        
-        assertNull(arcEntry.getBinary());
-        arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 7733,true); 
-        byte[] orgBinary = arcEntry.getBinary();        
-        try (BufferedInputStream buf = arcEntry.getBinaryRaw()) {
-            byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
-            assertEquals("The expected number of bytes should be read from the lazy stream",
-                         newBinary.length, IOUtils.read(buf, newBinary));
-            assertEquals(orgBinary.length, newBinary.length); //Same length
-            assertArrayEquals(orgBinary, newBinary); //Same binary
-            assertEquals("There should be no more content in the lazy loaded stream", -1, buf.read());
-        }
-    }
-
-    
-    
 }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcGzParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcGzParserTest.java
@@ -52,7 +52,7 @@ public class ArcGzParserTest extends UnitTestUtils {
         assertNull(arcEntry.getBinary());
         arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 7733,true); 
         byte[] orgBinary = arcEntry.getBinary();        
-        try (BufferedInputStream buf = arcEntry.getBinaryLazyLoad()) {
+        try (BufferedInputStream buf = arcEntry.getContentRaw()) {
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",
                          newBinary.length, IOUtils.read(buf, newBinary));

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
@@ -23,7 +23,7 @@ public class ArcParserTest extends UnitTestUtils{
         
         File file = getFile("src/test/resources/example_arc/IAH-20080430204825-00000-blackbook.arc");
         
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 136767 ,true); //Image entry
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 136767); //Image entry
         assertEquals("image/jpeg", arcEntry.getContentType());
         assertEquals("hewlett.jpg", arcEntry.getFileName());
         assertEquals(7510, arcEntry.getContentLength());
@@ -45,7 +45,7 @@ public class ArcParserTest extends UnitTestUtils{
       
       File file = getFile("src/test/resources/example_arc/IAH-20080430204825-00000-blackbook.arc");
       
-      ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 280750 ,false); //redirect
+      ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 280750); //redirect
 
       
       String url=arcEntry.getUrl();

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
@@ -5,9 +5,6 @@ import static org.junit.Assert.*;
 import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.net.URL;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -54,7 +51,7 @@ public class ArcParserTest extends UnitTestUtils{
         byte[] orgBinary = arcEntry.getBinary();
         assertTrue("The extracted binary size should be > 0 but was " + arcEntry.getBinaryArraySize(),
                    arcEntry.getBinaryArraySize() > 0);
-        try (BufferedInputStream buf = arcEntry.getBinaryLazyLoad()) {
+        try (BufferedInputStream buf = arcEntry.getContentRaw()) {
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",
                          newBinary.length, IOUtils.read(buf, newBinary));

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
@@ -28,7 +28,7 @@ public class ArcParserTest extends UnitTestUtils{
         assertEquals("hewlett.jpg", arcEntry.getFileName());
         assertEquals(7510, arcEntry.getContentLength());
 
-        BufferedImage image = ImageUtils.getImageFromBinary(arcEntry.getBinary());
+        BufferedImage image = ImageUtils.getImageFromBinary(arcEntry.getBinaryDecoded());
         assertEquals(300,image.getWidth());
         assertEquals(116,image.getHeight());
         assertEquals(200,arcEntry.getStatus_code());        
@@ -38,33 +38,8 @@ public class ArcParserTest extends UnitTestUtils{
         System.out.println(arcEntry.getRedirectUrl());
                      
     }
-    
-    
-    @Test
-    public void testLazyLoadBinary() throws Exception {
-        
-        File file = getFile("src/test/resources/example_arc/IAH-20080430204825-00000-blackbook.arc");        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 136767, false); //Image entry
-        
-        assertNull(arcEntry.getBinary());
-        arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 136767,true); //Image entry and load binary
-        byte[] orgBinary = arcEntry.getBinary();
-        assertTrue("The extracted binary size should be > 0 but was " + arcEntry.getBinaryArraySize(),
-                   arcEntry.getBinaryArraySize() > 0);
-        try (BufferedInputStream buf = arcEntry.getBinaryRaw()) {
-            byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
-            assertEquals("The expected number of bytes should be read from the lazy stream",
-                         newBinary.length, IOUtils.read(buf, newBinary));
-            assertEquals(orgBinary.length, newBinary.length); //Same length
-            assertArrayEquals(orgBinary, newBinary); //Same binary
-            assertEquals("There should be no more content in the lazy loaded stream", -1, buf.read());
-        }
-    }
 
-    
-    
-    
-    
+
     @Test
     public void testArcParserRedirect() throws Exception {
       

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/ArcParserTest.java
@@ -51,7 +51,7 @@ public class ArcParserTest extends UnitTestUtils{
         byte[] orgBinary = arcEntry.getBinary();
         assertTrue("The extracted binary size should be > 0 but was " + arcEntry.getBinaryArraySize(),
                    arcEntry.getBinaryArraySize() > 0);
-        try (BufferedInputStream buf = arcEntry.getContentRaw()) {
+        try (BufferedInputStream buf = arcEntry.getBinaryRaw()) {
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",
                          newBinary.length, IOUtils.read(buf, newBinary));

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
@@ -4,9 +4,6 @@ import static org.junit.Assert.*;
 import java.awt.image.BufferedImage;
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.net.URL;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -14,8 +11,6 @@ import org.junit.Test;
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
 import dk.kb.netarchivesuite.solrwayback.facade.Facade;
 import dk.kb.netarchivesuite.solrwayback.image.ImageUtils;
-import dk.kb.netarchivesuite.solrwayback.parsers.ArcFileParserFactory;
-import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
 import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
 
 
@@ -74,7 +69,7 @@ public class WarcGzParserTest  extends UnitTestUtils{
         assertNull(arcEntry.getBinary());
         arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 48777,true); //Image entry and load binary
         byte[] orgBinary = arcEntry.getBinary();        
-        try (BufferedInputStream buf = arcEntry.getBinaryLazyLoad()) {
+        try (BufferedInputStream buf = arcEntry.getContentRaw()) {
 
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
@@ -23,7 +23,7 @@ public class WarcGzParserTest  extends UnitTestUtils{
         // so the WARC file can be edited with further evil header entries.
         File file = getFile("src/test/resources/example_warc/Evil-Warc-Headers.warc");
         try {        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 0,false);  //first entry, no WARC metadata header
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 0);  //first entry, no WARC metadata header
         
         assertEquals("text/plain", arcEntry.getContentType());
         assertEquals("robots.txt", arcEntry.getFileName());
@@ -42,7 +42,7 @@ public class WarcGzParserTest  extends UnitTestUtils{
         
         File file = getFile("src/test/resources/example_warc/IAH-20080430204825-00000-blackbook.warc.gz");
         
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 48777,true); //Image entry. offsets can be seen in the cdx file
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 48777); //Image entry. offsets can be seen in the cdx file
         assertEquals("image/jpeg", arcEntry.getContentType());
         assertEquals("hewlett.jpg", arcEntry.getFileName());
         assertEquals(7812, arcEntry.getWarcEntryContentLength());

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
@@ -69,7 +69,7 @@ public class WarcGzParserTest  extends UnitTestUtils{
         assertNull(arcEntry.getBinary());
         arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 48777,true); //Image entry and load binary
         byte[] orgBinary = arcEntry.getBinary();        
-        try (BufferedInputStream buf = arcEntry.getContentRaw()) {
+        try (BufferedInputStream buf = arcEntry.getBinaryRaw()) {
 
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcGzParserTest.java
@@ -49,7 +49,7 @@ public class WarcGzParserTest  extends UnitTestUtils{
         assertEquals(7510, arcEntry.getContentLength());
         assertEquals(200,arcEntry.getStatus_code());
         
-        BufferedImage image = ImageUtils.getImageFromBinary(arcEntry.getBinary());
+        BufferedImage image = ImageUtils.getImageFromBinary(arcEntry.getBinaryDecoded());
         assertEquals(300,image.getWidth());
         assertEquals(116,image.getHeight());        
         assertEquals("http://www.archive.org/images/hewlett.jpg",arcEntry.getUrl());
@@ -59,28 +59,6 @@ public class WarcGzParserTest  extends UnitTestUtils{
     
     }
 
-    
-    @Test
-    public void testLazyLoadBinary() throws Exception {
-        
-        File file = getFile("src/test/resources/example_warc/IAH-20080430204825-00000-blackbook.warc.gz");        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 48777, false); //Image entry
-        
-        assertNull(arcEntry.getBinary());
-        arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 48777,true); //Image entry and load binary
-        byte[] orgBinary = arcEntry.getBinary();        
-        try (BufferedInputStream buf = arcEntry.getBinaryRaw()) {
-
-            byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
-            assertEquals("The expected number of bytes should be read from the lazy stream",
-                         newBinary.length, IOUtils.read(buf, newBinary));
-            assertEquals(orgBinary.length, newBinary.length); //Same length
-            assertArrayEquals(orgBinary, newBinary); //Same binary
-            assertEquals("There should be no more content in the lazy loaded stream", -1, buf.read());
-        }
-    }
-
-    
     /* The warc file used for these tests below can not be shared.
    
      @Test

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcParserTest.java
@@ -23,7 +23,7 @@ public class WarcParserTest extends UnitTestUtils{
         
         File file = getFile("src/test/resources/example_warc/IAH-20080430204825-00000-blackbook.warc");
         
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 181688,true); //Image entry
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 181688); //Image entry
         assertEquals("image/jpeg", arcEntry.getContentType());
         assertEquals("hewlett.jpg", arcEntry.getFileName());
         assertEquals(7812, arcEntry.getWarcEntryContentLength());
@@ -45,7 +45,7 @@ public class WarcParserTest extends UnitTestUtils{
 
         File file = getFile("src/test/resources/example_warc/IAH-20080430204825-00000-blackbook.warc");
         
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 216504,false); //Image entry
+        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 216504); //Image entry
 
         //System.out.println(arcEntry.getRedirectUrl());
         

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcParserTest.java
@@ -62,7 +62,7 @@ public class WarcParserTest extends UnitTestUtils{
         assertNull(arcEntry.getBinary());
         arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 181688,true); //Image entry and load binary
         byte[] orgBinary = arcEntry.getBinary();        
-        try (BufferedInputStream buf = arcEntry.getContentRaw()) {
+        try (BufferedInputStream buf = arcEntry.getBinaryRaw()) {
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",
                          newBinary.length, IOUtils.read(buf, newBinary));

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcParserTest.java
@@ -30,7 +30,7 @@ public class WarcParserTest extends UnitTestUtils{
         assertEquals(7510, arcEntry.getContentLength());
         assertEquals(200,arcEntry.getStatus_code());
         
-        BufferedImage image = ImageUtils.getImageFromBinary(arcEntry.getBinary());
+        BufferedImage image = ImageUtils.getImageFromBinary(arcEntry.getBinaryDecoded());
         assertEquals(300,image.getWidth());
         assertEquals(116,image.getHeight());        
         assertEquals("http://www.archive.org/images/hewlett.jpg",arcEntry.getUrl());
@@ -50,25 +50,5 @@ public class WarcParserTest extends UnitTestUtils{
         //System.out.println(arcEntry.getRedirectUrl());
         
     
-    }
-    
-
-    @Test
-    public void testLazyLoadBinary() throws Exception {
-        
-        File file = getFile("src/test/resources/example_warc/IAH-20080430204825-00000-blackbook.warc");        
-        ArcEntry arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 181688, false); //Image entry
-        
-        assertNull(arcEntry.getBinary());
-        arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 181688,true); //Image entry and load binary
-        byte[] orgBinary = arcEntry.getBinary();        
-        try (BufferedInputStream buf = arcEntry.getBinaryRaw()) {
-            byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
-            assertEquals("The expected number of bytes should be read from the lazy stream",
-                         newBinary.length, IOUtils.read(buf, newBinary));
-            assertEquals(orgBinary.length, newBinary.length); //Same length
-            assertArrayEquals(orgBinary, newBinary); //Same binary
-            assertEquals("There should be no more content in the lazy loaded stream", -1, buf.read());
-        }
     }
 }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcParserTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/warc/WarcParserTest.java
@@ -62,7 +62,7 @@ public class WarcParserTest extends UnitTestUtils{
         assertNull(arcEntry.getBinary());
         arcEntry = Facade.getArcEntry(file.getCanonicalPath(), 181688,true); //Image entry and load binary
         byte[] orgBinary = arcEntry.getBinary();        
-        try (BufferedInputStream buf = arcEntry.getBinaryLazyLoad()) {
+        try (BufferedInputStream buf = arcEntry.getContentRaw()) {
             byte[] newBinary = new byte[(int) arcEntry.getBinaryArraySize()];
             assertEquals("The expected number of bytes should be read from the lazy stream",
                          newBinary.length, IOUtils.read(buf, newBinary));

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/util/LimitedReaderTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/util/LimitedReaderTest.java
@@ -1,0 +1,51 @@
+package dk.kb.netarchivesuite.solrwayback.util;
+
+import junit.framework.TestCase;
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+public class LimitedReaderTest extends TestCase {
+
+    public void testExact() throws IOException {
+        String TEXT = "foobar";
+        assertEquals(TEXT, readHelper(TEXT, TEXT.length()));
+    }
+
+    public void testTruncated() throws IOException {
+        String TEXT = "foobar";
+        assertEquals("foo", readHelper(TEXT, 3));
+    }
+
+    public void testOvercommit() throws IOException {
+        String TEXT = "foobar";
+        assertEquals(TEXT, readHelper(TEXT, TEXT.length()*2));
+    }
+
+    /**
+     * Creates a {@link LimitedReader} from the given {@code text} with the given {@code limit},
+     * then reads the full content as a String and returns that.
+     * @param text  source for the {@link LimitedReader}.
+     * @param limit limit for the {@link LimitedReader}.
+     * @return the full String content of the constructed {@link LimitedReader}.
+     */
+    private String readHelper(String text, int limit) throws IOException {
+        LimitedReader reader = new LimitedReader(new StringReader(text), limit);
+        return IOUtils.toString(reader);
+    }
+}

--- a/src/test/resources/properties/solrwaybackweb.properties
+++ b/src/test/resources/properties/solrwaybackweb.properties
@@ -24,6 +24,11 @@ openwayback.baseurl=http://web.archive.org/web/
 #alternative.playback.collection.mapping=coronacollection=http://servername.com/pywbcorona/;examplecollection=http://servername1.com/pywbexample/
 #alternative.playback.collection.mapping={$collection}=http://servername1.com/pywb{$collection}/
 
+# Playback rewrites the content for webpages, CSS-files etc. This can lead to Out Of Memory for huge files.
+# This setting controls the maximum amount of characters that are processed when rewriting.
+# Excess characters are ignored. Default is 100MB.
+warc.entry.text.max.characters=100000000
+
 # Will toogle the warc+csv export options.
 allow.export.warc=true
 allow.export.csv=true


### PR DESCRIPTION
This is a major clean up of binary handling for `ArcEntry` and related classes. No binaries are loaded up front and wherever possible, `InputStream`s or `Reader`s are used to deliver the content. There are still a few places where it is necessary to load the binary on heap and for that a limit (default: 100MB) has been introduced on the size of the extracted binary.

This should makes it less likely that an Out Of Memory Error is thrown during export (specifically link resolving as part of expanded export) or playback of HTML, CSS and JavaScript content.

This closes #337.