### PR TITLE
restlet maven repo changed hostname

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <repository>
       <id>maven-restlet</id>
       <name>Public online Restlet repository</name>
-      <url>https://maven.restlet.com</url>
+      <url>https://maven.restlet.talend.com</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
I ran into a little problem while maven started downloading the restlet-libraries. 
https://maven.restlet.com (as mentioned in pom.xml) redirects  to https://maven.restlet.talend.com and the ssl certificate of that site was considered invalid, so I changed the hostname..