### PR TITLE
GSON dependency update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.3.1</version>
+      <version>2.13.2</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Update gson dependency version to 2.13.2. Only affects class `SolrStatsTest`.

