### PR TITLE
342 cache invalidation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Search boost ranking for frontpages(url_type:slashpage^5) changed in SolrWayback
 
 Export fields improvement. Can now also export to JSON and JSONL besides CVS. Option to flatten fields. The grouping (url_norm) if selected in query will also be used in export. ( see https://github.com/netarchivesuite/solrwayback/issues/279)
 
+Bugfix: Caching was effectively disabled when setting maxAgeSeconds to a year or more
 
 4.4.0
 -----

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/CachingSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/CachingSolrClient.java
@@ -64,8 +64,9 @@ public class CachingSolrClient extends SolrClient {
     public CachingSolrClient(SolrClient inner,
                              int maxCachedEntries, int maxCacheTimeSeconds, int maxConcurrentConnections) {
         this.inner = inner;
-        queryCache = new TimeCache<>(maxCachedEntries == -1 ? Integer.MAX_VALUE : maxCachedEntries,
-                                    maxCacheTimeSeconds == -1 ? Integer.MAX_VALUE / 4 : maxCacheTimeSeconds * 1000L);
+        int maxCapacity = maxCachedEntries == -1 ? Integer.MAX_VALUE : maxCachedEntries;
+        long maxAgeMS= maxCacheTimeSeconds == -1 ? Integer.MAX_VALUE / 4 : maxCacheTimeSeconds * 1000L;        
+        queryCache = new TimeCache<>(maxCapacity,maxAgeMS);
         namedCache = queryCache.createLinked();
         this.maxConnections = maxConcurrentConnections;
         connection = new Semaphore(maxConcurrentConnections == -1 ? Integer.MAX_VALUE : maxConcurrentConnections, true);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/CachingSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/CachingSolrClient.java
@@ -65,11 +65,10 @@ public class CachingSolrClient extends SolrClient {
                              int maxCachedEntries, int maxCacheTimeSeconds, int maxConcurrentConnections) {
         this.inner = inner;
         queryCache = new TimeCache<>(maxCachedEntries == -1 ? Integer.MAX_VALUE : maxCachedEntries,
-                                    maxCacheTimeSeconds == -1 ? Integer.MAX_VALUE / 4 : maxCacheTimeSeconds * 1000);
+                                    maxCacheTimeSeconds == -1 ? Integer.MAX_VALUE / 4 : maxCacheTimeSeconds * 1000L);
         namedCache = queryCache.createLinked();
         this.maxConnections = maxConcurrentConnections;
-        connection = new Semaphore(maxConcurrentConnections == -1 ? Integer.MAX_VALUE : maxConcurrentConnections,
-                                   true);
+        connection = new Semaphore(maxConcurrentConnections == -1 ? Integer.MAX_VALUE : maxConcurrentConnections, true);
     }
 
     /**
@@ -140,7 +139,7 @@ public class CachingSolrClient extends SolrClient {
         return "CachingSolrClient{" +
                "maxConnections=" + maxConnections +
                ", size/capacity=" + size() + "/" + queryCache.capacity() +
-               ", maxAgeSeconds=" + queryCache.getMaxAge()/1000 +
+               ", maxAgeSeconds=" + queryCache.getMaxAgeMS()/1000 +
                ", hits/calls=" + getHits() + "/" + getCalls() +
                '}';
     }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/TimeCache.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/TimeCache.java
@@ -33,7 +33,7 @@ public class TimeCache<O> implements Map<String, O> {
 
     private final Map<String, TimeEntry<O>> inner;
     private final int maxCapacity;
-    private final long maxAge;
+    private final long maxAgeMS;
     private final AtomicLong calls = new AtomicLong(0);
     private final AtomicLong hits = new AtomicLong(0);
 
@@ -46,7 +46,7 @@ public class TimeCache<O> implements Map<String, O> {
     public TimeCache(int maxCapacity, long maxAgeMS) {
         super();
         this.maxCapacity = maxCapacity;
-        this.maxAge = maxAgeMS;
+        this.maxAgeMS = maxAgeMS;
         this.inner = Collections.synchronizedMap(new LinkedHashMap<String, TimeEntry<O>>() {
             @Override
             protected boolean removeEldestEntry(Map.Entry<String, TimeEntry<O>> eldest) {
@@ -63,7 +63,7 @@ public class TimeCache<O> implements Map<String, O> {
      * @return a new cache with limits (max count and age) shared with this cache.
      */
     public <T> TimeCache<T> createLinked() {
-        TimeCache<T> other = new TimeCache<T>(maxCapacity, maxAge);
+        TimeCache<T> other = new TimeCache<T>(maxCapacity, maxAgeMS);
         other.link(this);
         return other;
     }
@@ -152,8 +152,8 @@ public class TimeCache<O> implements Map<String, O> {
         return maxCapacity;
     }
 
-    public long getMaxAge() {
-        return maxAge;
+    public long getMaxAgeMS() {
+        return maxAgeMS;
     }
 
     @Override
@@ -253,7 +253,7 @@ public class TimeCache<O> implements Map<String, O> {
         }
 
         public boolean isTooOld() {
-            return getCreated().plus(maxAge, ChronoUnit.MILLIS).isBefore(Instant.now());
+            return getCreated().plus(maxAgeMS, ChronoUnit.MILLIS).isBefore(Instant.now());
         }
     }
 }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/CachingSolrClientTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/CachingSolrClientTest.java
@@ -1,0 +1,41 @@
+package dk.kb.netarchivesuite.solrwayback.solr;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+public class CachingSolrClientTest extends TestCase {
+
+    @Test
+    public void testCacheSetting() {
+        final int CACHE_TIME_SECONDS = 123;
+        CachingSolrClient caching = new CachingSolrClient(null, -1, CACHE_TIME_SECONDS, 3);
+        assertEquals("The query cache time should match creation time",
+                CACHE_TIME_SECONDS*1000, caching.queryCache.getMaxAgeMS());
+        assertEquals("The named cache (linked from query cache) time should match creation time",
+                CACHE_TIME_SECONDS*1000, caching.namedCache.getMaxAgeMS());
+    }
+
+    // Failes before 2023-05-01 due to a non-working implicit cast of int->long in CachingSolrClient
+    public void testCacheSettingOverflowInt() {
+        final int CACHE_TIME_SECONDS = 365*24*60*60;
+        CachingSolrClient caching = new CachingSolrClient(null, -1, CACHE_TIME_SECONDS, 3);
+        assertEquals("The query cache time should match creation time",
+                CACHE_TIME_SECONDS*1000L, caching.queryCache.getMaxAgeMS());
+        assertEquals("The named cache (linked from query cache) time should match creation time",
+                CACHE_TIME_SECONDS*1000L, caching.namedCache.getMaxAgeMS());
+    }
+}

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/TimeCacheTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/TimeCacheTest.java
@@ -1,0 +1,51 @@
+package dk.kb.netarchivesuite.solrwayback.solr;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+public class TimeCacheTest extends TestCase {
+
+    public void testTimeBasedCaching() throws InterruptedException {
+        TimeCache<Integer> timeCache = new TimeCache<>(100, 500);
+        timeCache.get("first", () -> 1);
+        Thread.sleep(10);
+        assertTrue("After 10 ms the cache should hold the key/value",
+                timeCache.containsKey("first"));
+        Thread.sleep(500);
+        assertTrue("After 510 ms the cache should no longer hold the key/value",
+                timeCache.containsKey("first"));
+    }
+
+    public void testTimeBasedCachingNegative() throws InterruptedException {
+        TimeCache<Integer> timeCache = new TimeCache<>(100, -500);
+        timeCache.get("first", () -> 1);
+        assertFalse("First entry should never be available as maxAge is < 0",
+                timeCache.containsKey("first"));
+    }
+
+    public void testCountBasedCaching() {
+        TimeCache<Integer> timeCache = new TimeCache<>(1, 50000);
+        timeCache.get("first", () -> 1);
+        assertTrue("First entry should be available initially",
+                timeCache.containsKey("first"));
+        timeCache.get("second", () -> 2);
+        assertTrue("Second entry should be available after addition",
+                timeCache.containsKey("second"));
+        assertFalse("First entry should not be available after second has been added",
+                timeCache.containsKey("first"));
+    }
+}


### PR DESCRIPTION
The conversion from seconds to milliseconds for max age in `CachingSolrClient` has an implicit cast from the given `int` to `long`, according to IntelliJ IDEA. The added unit tests showed that was a lie: There were no cast and the `int` overflowed to negative, effectively disabling the cache.

This pull request adds unit tests for the cache module and fixed the overflow problem with an explicit promotion to `long`. This closes #342 