### PR TITLE
386 warc retrieval

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcSource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcSource.java
@@ -14,16 +14,31 @@
  */
 package dk.kb.netarchivesuite.solrwayback.interfaces;
 
+import dk.kb.netarchivesuite.solrwayback.properties.PropertiesLoader;
+import dk.kb.netarchivesuite.solrwayback.util.SkippingHTTPInputStream;
+
 import java.io.FileInputStream;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.function.Supplier;
+import java.util.regex.Pattern;
 
 /**
  * Encapsulates a supplier of data from a WARC- or ARC, independent of storage system.
+ *
+ * When HTTP sources are used, the server SHOULD support HTTP range requests:
+ * https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
+ * It is possible to use HTTP servers without range requests, although this is extremely inefficient
+ * for larger WARCs. To enable non-range support, set
+ * {@code warc.file.resolver.source.http.readfallback=true}
  */
 public class ArcSource implements Supplier<InputStream> {
+    private static final Pattern HTTP = Pattern.compile("^https?://.*");
+    private static final Pattern FILE = Pattern.compile("^file://.*");
+
     private final String source;
     private final Supplier<InputStream> supplier;
 
@@ -32,7 +47,6 @@ public class ArcSource implements Supplier<InputStream> {
      * {@link InputStream#skip(long)} effectively as the primary use case of {@code ArcSource} is to extract a single
      * entry from a (W)ARC by skipping to entry start and reading forward from there.
      * @param source the source (URL, file path or similar) of the ArcData.
-     * @return a Supplier that delivers an InputStream for the (w)arc file, positioned at the beginning.
      */
     public ArcSource(String source, Supplier<InputStream> supplier) {
         this.source = source;
@@ -56,17 +70,69 @@ public class ArcSource implements Supplier<InputStream> {
     }
 
     /**
+     * Construct an ArcSource from a file path.
+     * <p>
+     * Consider using the general {@link #create(String)} instead of this method.
      * @param file a file on the local file system.
      * @return an ArcSource for the given file.
      */
     public static ArcSource fromFile(String file) {
         return new ArcSource(file, () -> {
             try {
+                // TODO: Verify that Files.newInputStream supports efficient skipping then switch to that
                 return new FileInputStream(file);
             } catch (IOException e) {
                 throw new RuntimeException("Unable to create FileInputStream for '" + file + "'", e);
             }
         });
+    }
+
+    /**
+     * Construct an ArcSource from a http(s) URL.
+     * <p>
+     * Consider using the general {@link #create(String)} instead of this method.
+     * @param httpURL an URL for a WARC.
+     * @return an ArcSource for the given file.
+     */
+    public static ArcSource fromHTTP(String httpURL) {
+        final URL url;
+        try {
+            url = new URL(httpURL);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Unable to construct URL from '" + httpURL + "'", e);
+        }
+
+        return new ArcSource(httpURL, () -> {
+            try {
+                return new SkippingHTTPInputStream(url, PropertiesLoader.WARC_SOURCE_HTTP_FALLBACK);
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to open stream for '" + httpURL + "'", e);
+            }
+        });
+    }
+    /**
+     * Construct an ArcSource from multiple possible source types.
+     * Supported sources are
+     * <ul>
+     *     <li>File path ({@code /mounts/archive/ab/cd/harvest_abcdefgh.warc.gz}</li>
+     *     <li>File URL  ({@code file:///mounts/archive/ab/cd/harvest_abcdefgh.warc.gz}</li>
+     *     <li>HTTP URL  ({@code http://archive.example.com/warcs/ab/cd/harvest_abcdefgh.warc.gz}</li>
+     *     <li>HTTPS URL ({@code https://archive.example.com/warcs/ab/cd/harvest_abcdefgh.warc.gz}</li>
+     * </ul>
+     * Note: In order for HTTP(S) to be efficient as a delivery mechanism for WARC content, the server must support
+     * HTTP range requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
+     * @param source a path on the file system or an URL.
+     * @return an ArcSource for the given WARC.
+     */
+    public static ArcSource create(String source) {
+        if (HTTP.matcher(source).matches()) {
+            return fromHTTP(source);
+        }
+        if (FILE.matcher(source).matches()) {
+            return fromFile(source.substring("file://".length()));
+        }
+        // No protocol means file path
+        return fromFile(source);
     }
 
     @Override

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/AutoFileResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/AutoFileResolver.java
@@ -1,0 +1,240 @@
+package dk.kb.netarchivesuite.solrwayback.interfaces;
+
+import dk.kb.netarchivesuite.solrwayback.util.FileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Optional FileLocationResolver interface implementation.
+ * <p>
+ * This class scans one or more {@link #roots} folders for (W)ARC files and maintains a map from files to locations.
+ * This requires WARC filenames to be unique.
+ * <p>
+ * To activate it, set this in solrwayback.properties:
+ * <pre>
+ warc.file.resolver.class=AutoFileResolver
+ warc.file.resolver.parameters.autoresolver.roots=/home/sw/warcs1,/netmounts/colfoo
+ warc.file.resolver.parameters.autoresolver.pattern=.*[.]w?arc([.]gz)?
+ warc.file.resolver.parameters.autoresolver.rescan.enabled=false
+ warc.file.resolver.parameters.autoresolver.rescan.seconds=1200
+ </pre>
+ * Only the {@code roots} parameter is mandatory.
+ * {@code pattern}, {@code rescan.enabled} and {@code rescan.seconds} has the
+ * defaults shown above
+ */
+// TODO: Unit test (use the WARCs in test/resources)
+// TODO: Sample solrwayback.properties entries
+// TODO: Changelog update
+@SuppressWarnings("unused")
+public class AutoFileResolver implements ArcFileLocationResolverInterface, Runnable {
+    private static final Logger log = LoggerFactory.getLogger(AutoFileResolver.class);
+
+    // Prefixed warc.file.resolver.parameters
+    public static final String  ROOTS_KEY = "autoresolver.roots";
+    public static final String  PATTERN_KEY = "autoresolver.pattern";
+    public static final String  PATTERN_DEFAULT = ".*[.]w?arc([.]gz)?";
+    public static final String  RESCAN_ENABLED_KEY = "autoresolver.rescan.enabled";
+    public static final boolean RESCAN_ENABLED_DEFAULT = false;
+    public static final String  RESCAN_SECONDS_KEY = "autoresolver.rescan.seconds";
+    public static final long    RESCAN_SECONDS_DEFAULT = 60;
+
+    public enum STATE {
+        /** Initial scan is running: Lookups will lock until the scan has finished. */
+        initializing,
+        /** Subsequent scan is running: Lookups will use the map from the previous scan. */
+        scanning,
+        /** No scan is currently running: Lookups will use the current map. */
+        dormant }
+
+    /**
+     * Map from filename to path: {@code /a/b/c/test.warc} becomes {@code test.warc} -> {@code /a/b/c}.
+     */
+    private Map<String, String> WARCS = new HashMap<>();
+    private final List<Path> roots = new ArrayList<>();
+    private Pattern filePattern;
+    private boolean rescanEnabled;
+    private long rescanSeconds;
+    private STATE state = STATE.initializing;
+
+    /**
+     * Constructs an AutoFileResolver in its uni-initialized state.
+     *
+     * The caller should ensure that {@link #setParameters(Map)} and {@link #initialize()} is subsequently called.
+     */
+    @SuppressWarnings("unused")
+    public AutoFileResolver() { }
+
+    /**
+     * Configure the auto resolver. This method must be called before calling {@link #resolveArcFileLocation(String)}.
+     * @param parameters a parameter map as resolved by {@code PropertiesLoader#loadArcResolverParameters(Properties)}.
+     */
+    @Override
+    public void setParameters(Map<String, String> parameters) {
+        if (!parameters.containsKey(ROOTS_KEY)) {
+            String message =
+                    "The property warc.file.resolver.parameters." + ROOTS_KEY + " was not present in properties. " +
+                    "This property is needed for AutoFileResolver to work. Please add the property with one or more " +
+                    "paths to WARCs as key. Use comma to separate paths";
+            log.error(message);
+            throw new IllegalStateException(message);
+        }
+        Arrays.stream(parameters.get(ROOTS_KEY).split(" *, *")).
+                map(String::trim).
+                filter(path -> !path.isEmpty()).
+                map(FileUtil::toExistingFolder).
+                forEach(roots::add);
+        if (roots.isEmpty()) {
+            String message = "The property warc.file.resolver.parameters." + ROOTS_KEY + " contained no folders. " +
+                             "At least 1 folder is needed AutoFileResolver to work.";
+            log.error(message);
+            throw new IllegalStateException(message);
+        }
+
+        filePattern = parameters.containsKey(PATTERN_KEY) ?
+                Pattern.compile(parameters.get(PATTERN_KEY)):
+                Pattern.compile(PATTERN_DEFAULT);
+        rescanEnabled = parameters.containsKey(RESCAN_ENABLED_KEY) ?
+                Boolean.parseBoolean(parameters.get(RESCAN_ENABLED_KEY)) :
+                RESCAN_ENABLED_DEFAULT;
+        rescanSeconds = parameters.containsKey(RESCAN_SECONDS_KEY) ?
+                Long.parseLong(parameters.get(RESCAN_SECONDS_KEY)) :
+                RESCAN_SECONDS_DEFAULT;
+
+        log.info("Assigned parameters for {}", this);
+    }
+
+    /**
+     * Create and start the Thread for background scanning.
+     */
+    @Override
+    public void initialize() {
+        log.info("Creating and activating scan thread");
+        Thread scanThread = new Thread(this, "AutoFileResolverThread");
+        scanThread.setDaemon(true); // Shut down the Thread automatically on war redeploy
+        scanThread.start();
+    }
+
+    /**
+     * Perform 1 scan, then optionally perform subsequent scans with {@link #rescanSeconds} beween each rescan.
+     */
+    @SuppressWarnings("BusyWait")
+    @Override
+    public void run() {
+        long scanCount = 0;
+        do { // 1 scan is guaranteed, even if rescanEnabled is false
+            state = scanCount++ == 0 ? STATE.initializing : STATE.scanning;
+            scanFull();
+            state = STATE.dormant;
+
+            if (rescanEnabled) {
+                try {
+                    Thread.sleep(rescanSeconds*1000);
+                } catch (InterruptedException e) {
+                    log.warn("Interrupted while sleeping. This should not happen but is not fatal");
+                }
+            }
+        } while (rescanEnabled);
+    }
+
+    /**
+     * Perform a full scan for WARCs from all roots.
+     * The collected mappings only takes effect when the scan has fully completed.
+     */
+    private synchronized void scanFull() {
+        final long startTime = System.currentTimeMillis();
+        log.info("Starting scan for (W)ARC from roots {}. This might take a while", roots);
+
+        Map<String, String> newWARCs = new HashMap<>();
+        for (Path root : roots) {
+            scanRoot(root, newWARCs);
+        }
+        WARCS = newWARCs;
+
+        log.info("Finished scan for WARCs from {} roots in {} seconds. Number of registered files: {}",
+                 roots.size(), (System.currentTimeMillis() - startTime) / 1000, WARCS.size());
+    }
+
+    /**
+     * Scan recursively from the given {@code path} and add WARC files to the {@code warcs} map.
+     * @param path  folder to scan from.
+     * @param warcs map for collecting WARC to folder mappings.
+     */
+    private void scanRoot(Path path, Map<String, String> warcs) {
+        final String location = path.toString(); // TODO: Check that it does not end in '/'
+        // Performance note: We do not use the more convenient Files.walk as we want to ensure that location is
+        // the same object for same path, in order to save heap space for the map
+        try (DirectoryStream<Path> pathEntries = Files.newDirectoryStream(path)) {
+            pathEntries.forEach(pathEntry -> {
+                if (Files.isDirectory(pathEntry)) {
+                    scanRoot(pathEntry, warcs);
+                    return;
+                }
+                String filename = pathEntry.getFileName().toString();
+                if (!filePattern.matcher(filename).matches()) {
+                    log.debug("Scanner encountered non-matching file '{}'", filename);
+                    return;
+                }
+                if (warcs.containsKey(filename)) {
+                    log.warn("The WARC name '{}' in folder '{}' is already present in folder '{}'",
+                             filename, location, warcs.get(filename));
+                }
+                warcs.put(filename, location);
+            });
+        } catch (AccessDeniedException e) {
+            log.debug("AccessDeniedException for path '{}'", path);
+        } catch (IOException e) {
+            log.warn("Exception while scanning the content of folder '" + path + "'", e);
+        }
+    }
+
+    @Override
+    public ArcSource resolveArcFileLocation(String source_file_path){
+        while (state == STATE.initializing) {
+            try {
+                // Busy wait is not the clean way, but this is only relevant during startup
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                log.debug("Interrupted while waiting for state change. This is not problematic");
+            }
+        }
+
+        String fileName = new File(source_file_path).getName();
+        String value = WARCS.get(fileName);
+
+        String finalPath = value == null ? source_file_path : value + "/" + fileName;
+
+        return ArcSource.fromFile(finalPath);
+    }
+
+    /**
+     * @return the state of the resolver: Initializing, scanning or dormant.
+     */
+    public STATE getState() {
+        return state;
+    }
+
+    @Override
+    public String toString() {
+        return "AutoFileResolver(" +
+               "roots='" + roots + "'" +
+               ", filePattern=" + filePattern +  "'" +
+               ", rescanEnabled=" + rescanEnabled +
+               ", rescanSeconds=" + rescanSeconds +
+               ", state=" + state +
+               ", #WARCS=" + WARCS.size() +
+               '}';
+    }
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/AutoFileResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/AutoFileResolver.java
@@ -211,6 +211,7 @@ public class AutoFileResolver implements ArcFileLocationResolverInterface, Runna
             }
         }
 
+        // This apparent arbitrary file access is handled in the facade if warc.files.verify.collection==true
         String fileName = new File(source_file_path).getName();
         String value = WARCS.get(fileName);
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/FileMovedMappingResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/FileMovedMappingResolver.java
@@ -16,22 +16,24 @@ import org.slf4j.LoggerFactory;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
-/*
+/**
  * Optional FileLocationResolver interface implementation.
  *  
- * This class takes an a text file as input. 
+ * This class takes a text file as input.
 
  * To activate it, set this in solrwayback.properties:
- *   warc.file.resolver.class= FileMovedMappingResolver
- *   warc.file.resolver.filemovemappingresolver=<mapping file location>
+ *   {@code warc.file.resolver.class= FileMovedMappingResolver}
+ *   {@code warc.file.resolver.filemovemappingresolver=<mapping file location>}
  *   
  * The filename must be defined in the warc.file.resolver.class property in solrwayback
  * Each line is the full location of the warc-file that has a new location after indexing
- * 
+ *
+ * Resolving to files and HTTP(S) URLs are supported.
+ *
  * This resolver class will be activated by the InitialContextLoader
  * 
  * The Solr index has the filename stored already, but the full path in solr can be changed since indexing.
- * If the filename is found the this list, the resolver will use this full path instead of the one stored in solr.
+ * If the filename is found the list, the resolver will use this full path instead of the one stored in solr.
  * 
  */
 public class FileMovedMappingResolver implements ArcFileLocationResolverInterface {
@@ -94,7 +96,7 @@ public class FileMovedMappingResolver implements ArcFileLocationResolverInterfac
 
         String finalPath = value == null ? source_file_path : value + "/" + fileName;
 
-        return ArcSource.fromFile(finalPath);
+        return ArcSource.create(finalPath);
       }
 
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/IdentityArcFileResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/IdentityArcFileResolver.java
@@ -3,6 +3,9 @@ package dk.kb.netarchivesuite.solrwayback.interfaces;
 
 import java.util.Map;
 
+/**
+ * @deprecated use {@link RewriteLocationResolver} instead. Its default behaviour works 100% as IdentityArcFileResolver.
+ */
 public class IdentityArcFileResolver implements ArcFileLocationResolverInterface {
   /*
    * This implementation just returns the same file location as output. Can be used if path to the arc-files is the same as 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/RewriteLocationResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/interfaces/RewriteLocationResolver.java
@@ -1,0 +1,90 @@
+package dk.kb.netarchivesuite.solrwayback.interfaces;
+
+import dk.kb.netarchivesuite.solrwayback.util.SkippingHTTPInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Adjust the given input WARC path using regexp/pattern. Resolving to files and HTTP(S) URLs are supported.
+ *
+ * This is the default WARC resolver. All properties are optional and the default is the identity:
+ * The input WARC paths are used directly as-is.
+ *
+ * Optional properties:
+ *   {@code warc.file.resolver.class=RewriteLocationResolver}
+ *   {@code warc.file.resolver.parameters.path.regexp=<regexp for the input>}
+ *   {@code warc.file.resolver.parameters.path.replacement=<replacement definition for the regexp result>}
+ * The regexp and the pattern defaults to {@code .*} and {@code $0} respectively (the identity).
+ *
+ * Sample config for requesting the WARCs from a remote server by stripping the path and using the filename only:
+ *   {@code warc.file.resolver.class=RewriteLocationResolver}
+ *   {@code warc.file.resolver.parameters.path.regexp=.*([^/]*)}
+ *   {@code warc.file.resolver.parameters.path.replacement=http://example.com/warcstore/$1}
+ *
+ * This resolver class will be activated by the InitialContextLoader.
+ *
+ * Note: In order for HTTP(S) to be efficient as a delivery mechanism for WARC content, the server must support
+ * HTTP range requests: https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
+ * It is not recommended to set readfallback to true as this will result is excessive overhead, unless the
+ * backing WARC files are tiny (a few megabytes), if the server does not support range requests.
+ */
+public class RewriteLocationResolver implements ArcFileLocationResolverInterface {
+    private static final Logger log = LoggerFactory.getLogger(RewriteLocationResolver.class);
+
+    public static final String REGEXP_KEY = "path.regexp";
+    public static final String REGEXP_DEFAULT = ".*";  // Match everything
+    public static final String REPLACEMENT_KEY = "path.replacement";
+    public static final String REPLACEMENT_DEFAULT = "$0"; // The full match
+
+    private Pattern regexp = Pattern.compile(REGEXP_DEFAULT);
+    private String replacement = REPLACEMENT_DEFAULT;
+
+    public RewriteLocationResolver() { }
+
+    @Override
+    public void setParameters(Map<String, String> parameters) {
+        setPathPattern(parameters.getOrDefault(REGEXP_KEY, REGEXP_DEFAULT));
+        setPathReplacement(parameters.getOrDefault(REPLACEMENT_KEY, REPLACEMENT_DEFAULT));
+    }
+
+    public void setPathPattern(String inputPattern) {
+        this.regexp = Pattern.compile(inputPattern);
+    }
+
+    public void setPathReplacement(String replacement) {
+        this.replacement = replacement;
+    }
+
+    @Override
+    public void initialize() {
+        log.info("Initialized " + this);
+    }
+  
+    @Override
+    public ArcSource resolveArcFileLocation(String source_file_path) {
+        Matcher m = regexp.matcher(source_file_path);
+        if (!m.matches()) {
+            throw new IllegalArgumentException(
+                    "Unable to match '" + source_file_path + "' against the pattern '" + regexp.pattern() + "'");
+        }
+        String rewritten = m.replaceFirst(replacement);
+        log.debug("Rewrote (W)ARCFileLocation '{}' to '{}'", source_file_path, rewritten);
+        return ArcSource.create(rewritten);
+    }
+
+    @Override
+    public String toString() {
+        return "RewriteLocationResolver(" +
+               "regexp='" + regexp + "'" +
+               ", replacement='" + replacement + "'" +
+               ')';
+    }
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParserFileResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParserFileResolver.java
@@ -3,6 +3,7 @@ package dk.kb.netarchivesuite.solrwayback.parsers;
 import java.util.HashMap;
 
 import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
+import dk.kb.netarchivesuite.solrwayback.interfaces.RewriteLocationResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,7 +26,7 @@ public class ArcParserFileResolver {
 
   private static final HashMap<String, ArcSource> cache = new HashMap<>();
 
-  private static ArcFileLocationResolverInterface resolver = new IdentityArcFileResolver(); // Default
+  private static ArcFileLocationResolverInterface resolver = new RewriteLocationResolver(); // Default
   private static final Logger log = LoggerFactory.getLogger(ArcFileLocationResolverInterface.class);
 
   public static void setArcFileLocationResolver(ArcFileLocationResolverInterface resolverImpl) {

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
@@ -6,9 +6,7 @@ import java.io.InputStreamReader;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Properties;
 import java.util.*;
 
@@ -32,6 +30,7 @@ public class PropertiesLoader {
     private static final String SOLR_SERVER_PROPERTY="solr.server";
     private static final String WARC_FILE_RESOLVER_CLASS_PROPERTY="warc.file.resolver.class";
     private static final String WARC_FILE_RESOLVER_PARAMETERS_PROPERTY="warc.file.resolver.parameters";
+    private static final String WARC_SOURCE_HTTP_FALLBACK_PROPERTY = "warc.file.resolver.source.http.readfallback";
     private static final String WAYBACK_BASEURL_PROPERTY="wayback.baseurl";
     private static final String CHROME_COMMAND_PROPERTY="chrome.command";
     private static final String SCREENSHOT_TEMP_IMAGEDIR_PROPERTY="screenshot.temp.imagedir";
@@ -60,6 +59,7 @@ public class PropertiesLoader {
     public static String SCREENSHOT_TEMP_IMAGEDIR = null;
     public static String WARC_FILE_RESOLVER_CLASS = null;
     public static Map<String, String> WARC_FILE_RESOLVER_PARAMETERS= new HashMap<>();
+    public static boolean WARC_SOURCE_HTTP_FALLBACK = false;
     public static String PID_COLLECTION_NAME = null;
     public static String WORDCLOUD_STOPWORDS;
     public static LinkedHashMap<String,String> SOLR_PARAMS_MAP= new LinkedHashMap<String,String>(); 
@@ -111,6 +111,9 @@ public class PropertiesLoader {
             CHROME_COMMAND = serviceProperties.getProperty(CHROME_COMMAND_PROPERTY);
             SCREENSHOT_TEMP_IMAGEDIR = serviceProperties.getProperty(SCREENSHOT_TEMP_IMAGEDIR_PROPERTY);
             WARC_FILE_RESOLVER_CLASS = serviceProperties.getProperty(WARC_FILE_RESOLVER_CLASS_PROPERTY);
+            // Legacy support
+            WARC_SOURCE_HTTP_FALLBACK = Boolean.parseBoolean(serviceProperties.getProperty("warc.file.resolver.parameters.readfallback", "false"));
+            WARC_SOURCE_HTTP_FALLBACK = Boolean.parseBoolean(serviceProperties.getProperty(WARC_SOURCE_HTTP_FALLBACK_PROPERTY, "false"));
             PID_COLLECTION_NAME = serviceProperties.getProperty(PID_COLLECTION_NAME_PROPERTY);
             loadArcResolverParameters(serviceProperties);
             String timeout  = serviceProperties.getProperty(SCREENSHOT_PREVIEW_TIMEOUT_PROPERTY);
@@ -160,6 +163,7 @@ public class PropertiesLoader {
             log.info("Property:"+ SCREENSHOT_PREVIEW_TIMEOUT_PROPERTY +" = " +  SCREENSHOT_PREVIEW_TIMEOUT);
             log.info("Property:"+ WARC_FILE_RESOLVER_CLASS_PROPERTY +" = " + WARC_FILE_RESOLVER_CLASS);
             log.info("Property:"+ WARC_FILE_RESOLVER_PARAMETERS_PROPERTY +" = " + WARC_FILE_RESOLVER_PARAMETERS);
+            log.info("Property:"+ WARC_SOURCE_HTTP_FALLBACK_PROPERTY + " = " + WARC_SOURCE_HTTP_FALLBACK);
             log.info("Property:"+ URL_NORMALISER_PROPERTY +" = " +  URL_NORMALISER);
             log.info("Property:"+ PID_COLLECTION_NAME_PROPERTY +" = " +  PID_COLLECTION_NAME);
             log.info("Property:"+ WARC_FILES_VERIFY_COLLECTION_PROPERTY  +" = " + WARC_FILES_VERIFY_COLLECTION);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
@@ -31,6 +31,8 @@ public class PropertiesLoader {
     private static final String WARC_FILE_RESOLVER_CLASS_PROPERTY="warc.file.resolver.class";
     private static final String WARC_FILE_RESOLVER_PARAMETERS_PROPERTY="warc.file.resolver.parameters";
     private static final String WARC_SOURCE_HTTP_FALLBACK_PROPERTY = "warc.file.resolver.source.http.readfallback";
+    // The now deprecated ArcHTTPResolver used this property to specify readfallback
+    private static final String WARC_SOURCE_HTTP_FALLBACK_LEGACY_PROPERTY = "warc.file.resolver.parameters.readfallback";
     private static final String WAYBACK_BASEURL_PROPERTY="wayback.baseurl";
     private static final String CHROME_COMMAND_PROPERTY="chrome.command";
     private static final String SCREENSHOT_TEMP_IMAGEDIR_PROPERTY="screenshot.temp.imagedir";
@@ -112,7 +114,7 @@ public class PropertiesLoader {
             SCREENSHOT_TEMP_IMAGEDIR = serviceProperties.getProperty(SCREENSHOT_TEMP_IMAGEDIR_PROPERTY);
             WARC_FILE_RESOLVER_CLASS = serviceProperties.getProperty(WARC_FILE_RESOLVER_CLASS_PROPERTY);
             // Legacy support
-            WARC_SOURCE_HTTP_FALLBACK = Boolean.parseBoolean(serviceProperties.getProperty("warc.file.resolver.parameters.readfallback", "false"));
+            WARC_SOURCE_HTTP_FALLBACK = Boolean.parseBoolean(serviceProperties.getProperty(WARC_SOURCE_HTTP_FALLBACK_LEGACY_PROPERTY, "false"));
             WARC_SOURCE_HTTP_FALLBACK = Boolean.parseBoolean(serviceProperties.getProperty(WARC_SOURCE_HTTP_FALLBACK_PROPERTY, "false"));
             PID_COLLECTION_NAME = serviceProperties.getProperty(PID_COLLECTION_NAME_PROPERTY);
             loadArcResolverParameters(serviceProperties);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/properties/PropertiesLoader.java
@@ -115,7 +115,7 @@ public class PropertiesLoader {
             WARC_FILE_RESOLVER_CLASS = serviceProperties.getProperty(WARC_FILE_RESOLVER_CLASS_PROPERTY);
             // Legacy support
             WARC_SOURCE_HTTP_FALLBACK = Boolean.parseBoolean(serviceProperties.getProperty(WARC_SOURCE_HTTP_FALLBACK_LEGACY_PROPERTY, "false"));
-            WARC_SOURCE_HTTP_FALLBACK = Boolean.parseBoolean(serviceProperties.getProperty(WARC_SOURCE_HTTP_FALLBACK_PROPERTY, "false"));
+            WARC_SOURCE_HTTP_FALLBACK = Boolean.parseBoolean(serviceProperties.getProperty(WARC_SOURCE_HTTP_FALLBACK_PROPERTY, Boolean.toString(WARC_SOURCE_HTTP_FALLBACK)));
             PID_COLLECTION_NAME = serviceProperties.getProperty(PID_COLLECTION_NAME_PROPERTY);
             loadArcResolverParameters(serviceProperties);
             String timeout  = serviceProperties.getProperty(SCREENSHOT_PREVIEW_TIMEOUT_PROPERTY);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
@@ -5,6 +5,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -19,8 +21,8 @@ import org.slf4j.LoggerFactory;
 public class FileUtil {
 
     private static final Logger log = LoggerFactory.getLogger(FileUtil.class);
-
-
+    
+    
     /**
      * Retrieve the given resource as an UTF-8 String.
      * @param resource a class path entry or a file path.
@@ -28,15 +30,7 @@ public class FileUtil {
      * @throws IOException if the resource could not be fetch or UTF-8 parsed.
      */
     public static String fetchUTF8(String resource) throws IOException {
-        URL url = Thread.currentThread().getContextClassLoader().getResource(resource);
-        if (url == null) {
-            Path path = Paths.get(resource);
-            if (!Files.exists(path)) {
-                throw new FileNotFoundException("Unable to locate '" + resource + "'");
-            }
-            url = path.toUri().toURL();
-        }
-        return IOUtils.toString(url, StandardCharsets.UTF_8);
+        return IOUtils.toString(resolve(resource).toUri().toURL(), StandardCharsets.UTF_8);
     }
 
     /**
@@ -46,49 +40,46 @@ public class FileUtil {
      * @throws Exception if the resource could not be fetch
      */
     public static File fetchFile(String resource) throws Exception {
+        return new File(resolve(resource).toUri());
+    }
 
+    /**
+     * Locates a file designated by {@code resource} by using the class loadr primarily and direct checking of
+     * the file system secondarily.
+     * @param resource a resource available on the file system.
+     * @return the path to the {@code resource}.
+     * @throws IOException if {@code resource} could not be located.
+     */
+    public static Path resolve(String resource) throws IOException {
         URL url = Thread.currentThread().getContextClassLoader().getResource(resource);
         if (url == null) {
             Path path = Paths.get(resource);
             if (!Files.exists(path)) {
                 throw new FileNotFoundException("Unable to locate '" + resource + "'");
-            }                          
-            return new File(path.toUri());
+            }
+            return path;
         }
-        else {
-            return new File(url.toURI());
+        try {
+            return Paths.get(url.toURI());
+        } catch (URISyntaxException e) {
+            throw new IOException("Unable to convert URL '" + url + "' to URI", e);
         }
-
-    }
-    
-    
-   /**
-    * 
-    * @param resource a class path entry or a file path.
-    * @return true if file exist and not directory
-    */
-    public static boolean validateFileExist(String file) {
-    
-        if (file == null) {
-          log.error("Can not validate file, file is null");
-          return false; 
-        }
-        
-        Path path = Paths.get(file);
-
-        boolean exists = Files.exists(path);
-
-        if (!exists) {
-            log.error("File does not exist:"+file);
-            return false;   
-        }
-
-        boolean directory = Files.isDirectory(path);        
-        if (directory) {
-            log.error("Expected file is a directory:"+file);
-            return false; 
-        }                
-        return true;        
     }
 
+    /**
+     * Converts sPath to a {@link Path} and checks that it is an accessible folder.
+     * @param sPath a file system path.
+     * @return a {@link Path} guaranteed to point to an accessible folder.
+     */
+    public static Path toExistingFolder(String sPath) {
+        Path path = Paths.get(sPath);
+        if (!Files.isReadable(path)) {
+            throw new IllegalStateException("Unable to access folder '" + sPath + "'");
+        }
+        if (!Files.isDirectory(path)) {
+            throw new IllegalStateException("The path '" + sPath + "' is not a folder");
+        }
+        return path;
+    }
+    
 }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcSourceTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/ArcSourceTest.java
@@ -1,0 +1,69 @@
+package dk.kb.netarchivesuite.solrwayback.interfaces;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+
+import static org.junit.Assert.assertTrue;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+public class ArcSourceTest {
+
+    @Test
+    public void testPath() throws IOException {
+        String known = Objects.requireNonNull(Thread.currentThread().getContextClassLoader().getResource("logback-test.xml")).getPath();
+
+        ArcSource source = ArcSource.create(known);
+        String content = IOUtils.toString(source.get(), StandardCharsets.UTF_8);
+
+        assertTrue("Getting file system content from '" + known + " should work", content.startsWith("<?xml"));
+    }
+
+    @Test
+    public void testFileURL() throws IOException {
+        String known = "file://" +
+                Objects.requireNonNull(Thread.currentThread().getContextClassLoader().getResource("logback-test.xml")).getPath();
+
+        ArcSource source = ArcSource.create(known);
+        String content = IOUtils.toString(source.get(), StandardCharsets.UTF_8);
+
+        assertTrue("Getting file system content from '" + known + " should work", content.startsWith("<?xml"));
+    }
+
+    @Test
+    public void testHTTSURL() throws IOException {
+        String known = "http://bash.org/";
+
+        ArcSource source = ArcSource.create(known);
+        String content = IOUtils.toString(source.get(), StandardCharsets.UTF_8);
+
+        assertTrue("Getting file system content from '" + known + " should work", content.contains("<html"));
+    }
+
+    @Test
+    public void testHTTPSURL() throws IOException {
+        String known = "https://www.kb.dk/";
+
+        ArcSource source = ArcSource.create(known);
+        String content = IOUtils.toString(source.get(), StandardCharsets.UTF_8);
+
+        assertTrue("Getting file system content from '" + known + " should work", content.contains("<html"));
+    }
+
+}

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/AutoFileResolverTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/AutoFileResolverTest.java
@@ -1,0 +1,61 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.netarchivesuite.solrwayback.interfaces;
+
+import dk.kb.netarchivesuite.solrwayback.util.FileUtil;
+import static org.junit.Assert.*;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AutoFileResolverTest {
+    private static final String KNOWN_ARC_WITH_PATH = "example_arc/IAH-20080430204825-00000-blackbook.arc";
+
+    private static final String ARC =     "IAH-20080430204825-00000-blackbook.arc";
+    private static final String ARC_GZ =  "IAH-20080430204825-00000-blackbook.arc.gz";
+    private static final String WARC =    "IAH-20080430204825-00000-blackbook.warc";
+    private static final String WARC_GZ = "IAH-20080430204825-00000-blackbook.warc.gz";
+    private static final List<String> ALL = Arrays.asList(ARC, ARC_GZ, WARC, WARC_GZ);
+
+    @Test
+    public void staticScan() throws IOException {
+        // The test/resources folder in the solrwayback checkout
+        Path root = FileUtil.resolve(KNOWN_ARC_WITH_PATH).getParent().getParent();
+        Map<String, String> config = new HashMap<>();
+        config.put(AutoFileResolver.ROOTS_KEY, root.toString());
+        AutoFileResolver resolver = new AutoFileResolver();
+        resolver.setParameters(config);
+        resolver.initialize();
+
+        for (String warc: ALL) {
+            Path warcPath = Paths.get(resolver.resolveArcFileLocation(warc).getSource());
+            assertNotNull("There should be a path for (W)ARC '" + warc + "'", warcPath);
+            assertTrue("The path '" + warcPath + "' for (W)ARC '" + warc + "' should exist", Files.exists(warcPath));
+        }
+    }
+
+    @Test
+    public void testRescan() {
+        throw new UnsupportedOperationException("Not implemented but needs to be tested");
+    }
+}

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/RewriteLocationResolverTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/interfaces/RewriteLocationResolverTest.java
@@ -22,21 +22,18 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
-
 /**
  * Piggy backs on {@link dk.kb.netarchivesuite.solrwayback.util.SkippingHTTPInputStreamTest}.
  */
-public class ArcHTTPResolverTest {
+public class RewriteLocationResolverTest {
     public static final String ADAMS_FILE = "foo/18068_Adams_Illustrated_Panorama_of_History_1878_size_104345x11288.tif";
 
     @Test
     public void testSkip() throws IOException {
         Map<String, String> skipParams = new HashMap<>();
-        skipParams.put(ArcHTTPResolver.REGEXP_KEY, ".*/([^/]*)");
-        skipParams.put(ArcHTTPResolver.REPLACEMENT_KEY, "https://labs.statsbiblioteket.dk/anskuelse/adams_history/$1");
-        skipParams.put(ArcHTTPResolver.READ_FALLBACK_KEY, "false");
-        ArcHTTPResolver resolver = new ArcHTTPResolver();
+        skipParams.put(RewriteLocationResolver.REGEXP_KEY, ".*/([^/]*)");
+        skipParams.put(RewriteLocationResolver.REPLACEMENT_KEY, "https://labs.statsbiblioteket.dk/anskuelse/adams_history/$1");
+        RewriteLocationResolver resolver = new RewriteLocationResolver();
         resolver.setParameters(skipParams);
         resolver.initialize();
 

--- a/src/test/resources/properties/solrwayback.properties
+++ b/src/test/resources/properties/solrwayback.properties
@@ -46,10 +46,15 @@ warc.files.verify.collection=false
 #
 # Default resolver: Optionally rewrites the input
 warc.file.resolver.class=dk.kb.netarchivesuite.solrwayback.interfaces.RewriteLocationResolver
-# Default parameters for RewriteLocationResolver: Return the input path unchanged
+# Default parameters for RewriteLocationResolver: Return the input path unchanged:
 # warc.file.resolver.parameters.path.regexp=.*
 # warc.file.resolver.parameters.path.replacement=$0
-# Sample parameters for RewriteLocationResolver that rewrites to a HTTP server
+# Sample parameters for RewriteLocationResolver that handles changed root location for WARC files,
+# where the subfolder structure for the WARCs is preserved:
+# warc.file.resolver.parameters.path.regexp=/home/harvester/warcs/(.*)
+# warc.file.resolver.parameters.path.replacement=/warcs/$1
+# Sample parameters for RewriteLocationResolver that rewrites to a HTTP server where all WARCs are accessible
+# directly under the "warcstore/" folder:
 # warc.file.resolver.parameters.path.regexp=.*([^/]*)
 # warc.file.resolver.parameters.path.replacement=http://example.com/warcstore/$1
 #
@@ -60,7 +65,9 @@ warc.file.resolver.class=dk.kb.netarchivesuite.solrwayback.interfaces.RewriteLoc
 # /storage/warcs/col1/mywarc_123.warc.gz
 # warc.file.resolver.parameters=/home/user/netarkivet.files
 #
-# Auto discovery: Scans folders for WARCs
+# Auto discovery: Scans folders for WARCs.
+# IMPORTANT: On a networked drive with millions of WARCs, the scan might take significant time
+# and IO resources. Use RewriteLocationResolver or FileMovedMappingResolver where possible.
 # warc.file.resolver.class=dk.kb.netarchivesuite.solrwayback.interfaces.AutoFileResolver
 # The AutoFileResolver MUST have at least one root to scan from
 # warc.file.resolver.parameters.autoresolver.roots=/home/sw/warcs1,/netmounts/colfoo


### PR DESCRIPTION
Large rewrite of WARC resolving. There are now 3 WARC resolvers:
* `RewriteLocationResolver`: Rewrites based on regexp/replacement. Default is the identity (no rewrite). This is the default resolver
* `FileMovedMappingResolver`: Rewrites based on a list of known WARCs
* `AutoFileResolver`: Scans one or more file system roots for WARCs. If enabled, rescans are performed at given intervals

Support for HTTP(S) has been moved to the `ArcSource` class, so both `RewriteLocationResolver` and `FileMovedMappingResolver` supports HTTP(S) URLs as well as plain file system paths.

Question: `RewriteLocationResolver` is not a very telling name as all the resolver rewrites. Maybe it should be called `BasicResolver`, `RuleResolver`, `RegexpResolver` or something fourth?

* This closes #386 
* This closes #385 
* This closes #374 