### PR TITLE
Avoid query warnings for datetime range queries

### DIFF
--- a/src/js/src/mixins/SearchUtils.js
+++ b/src/js/src/mixins/SearchUtils.js
@@ -131,7 +131,9 @@ export default {
           responses.push('Smart quotes. When quoting, use simple quote signs " - ' +  q.replace(/[`‘’'„“‟”❝❞]/ + '"'))
         }
 
-        if (q.match(/[^:"]*:[^:" ]*[^\\]:[^" ]( ?.*)$/)) {
+        // Remove all 'f:[something TO somethingelse] to avoid colon warnings for crawl_date:[2023-12-99T12:34:56Z TO *]
+        let qfold = q.replace(/[^\\]: *\[ *[^ ]+ * TO  *[^ ]+ *]/g, '')
+        if (qfold.match(/[^:"]+:[^:" ]*[^\\]:[^" ]( ?.*)$/)) {
           responses.push('Two colons without quote signs. When a qualified search is performed, consider quoting the value - ' + q.replace(/([^:"]*:)([^:" ]*[^\\]:[^" ]*)( ?.*)$/, '$1"$2"$3'))
         }
 


### PR DESCRIPTION
The query sanity check raises a warning for valid datetime ranges such as `crawl_time:[2023-12-99T12:34:56Z TO *]`. This pull request disables false warnings of that type.