### PR TITLE
Set explicit encoding UTF-8 for indexing

### DIFF
--- a/src/bundle/indexing/batch_warcs1_folder.bat
+++ b/src/bundle/indexing/batch_warcs1_folder.bat
@@ -1,4 +1,4 @@
 cd /D "%~dp0"
 
-FOR /R warcs1 %%G IN (*.*) do  java -Xmx2048M -Djava.io.tmpdir=tika_tmp -jar warc-indexer-3.2.0-SNAPSHOT-jar-with-dependencies.jar -c config3.conf -s  "http://localhost:8983/solr/netarchivebuilder"  "%%G"
+FOR /R warcs1 %%G IN (*.*) do  java -Dfile.encoding=UTF-8 -Xmx2048M -Djava.io.tmpdir=tika_tmp -jar warc-indexer-3.2.0-SNAPSHOT-jar-with-dependencies.jar -c config3.conf -s  "http://localhost:8983/solr/netarchivebuilder"  "%%G"
 

--- a/src/bundle/indexing/batch_warcs1_folder.sh
+++ b/src/bundle/indexing/batch_warcs1_folder.sh
@@ -5,10 +5,10 @@ pushd ${BASH_SOURCE%/*} > /dev/null
 FILES=warcs1/*
 for f in $FILES
 do
-  echo "Processing $f file..."
-java -Xmx1024M -Djava.io.tmpdir=tika_tmp -jar warc-indexer-3.2.0-SNAPSHOT-jar-with-dependencies.jar -c config3.conf -s  "http://localhost:8983/solr/netarchivebuilder"  $f
-
+    echo "Processing $f file..."
+    java -Dfile.encoding=UTF-8 -Xmx1024M -Djava.io.tmpdir=tika_tmp -jar warc-indexer-3.2.0-SNAPSHOT-jar-with-dependencies.jar -c config3.conf -s  "http://localhost:8983/solr/netarchivebuilder"  $f
 done
+
 echo "Flushing Solr. Documents will be visible after flush"
 curl -s "http://localhost:8983/solr/netarchivebuilder/update?commit=true&openSearcher=true"  > /dev/null
 

--- a/src/bundle/indexing/batch_warcs2_folder.bat
+++ b/src/bundle/indexing/batch_warcs2_folder.bat
@@ -1,4 +1,4 @@
 cd /D "%~dp0"
 
-FOR /R warcs2 %%G IN (*.*) do  java -Xmx2048M -Djava.io.tmpdir=tika_tmp -jar warc-indexer-3.2.0-SNAPSHOT-jar-with-dependencies.jar -c config3.conf -s  "http://localhost:8983/solr/netarchivebuilder"  "%%G"
+FOR /R warcs2 %%G IN (*.*) do  java -Dfile.encoding=UTF-8 -Xmx2048M -Djava.io.tmpdir=tika_tmp -jar warc-indexer-3.2.0-SNAPSHOT-jar-with-dependencies.jar -c config3.conf -s  "http://localhost:8983/solr/netarchivebuilder"  "%%G"
 

--- a/src/bundle/indexing/batch_warcs2_folder.sh
+++ b/src/bundle/indexing/batch_warcs2_folder.sh
@@ -5,10 +5,10 @@ pushd ${BASH_SOURCE%/*} > /dev/null
 FILES=warcs2/*
 for f in $FILES
 do
-  echo "Processing $f file..."
-java -Xmx1024M -Djava.io.tmpdir=tika_tmp -jar warc-indexer-3.2.0-SNAPSHOT-jar-with-dependencies.jar -c config3.conf -s  "http://localhost:8983/solr/netarchivebuilder"  $f
-
+    echo "Processing $f file..."
+    java -Dfile.encoding=UTF-8 -Xmx1024M -Djava.io.tmpdir=tika_tmp -jar warc-indexer-3.2.0-SNAPSHOT-jar-with-dependencies.jar -c config3.conf -s  "http://localhost:8983/solr/netarchivebuilder"  $f
 done
+
 echo "Flushing Solr. Documents will be visible after flush"
 curl -s "http://localhost:8983/solr/netarchivebuilder/update?commit=true&openSearcher=true"  > /dev/null
 

--- a/src/bundle/indexing/warc-indexer.sh
+++ b/src/bundle/indexing/warc-indexer.sh
@@ -41,6 +41,7 @@ THREADS_DEFAULT="2"
 : ${TMP_ROOT:="${STATUS_ROOT}/tmp"}
 : ${SOLR_CHECK:="true"}
 : ${SOLR_COMMIT:="true"}
+
 popd > /dev/null
 
 function usage() {
@@ -198,10 +199,10 @@ index_warc() {
 
     echo "   - Indexing $WARC"
     mkdir "$WARC_TMP"
-    local CALL="java -Xmx1024M -Djava.io.tmpdir=\"$WARC_TMP\" -jar \"$INDEXER_JAR\" -c \"$INDEXER_CONFIG\" $INDEXER_CUSTOM -s  \"$SOLR_URL\"  \"$WARC\" &> \"$WARC_LOG\""
+    local CALL="java -Dfile.encoding=UTF-8 -Xmx1024M -Djava.io.tmpdir=\"$WARC_TMP\" -jar \"$INDEXER_JAR\" -c \"$INDEXER_CONFIG\" $INDEXER_CUSTOM -s  \"$SOLR_URL\"  \"$WARC\" &> \"$WARC_LOG\""
     echo "$CALL" >> "$WARC_LOG"
     # Using  >> "$WARC_LOG" 2>&1 instead of &>> to be able to run on machines with bash version 3. Most Macs come with some version of bash 3.
-    java -Xmx1024M -Djava.io.tmpdir="$WARC_TMP" -jar "$INDEXER_JAR" -c "$INDEXER_CONFIG" $INDEXER_CUSTOM -s  "$SOLR_URL"  "$WARC" >> "$WARC_LOG" 2>&1
+    java -Dfile.encoding=UTF-8 -Xmx1024M -Djava.io.tmpdir="$WARC_TMP" -jar "$INDEXER_JAR" -c "$INDEXER_CONFIG" $INDEXER_CUSTOM -s  "$SOLR_URL"  "$WARC" >> "$WARC_LOG" 2>&1
     local RC=$?
     if [[ $(wc -l < "$WARC_LOG") -eq 1 ]]; then
         mv "$WARC_LOG" "$WARC_FAILED"


### PR DESCRIPTION
The warc-indexer used for indexing WARCs to Solr does not specify UTF-8 as the output character encoding itself. While UTF-8 is default on many systems, it is still an assumption and if e.g. ASCII is the default, all non-ASCII characters will be replaced with an "unknown character" representation (typically a question mark in a black rhombus). This was triggered by Trym Brennes while running the bundle under Docker.

Setting file.encoding to UTF-8 is a workaround until the warc-indexer is changed to always output UTF-8. As the output is used for Solr (or Elasticsearch) which both supports UTF-8, this is the only encoding that makes sense.

This closes #405 