### PR TITLE
Upgrade solr dependencies to 9.4.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # SolrWayback changelog
 
+UNRELEASED
+-----
+Upgraded solr dependencies from v9.1.0 to v9.4.1
 
 
 5.1.2

--- a/pom.xml
+++ b/pom.xml
@@ -113,20 +113,20 @@
       <dependency>
         <groupId>org.apache.solr</groupId>
         <artifactId>solr-solrj</artifactId>
-        <version>9.1.0</version>
+        <version>9.4.1</version>
       </dependency>
 
       <dependency>
         <groupId>org.apache.solr</groupId>
         <artifactId>solr-test-framework</artifactId>
-        <version>9.1.0</version>
+        <version>9.4.1</version>
         <scope>test</scope>      
       </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.solr/solr-core -->
       <dependency>
           <groupId>org.apache.solr</groupId>
           <artifactId>solr-core</artifactId>
-          <version>9.1.0</version>
+          <version>9.4.1</version>
           <scope>test</scope>
         <exclusions>
          <exclusion>
@@ -140,7 +140,7 @@
       <dependency>
           <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-core</artifactId>
-          <version>9.2.0</version>
+          <version>9.8.0</version>
           <scope>test</scope>
       </dependency>
 

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/SolrStatsTest.java
@@ -13,23 +13,18 @@ import dk.kb.netarchivesuite.solrwayback.solr.SolrStats;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.CoreContainer;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.apache.solr.core.NodeConfig;
+import org.junit.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 
 public class SolrStatsTest {
     private static final Logger log = LoggerFactory.getLogger(SolrStatsTest.class);
 
-    private static String solr_home= "target/test-classes/solr_9";
+    private static String SOLR_HOME = "target/test-classes/solr_9";
     private static NetarchiveSolrClient server = null;
     private static CoreContainer coreContainer= null;
     private static EmbeddedSolrServer embeddedServer = null;
@@ -37,8 +32,10 @@ public class SolrStatsTest {
     @Before
     public void setUp() throws Exception {
         // Embedded Solr 9.1+ must have absolute home both as env and explicit param
-        System.setProperty("solr.install.dir", Path.of(solr_home).toAbsolutePath().toString());
-        coreContainer = CoreContainer.createAndLoad(Path.of(solr_home).toAbsolutePath());
+        Path solrHome = Path.of(SOLR_HOME).toAbsolutePath();
+        System.setProperty("solr.install.dir", solrHome.toString());
+        NodeConfig nodeConfig = new NodeConfig.NodeConfigBuilder("netarchivebuilder", solrHome).build();
+        coreContainer = new CoreContainer(nodeConfig);
         coreContainer.load();
         embeddedServer = new EmbeddedSolrServer(coreContainer,"netarchivebuilder");
         NetarchiveSolrTestClient.initializeOverLoadUnitTest(embeddedServer);

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/EmbeddedSolrTest.java
@@ -4,16 +4,11 @@ import static org.junit.Assert.assertEquals;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashSet;
 
-import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
-import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.*;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,23 +18,25 @@ import dk.kb.netarchivesuite.solrwayback.service.dto.IndexDoc;
 public class EmbeddedSolrTest {
 
     private static final Logger log = LoggerFactory.getLogger(EmbeddedSolrTest.class);        
-    private static String solr_home= "target/test-classes/solr_9";
+    private static String SOLR_HOME = "target/test-classes/solr_9";
     private static NetarchiveSolrClient server = null;
     private static  CoreContainer coreContainer= null;
     private static EmbeddedSolrServer embeddedServer = null;
     
     @Before
     public void setUp() throws Exception {
-       // Embedded Solr 9.1+ must have absolute home both as env and explicit param
-       System.setProperty("solr.install.dir", Path.of(solr_home).toAbsolutePath().toString());
-       coreContainer = CoreContainer.createAndLoad(Path.of(solr_home).toAbsolutePath());
-       coreContainer.load();
-       embeddedServer = new EmbeddedSolrServer(coreContainer,"netarchivebuilder");
-       NetarchiveSolrTestClient.initializeOverLoadUnitTest(embeddedServer);
-       server = NetarchiveSolrClient.getInstance();
-       
+        // Embedded Solr 9.1+ must have absolute home both as env and explicit param
+        Path solrHome = Path.of(SOLR_HOME).toAbsolutePath();
+        System.setProperty("solr.install.dir", solrHome.toString());
+        NodeConfig nodeConfig = new NodeConfig.NodeConfigBuilder("netarchivebuilder", solrHome).build();
+        coreContainer = new CoreContainer(nodeConfig);
+        coreContainer.load();
+        embeddedServer = new EmbeddedSolrServer(coreContainer,"netarchivebuilder");
+        NetarchiveSolrTestClient.initializeOverLoadUnitTest(embeddedServer);
+        server = NetarchiveSolrClient.getInstance();
+
         // Remove any items from previous executions:
-       embeddedServer.deleteByQuery("*:*"); //This is not on the NetarchiveSolrClient API!
+        embeddedServer.deleteByQuery("*:*"); //This is not on the NetarchiveSolrClient API!
     }
 
     /**

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStreamDirectTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/SolrStreamDirectTest.java
@@ -27,6 +27,7 @@ import org.apache.solr.client.solrj.embedded.EmbeddedSolrServer;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.core.CoreContainer;
+import org.apache.solr.core.NodeConfig;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -62,8 +63,10 @@ public class SolrStreamDirectTest {
         PropertiesLoader.initProperties(UnitTestUtils.getFile("properties/solrwayback_unittest.properties").getPath());
 
         // Embedded Solr 9.1+ must have absolute home both as env and explicit param
-        System.setProperty("solr.install.dir", Path.of(SOLR_HOME).toAbsolutePath().toString());
-        coreContainer = CoreContainer.createAndLoad(Path.of(SOLR_HOME).toAbsolutePath());
+        Path solrHome = Path.of(SOLR_HOME).toAbsolutePath();
+        System.setProperty("solr.install.dir", solrHome.toString());
+        NodeConfig nodeConfig = new NodeConfig.NodeConfigBuilder("netarchivebuilder", solrHome).build();
+        coreContainer = new CoreContainer(nodeConfig);
         coreContainer.load();
         embeddedServer = new EmbeddedSolrServer(coreContainer,"netarchivebuilder");
         NetarchiveSolrTestClient.initializeOverLoadUnitTest(embeddedServer);

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/UrlResolveTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/UrlResolveTest.java
@@ -64,8 +64,10 @@ public class UrlResolveTest {
         PropertiesLoader.initProperties(UnitTestUtils.getFile("properties/solrwayback_unittest.properties").getPath());
 
         // Embedded Solr 9.1+ must have absolute home both as env and explicit param
-        System.setProperty("solr.install.dir", Path.of(SOLR_HOME).toAbsolutePath().toString());
-        coreContainer = CoreContainer.createAndLoad(Path.of(SOLR_HOME).toAbsolutePath());
+        Path solrHome = Path.of(SOLR_HOME).toAbsolutePath();
+        System.setProperty("solr.install.dir", solrHome.toString());
+        NodeConfig nodeConfig = new NodeConfig.NodeConfigBuilder("netarchivebuilder", solrHome).build();
+        coreContainer = new CoreContainer(nodeConfig);
         coreContainer.load();
         solr = new ConvenientEmbeddedSolrServer(coreContainer, "netarchivebuilder");
         NetarchiveSolrTestClient.initializeOverLoadUnitTest(solr);


### PR DESCRIPTION
Closes #440 

I've managed to upgrade the tests to not fail on 9.4 by upgrading lucene accordingly to: [solr 9 release notes](https://cwiki.apache.org/confluence/display/SOLR/ReleaseNote9_4_0) and changing how the embeded server is started.

I hoped that it would be possible to switch directly to 9.6.0 to also upgrade the deprecated HttpClient in #458, however there might be some greater obstacles going beyond solr 9.4. I'll try and look into that at some point.