### PR TITLE
Simple bundle startup

### DIFF
--- a/src/bundle/solrwayback_bundle.bat
+++ b/src/bundle/solrwayback_bundle.bat
@@ -11,6 +11,10 @@ IF /I "%~1"=="start" (
     call solr-9\bin\solr.cmd start -c -m 4g
 
     echo Starting SolrWayback in tomcat...
+
+    REM Set CATALINA_HOME to the "tomcat-9" folder inside the current directory
+    set "CATALINA_HOME=%cd%\tomcat-9"
+
     call tomcat-9\bin\startup.bat
 
     echo.
@@ -20,10 +24,13 @@ IF /I "%~1"=="start" (
 
 IF /I "%~1"=="stop" (
     echo Stopping SolrWayback in tomcat...
+
+    REM Set CATALINA_HOME to the "tomcat-9" folder inside the current directory
+    set "CATALINA_HOME=%cd%\tomcat-9"
     call tomcat-9\bin\shutdown.bat
 
     echo Stopping solr...
-    call solr-9\bin\solr.cmd stop
+    call solr-9\bin\solr.cmd stop -all
 
     echo.
     echo Stopped SolrWayback

--- a/src/bundle/solrwayback_bundle.bat
+++ b/src/bundle/solrwayback_bundle.bat
@@ -1,0 +1,36 @@
+@echo off
+REM Check if an argument was provided
+IF "%~1"=="" (
+    echo Usage: %~nx0 ^{start^|stop^}
+    exit /b 1
+)
+
+REM Main case handling
+IF /I "%~1"=="start" (
+    echo Starting solr...
+    call solr-9\bin\solr.cmd start -c -m 4g
+
+    echo Starting SolrWayback in tomcat...
+    call tomcat-9\bin\startup.bat
+
+    echo.
+    echo Started SolrWayback
+    GOTO :eof
+)
+
+IF /I "%~1"=="stop" (
+    echo Stopping SolrWayback in tomcat...
+    call tomcat-9\bin\shutdown.bat
+
+    echo Stopping solr...
+    call solr-9\bin\solr.cmd stop
+
+    echo.
+    echo Stopped SolrWayback
+    GOTO :eof
+)
+
+REM Invalid option
+echo Invalid option: %~1
+echo Usage: %~nx0 ^{start^|stop^}
+exit /b 2

--- a/src/bundle/solrwayback_bundle.sh
+++ b/src/bundle/solrwayback_bundle.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Check if an argument was provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 {start|stop}"
+    exit 1
+fi
+
+case "$1" in
+    start)
+        echo "Starting solr..."
+        ./solr-9/bin/solr start -c -m 4g
+
+        echo "Starting SolrWayback in tomcat..."
+        ./tomcat-9/bin/startup.sh
+
+        printf "\n\nStarted SolrWayback\n"
+        ;;
+    stop)
+        echo "Stopping SolrWayback in tomcat..."
+        ./tomcat-9/bin/shutdown.sh
+
+        echo "Stopping solr..."
+        ./solr-9/bin/solr stop
+
+        printf "\n\nStopped SolrWayback\n"
+        ;;
+    *)
+        echo "Invalid option: $1"
+        echo "Usage: $0 {start|stop}"
+        exit 2
+        ;;
+esac


### PR DESCRIPTION
Add scripts to make startup and shutdown in a bundled solr wayback installation easier for users who are not used to working with a command line interface. This is a first version. I would like to make the scripts be able to set the memory allocation for solr for some customization.

Shell script tested on mac. Bat script tested on windows.