### PR TITLE
Fix incorrect date format for calendar

### DIFF
--- a/src/js/src/components/harvestCalendar/HarvestsDay.vue
+++ b/src/js/src/components/harvestCalendar/HarvestsDay.vue
@@ -40,7 +40,7 @@ export default {
   methods: {
     generateLink(harvest) {
       const solrWaybackUrl = configs.playbackConfig.solrwaybackBaseURL 
-      return `${solrWaybackUrl}services/web/${format(harvest, 'YYYYMMDDHHmmss')}/${this.url}`
+      return `${solrWaybackUrl}services/web/${format(harvest, 'yyyyMMddHHmmss')}/${this.url}`
     },
 
     formatHumanDate(date, showWeekday = false) {


### PR DESCRIPTION
We got an error when checking the calendar. 
The date format was YYYYMMDDHHmmsss. 
This should fix that error.