### PR TITLE
Make curl and wget interchangeable and optional in the bundle

### DIFF
--- a/src/bundle/indexing/warc-indexer.sh
+++ b/src/bundle/indexing/warc-indexer.sh
@@ -312,6 +312,7 @@ commit() {
 ###############################################################################
 
 check_parameters "$@"
+check_tools
 check_solr
 index_all
 commit


### PR DESCRIPTION
This pull request changes the `warc-indexer.sh` to seamlessly choose between `curl` or `wget` depending on which is available. If none are available, a warning is logged and `ping` & `commit` are not called - base indexing should work without `curl` and `wget`.