### PR TITLE
Trim the excessive logged stack trace for missing WARC files

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParserFileResolver.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/ArcParserFileResolver.java
@@ -1,15 +1,15 @@
 package dk.kb.netarchivesuite.solrwayback.parsers;
 
-import java.util.HashMap;
-
+import dk.kb.netarchivesuite.solrwayback.interfaces.ArcFileLocationResolverInterface;
 import dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource;
 import dk.kb.netarchivesuite.solrwayback.interfaces.RewriteLocationResolver;
+import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
+import dk.kb.netarchivesuite.solrwayback.service.exception.NotFoundServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import dk.kb.netarchivesuite.solrwayback.interfaces.ArcFileLocationResolverInterface;
-import dk.kb.netarchivesuite.solrwayback.interfaces.IdentityArcFileResolver;
-import dk.kb.netarchivesuite.solrwayback.service.dto.ArcEntry;
+import java.io.FileNotFoundException;
+import java.util.HashMap;
 
 /*
  * This class will resolve the arc-file location using source_file_path from the index.
@@ -57,6 +57,10 @@ public class ArcParserFileResolver {
       return ArcFileParserFactory.getArcEntry(arcSource, offset);
 
     } catch (Exception e) {
+      if (e instanceof RuntimeException && e.getCause() instanceof FileNotFoundException) {
+        // The only thing throwing FileNotFoundExceptions should be ArcSource.get and that already logs errors
+        throw new NotFoundServiceException("Unable to locate (W)ARC '" + source_file_path + "'");
+      }
       // It CAN happen, but crazy unlikely, and not critical at all... (took 10
       // threads spamming 1M+ requests/sec for it to happen in a test.):
       log.error("Critical error resolving warc:" + source_file_path + " and offset:" + offset + " Error:" + e.getMessage());


### PR DESCRIPTION
Missing WARC files, typically caused by a dismounted network drive or a moved folder, causes excessive track traces in the logs when performing playback of webpages. This pull request changes the code to

* Log the `FileNotFoundException` at the root level `ArcSource.get()`
* Perform explicit checking for the `FileNotFoundException` at the calling level `ArcParserFileResolver.getArcEntry(...)`, culling the stack trace and converting it to a proper HTTP 404 service exception.

After this pull request, the log entries from a missing WARC will be
```
2023-10-16 20:50:37 [http-nio-8080-exec-25] DEBUG dk.kb.netarchivesuite.solrwayback.service.SolrWaybackResource(SolrWaybackResource.java:933) - View from FilePath:/home/te/projects/wac2023/solrwayback_package_4.4.1/indexing/warcs1/mywarc.warc.gz offset:266225
2023-10-16 20:50:37 [http-nio-8080-exec-25] ERROR dk.kb.netarchivesuite.solrwayback.interfaces.ArcSource(ArcSource.java:90) - FileNotFoundException trying to access (W)ARC '/home/te/projects/wac2023/solrwayback_package_4.4.1/indexing/warcs1/mywarc.warc.gz'
2023-10-16 20:50:37 [http-nio-8080-exec-25] INFO  dk.kb.netarchivesuite.solrwayback.service.SolrWaybackResource(SolrWaybackResource.java:1135) - Handling serviceException:Unable to locate (W)ARC '/home/te/projects/wac2023/solrwayback_package_4.4.1/indexing/warcs1/mywarc.dk.warc.gz'
```
The first (the "real" message) is from the logger @ `ArcSource` and is enables closer bug finding. The second is from the Exception handler in the `SolrWaybackResource` and is unavoidable with the current architecture as the old contract is that the exception message will be logged here.

This closes #414 