### PR TITLE
353/feature/config resolve

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/listeners/InitializationContextListener.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/listeners/InitializationContextListener.java
@@ -34,6 +34,10 @@ public class InitializationContextListener implements ServletContextListener {
             version = props.getProperty("APPLICATION.VERSION");
             PropertiesLoaderWeb.SOLRWAYBACK_VERSION = version;
 
+            // Remove leading "/"
+            webAppContext = webAppContext.startsWith("/") && !webAppContext.substring(1).contains("/") ?
+                    webAppContext.substring(1) :
+                    webAppContext;
             // Resolve property locations
             // Properties are either explicitly set using the web app Environment or taken from user home
             String backendConfig = webAppContext + ".properties"; // If contextroot is not solrwayback, it will first look for that context specific propertyfile

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
@@ -75,7 +75,7 @@ public class FileUtil {
      *     <li>As {@code env:user.dir/resource}, {@code env:user.dir/../resource} etc</li>
      *     <li>As {@code env:user.home/resource}</li>
      * </ul>
-     * When running under Tomcat, {@code catalina.home} is guaranteed to be set and {@code catalina.home} might be set.
+     * When running under Tomcat, {@code catalina.home} is guaranteed to be set and {@code catalina.base} might be set.
      * @param resources one or more resources to look for. First file system match is returned.
      * @return a Path to an existing file, found using the priorities stated above.
      * @throws FileNotFoundException if none of the resources could be found.
@@ -103,7 +103,7 @@ public class FileUtil {
      *     <li>As {@code env:user.dir/resource}, {@code env:user.dir/../resource} etc</li>
      *     <li>As {@code env:user.home/resource}</li>
      * </ul>
-     * When running under Tomcat, {@code catalina.home} is guaranteed to be set and {@code catalina.home} might be set.
+     * When running under Tomcat, {@code catalina.home} is guaranteed to be set and {@code catalina.base} might be set.
      * @param resource a resource to look for.
      * @return a stream with Paths to check for existence of the given resource, in order of priority as listed above.
      */

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
@@ -70,11 +70,12 @@ public class FileUtil {
      * Specialized resolver that operates on the file system. Attempts to locate the given resources in order
      * <ul>
      *     <li>Directly as file</li>
-     *     <li>As {@code $CATALINA_BASE/resource}, {@code $CATALINA_BASE/../resource} etc</li>
-     *     <li>As {@code $CATALINA_HOME/resource}, {@code $CATALINA_HOME/../resource} etc</li>
+     *     <li>As {@code env:catalina.base/resource}, {@code env:catalina.base/../resource} etc</li>
+     *     <li>As {@code env:catalina.home/resource}, {@code env:catalina.home/../resource} etc</li>
      *     <li>As {@code env:user.dir/resource}, {@code env:user.dir/../resource} etc</li>
      *     <li>As {@code env:user.home/resource}</li>
      * </ul>
+     * When running under Tomcat, {@code catalina.home} is guaranteed to be set and {@code catalina.home} might be set.
      * @param resources one or more resources to look for. First file system match is returned.
      * @return a Path to an existing file, found using the priorities stated above.
      * @throws FileNotFoundException if none of the resources could be found.
@@ -83,7 +84,8 @@ public class FileUtil {
         Set<Path> candidates = Arrays.stream(resources).
                 flatMap(FileUtil::getContainerCandidates).
                 collect(Collectors.toCollection(LinkedHashSet::new));
-        
+
+        // We print all potential paths to show people reading logs where the resources can be
         log.info("Resolving resource in order {}", candidates);
 
         return candidates.stream().
@@ -101,6 +103,7 @@ public class FileUtil {
      *     <li>As {@code env:user.dir/resource}, {@code env:user.dir/../resource} etc</li>
      *     <li>As {@code env:user.home/resource}</li>
      * </ul>
+     * When running under Tomcat, {@code catalina.home} is guaranteed to be set and {@code catalina.home} might be set.
      * @param resource a resource to look for.
      * @return a stream with Paths to check for existence of the given resource, in order of priority as listed above.
      */
@@ -114,7 +117,7 @@ public class FileUtil {
     }
 
     /**
-     * Expand the given path to a Stream of the path itselv, followed by all its parents.
+     * Expand the given path to a Stream of the path itself, followed by all its parents.
      * @param path any path.
      * @return a stream of the path followed by all parents.
      */

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
@@ -1,16 +1,17 @@
 package dk.kb.netarchivesuite.solrwayback.util;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
@@ -43,7 +44,7 @@ public class FileUtil {
     }
 
     /**
-     * Locates a file designated by {@code resource} by using the class loadr primarily and direct checking of
+     * Locates a file designated by {@code resource} by using the class loader primarily and direct checking of
      * the file system secondarily.
      * @param resource a resource available on the file system.
      * @return the path to the {@code resource}.
@@ -64,6 +65,68 @@ public class FileUtil {
             throw new IOException("Unable to convert URL '" + url + "' to URI", e);
         }
     }
+
+    /**
+     * Specialized resolver that operates on the file system. Attempts to locate the given resources in order
+     * <ul>
+     *     <li>Directly as file</li>
+     *     <li>As {@code $CATALINA_BASE/resource}, {@code $CATALINA_BASE/../resource} etc</li>
+     *     <li>As {@code $CATALINA_HOME/resource}, {@code $CATALINA_HOME/../resource} etc</li>
+     *     <li>As {@code env:user.dir/resource}, {@code env:user.dir/../resource} etc</li>
+     *     <li>As {@code env:user.home/resource}</li>
+     * </ul>
+     * @param resources one or more resources to look for. First file system match is returned.
+     * @return a Path to an existing file, found using the priorities stated above.
+     * @throws FileNotFoundException if none of the resources could be found.
+     */
+    public static Path resolveContainerResource(String... resources) throws FileNotFoundException {
+        Set<Path> candidates = Arrays.stream(resources).
+                flatMap(FileUtil::getContainerCandidates).
+                collect(Collectors.toCollection(LinkedHashSet::new));
+        
+        log.info("Resolving resource in order {}", candidates);
+
+        return candidates.stream().
+                filter(Files::exists).
+                findFirst().
+                orElseThrow(() -> new FileNotFoundException("Unable to locate any of " + Arrays.toString(resources)));
+    }
+
+    /**
+     * Generates candidate Paths for the given resource in order
+     * <ul>
+     *     <li>Directly as file</li>
+     *     <li>As {@code env:catalina.base/resource}, {@code env:catalina.base/../resource} etc</li>
+     *     <li>As {@code env:catalina.home/resource}, {@code env:catalina.home/../resource} etc</li>
+     *     <li>As {@code env:user.dir/resource}, {@code env:user.dir/../resource} etc</li>
+     *     <li>As {@code env:user.home/resource}</li>
+     * </ul>
+     * @param resource a resource to look for.
+     * @return a stream with Paths to check for existence of the given resource, in order of priority as listed above.
+     */
+    static Stream<Path> getContainerCandidates(String resource) {
+        return Stream.of("catalina.base", "catalina.home", "user.dir", "user.home").
+                map(System::getProperty).            // Get the property value
+                filter(Objects::nonNull).            // Ignore the non-defined properties
+                map(Paths::get).                     // Convert to Path
+                flatMap(FileUtil::allLevels).        // All folders
+                map(path -> path.resolve(resource)); // All full paths
+    }
+
+    /**
+     * Expand the given path to a Stream of the path itselv, followed by all its parents.
+     * @param path any path.
+     * @return a stream of the path followed by all parents.
+     */
+    private static Stream<Path> allLevels(Path path) {
+        List<Path> levels = new ArrayList<>();
+        levels.add(path);
+        while ((path = path.getParent()) != null) {
+            levels.add(path);
+        }
+        return levels.stream();
+    }
+
     /**
      * Converts sPath to a {@link Path} and checks that it is an accessible folder.
      * @param sPath a file system path.

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/FileUtil.java
@@ -122,12 +122,9 @@ public class FileUtil {
      * @return a stream of the path followed by all parents.
      */
     private static Stream<Path> allLevels(Path path) {
-        List<Path> levels = new ArrayList<>();
-        levels.add(path);
-        while ((path = path.getParent()) != null) {
-            levels.add(path);
-        }
-        return levels.stream();
+        return path.getParent() != null ?
+                Stream.concat(Stream.of(path), allLevels(path.getParent())) :
+                Stream.of(path);
     }
 
     /**

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/util/FileUtilTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/util/FileUtilTest.java
@@ -1,0 +1,52 @@
+package dk.kb.netarchivesuite.solrwayback.util;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+public class FileUtilTest {
+    private static final Logger log = LoggerFactory.getLogger(FileUtilTest.class);
+
+    @Test
+    public void testGetContainerCandidates() {
+        List<Path> candidates = FileUtil.getContainerCandidates("foo").collect(Collectors.toList());
+        log.debug("Got candidates {}", candidates);
+
+        assertFalse("There should be some candidates", candidates.isEmpty());
+
+        Path expected = Paths.get(System.getProperty("user.home"), "foo");
+        assertTrue("The known path '" + expected + "' should be present in candidate list " + candidates,
+                candidates.contains(expected));
+    }
+
+    @Test
+    public void testResolveContainerResource() throws FileNotFoundException {
+        // We expect the current folder to be the project root and we know that the file pom.xml is there
+        Path pom = FileUtil.resolveContainerResource("pom.xml"); // Throws exception if not found
+        log.debug("Found pom: '" + pom + "'");
+    }
+}


### PR DESCRIPTION
Adds more flexible resolving of the config files. The use case is for the SolrWayback bundle, where the config files can now be placed directly in the bundle folder. It it also be possible to place the config files in the root of the project folder with the source code, when running under jetty.

If the location of the two property files are not specified in the WAR context, they are sought resolved from the container (e.g. tomcat or jetty) root. If not there, the parent folder is checked and so forth. If that does not yield results, the current folder as well as the user's home folder is checked in a similar manner.

Testing this properly is cumbersome as it requires at least

 * Placing a config file in the root of the project folder and running with jetty
 * Placing a config file in the root a tomcat folder where the WAR is deployed
 * Specifying a config file location in the context (i.e. `solrwayback.xml`) for SolrWayback using tomcat and checking that this is used instead of another config placed directly in the tomcat folder. See the `webapp/META-INF/context.xml` for how to specify the location explicitly

This closes #353 