### PR TITLE
Additional hardening of navigation tracker

### DIFF
--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResource.java
@@ -11,8 +11,9 @@ import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import java.util.*;
 
 import static dk.kb.netarchivesuite.solrwayback.util.DateUtils.convertWaybackDate2SolrDate;
@@ -27,7 +28,8 @@ public class NavigationHistoryResource {
     private static final Logger log = LoggerFactory.getLogger(NavigationHistoryResource.class);
     private static final String SESSION_KEY = "solrwayback_query_history";
 
-    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    // Use ISO-8601 UTC format, e.g. 2005-01-01T12:00:00Z
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ISO_INSTANT;
 
     // Maximum allowed size of the stored history in bytes (25 MB)
     public static long MAX_HISTORY_BYTES = 25L * 1024L * 1024L;
@@ -47,7 +49,8 @@ public class NavigationHistoryResource {
             List<Map<String, String>> history = getHistory(session);
 
             String url = (String) data.get("url");
-            String timestamp = DATE_FORMAT.format(LocalDateTime.now());
+            // Truncate to seconds so we don't include fractional seconds (e.g. 2026-03-02T18:05:57Z)
+            String timestamp = DATE_FORMAT.format(Instant.now().truncatedTo(ChronoUnit.SECONDS));
 
             Map<String, String> entry = new HashMap<>();
             entry.put("url", url);
@@ -95,7 +98,8 @@ public class NavigationHistoryResource {
             String url = (String) data.get("url");
             String originalUrl = (String) data.get("originalUrl");
             String archivalDate = convertWaybackDate2SolrDate((String) data.get("waybackDate"));
-            String timestamp = DATE_FORMAT.format(LocalDateTime.now());
+            // Truncate to seconds so we don't include fractional seconds (e.g. 2026-03-02T18:05:57Z)
+            String timestamp = DATE_FORMAT.format(Instant.now().truncatedTo(ChronoUnit.SECONDS));
 
             Map<String, String> entry = new HashMap<>();
             entry.put("url", url);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResource.java
@@ -94,11 +94,13 @@ public class NavigationHistoryResource {
 
             String url = (String) data.get("url");
             String originalUrl = (String) data.get("originalUrl");
-            String timestamp = convertWaybackDate2SolrDate((String) data.get("waybackDate"));
+            String archivalDate = convertWaybackDate2SolrDate((String) data.get("waybackDate"));
+            String timestamp = DATE_FORMAT.format(LocalDateTime.now());
 
             Map<String, String> entry = new HashMap<>();
             entry.put("url", url);
             entry.put("originalUrl", originalUrl);
+            entry.put("date", archivalDate);
             entry.put("timestamp", timestamp);
 
             // Check size before mutating the session-stored list

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/NavigationHistoryAction.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/NavigationHistoryAction.java
@@ -1,0 +1,21 @@
+package dk.kb.netarchivesuite.solrwayback.util;
+
+/**
+ * Represents the type of action recorded in a user's navigation history.
+ */
+public enum NavigationHistoryAction {
+    QUERY("QUERY"),
+    SEARCH_RESULT_CLICKED("SEARCH RESULT CLICKED"),
+    PLAYBACK_LINK_CLICKED("PLAYBACK LINK CLICKED");
+
+    private final String label;
+
+    NavigationHistoryAction(String label) {
+        this.label = label.toUpperCase();
+    }
+
+    @Override
+    public String toString() {
+        return label;
+    }
+}

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/NavigationHistoryUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/NavigationHistoryUtils.java
@@ -79,7 +79,7 @@ public class NavigationHistoryUtils {
     public static int populateQueryEntry(int actionNumber, String url, List<Map<String, Object>> result) {
         Map<String, Object> jsonEntry = new LinkedHashMap<>();
         jsonEntry.put("number", actionNumber++);
-        jsonEntry.put("action", "query");
+        jsonEntry.put("action", NavigationHistoryAction.QUERY);
 
         // Extract query
         String query = extractQueryFromUrl(url);
@@ -134,7 +134,7 @@ public class NavigationHistoryUtils {
     }
 
     /**
-     * Populate a playback link entry in the result list. Destinguishes between clicks from search results vs. links within playback.
+     * Populate a playback link entry in the result list. Distinguishes between clicks from search results vs. links within playback.
      */
     public static int populateResultEntries(int actionNumber, boolean lastWasPlayback, String timestamp, String originalUrl, List<Map<String, Object>> result, String url) {
         // Playback URL
@@ -143,9 +143,9 @@ public class NavigationHistoryUtils {
 
         // Distinguish between clicks from search results vs. links within playback
         if (lastWasPlayback) {
-            jsonEntry.put("action", "playback link clicked");
+            jsonEntry.put("action", NavigationHistoryAction.PLAYBACK_LINK_CLICKED);
         } else {
-            jsonEntry.put("action", "search result clicked");
+            jsonEntry.put("action", NavigationHistoryAction.SEARCH_RESULT_CLICKED);
         }
 
         jsonEntry.put("date", timestamp);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/NavigationHistoryUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/NavigationHistoryUtils.java
@@ -76,10 +76,11 @@ public class NavigationHistoryUtils {
     /**
      * Populate a query entry in the result list
      */
-    public static int populateQueryEntry(int actionNumber, String url, List<Map<String, Object>> result) {
+    public static int populateQueryEntry(int actionNumber, String timestamp, String url, List<Map<String, Object>> result) {
         Map<String, Object> jsonEntry = new LinkedHashMap<>();
         jsonEntry.put("number", actionNumber++);
         jsonEntry.put("action", NavigationHistoryAction.QUERY);
+        jsonEntry.put("timestamp", timestamp);
 
         // Extract query
         String query = extractQueryFromUrl(url);
@@ -136,7 +137,7 @@ public class NavigationHistoryUtils {
     /**
      * Populate a playback link entry in the result list. Distinguishes between clicks from search results vs. links within playback.
      */
-    public static int populateResultEntries(int actionNumber, boolean lastWasPlayback, String timestamp, String originalUrl, List<Map<String, Object>> result, String url) {
+    public static int populateResultEntries(int actionNumber, boolean lastWasPlayback, String timestamp, String date, String originalUrl, List<Map<String, Object>> result, String url) {
         // Playback URL
         Map<String, Object> jsonEntry = new LinkedHashMap<>();
         jsonEntry.put("number", actionNumber++);
@@ -148,7 +149,8 @@ public class NavigationHistoryUtils {
             jsonEntry.put("action", NavigationHistoryAction.SEARCH_RESULT_CLICKED);
         }
 
-        jsonEntry.put("date", timestamp);
+        jsonEntry.put("timestamp", timestamp);
+        jsonEntry.put("date", date);
         jsonEntry.put("url", originalUrl != null ? originalUrl : "unknown");
         jsonEntry.put("archivedUrl", url);
 
@@ -169,18 +171,19 @@ public class NavigationHistoryUtils {
         for (Map<String, String> entry : history) {
             String url = entry.get("url");
             String timestamp = entry.get("timestamp");
+            String date = entry.get("date");
             String originalUrl = entry.get("originalUrl");
 
             // Determine if this is a search query or playback URL
             if (url.contains("/search?query=")) {
                 // Only output if URL changed (covers query changes AND facet changes)
                 if (!url.equals(lastUrl)) {
-                    actionNumber = populateQueryEntry(actionNumber, url, result);
+                    actionNumber = populateQueryEntry(actionNumber, timestamp, url, result);
                     lastUrl = url;
                     lastWasPlayback = false;
                 }
             } else if (url.contains("/services/web/")) {
-                actionNumber = populateResultEntries(actionNumber, lastWasPlayback, timestamp, originalUrl, result, url);
+                actionNumber = populateResultEntries(actionNumber, lastWasPlayback, timestamp, date, originalUrl, result, url);
                 lastUrl = null;  // Reset so next search is always tracked
                 lastWasPlayback = true;
             }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResourceTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResourceTest.java
@@ -1,6 +1,8 @@
 package dk.kb.netarchivesuite.solrwayback.service;
 
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
+import dk.kb.netarchivesuite.solrwayback.util.NavigationHistoryAction;
+import dk.kb.netarchivesuite.solrwayback.util.NavigationHistoryUtils;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -329,13 +331,13 @@ public class NavigationHistoryResourceTest extends UnitTestUtils {
         // Verify first entry
         Map<String, Object> firstEntry = entity.get(0);
         assertEquals(1, firstEntry.get("number"));
-        assertEquals("query", firstEntry.get("action"));
+        assertEquals(NavigationHistoryAction.QUERY, firstEntry.get("action"));
         assertEquals("test", firstEntry.get("query"));
 
         // Verify second entry
         Map<String, Object> secondEntry = entity.get(1);
         assertEquals(2, secondEntry.get("number"));
-        assertEquals("query", secondEntry.get("action"));
+        assertEquals(NavigationHistoryAction.QUERY, secondEntry.get("action"));
         assertEquals("example", secondEntry.get("query"));
     }
 
@@ -361,7 +363,7 @@ public class NavigationHistoryResourceTest extends UnitTestUtils {
         assertEquals(1, entity.size());
 
         Map<String, Object> entry = entity.get(0);
-        assertEquals("query", entry.get("action"));
+        assertEquals(NavigationHistoryAction.QUERY, entry.get("action"));
         assertEquals("test", entry.get("query"));
         assertNotNull(entry.get("facets"));
 
@@ -382,6 +384,7 @@ public class NavigationHistoryResourceTest extends UnitTestUtils {
         history.add(createPlaybackEntry(
             "http://localhost:8080/services/web/20201231120000/http://example.com/page.html",
             "http://example.com/page.html",
+            "2026-03-02 15:30:00",
             "2020-12-31 12:00:00"
         ));
 
@@ -399,12 +402,12 @@ public class NavigationHistoryResourceTest extends UnitTestUtils {
         // Verify search entry
         Map<String, Object> searchEntry = entity.get(0);
         assertEquals(1, searchEntry.get("number"));
-        assertEquals("query", searchEntry.get("action"));
+        assertEquals(NavigationHistoryAction.QUERY, searchEntry.get("action"));
 
         // Verify playback entry
         Map<String, Object> playbackEntry = entity.get(1);
         assertEquals(2, playbackEntry.get("number"));
-        assertEquals("search result clicked", playbackEntry.get("action"));
+        assertEquals(NavigationHistoryAction.SEARCH_RESULT_CLICKED, playbackEntry.get("action"));
         assertEquals("http://example.com/page.html", playbackEntry.get("url"));
         assertEquals("2020-12-31 12:00:00", playbackEntry.get("date"));
     }
@@ -441,11 +444,11 @@ public class NavigationHistoryResourceTest extends UnitTestUtils {
 
         // First playback should be "search result clicked"
         Map<String, Object> firstPlayback = entity.get(1);
-        assertEquals("search result clicked", firstPlayback.get("action"));
+        assertEquals(NavigationHistoryAction.SEARCH_RESULT_CLICKED, firstPlayback.get("action"));
 
         // Second playback should be "playback link clicked"
         Map<String, Object> secondPlayback = entity.get(2);
-        assertEquals("playback link clicked", secondPlayback.get("action"));
+        assertEquals(NavigationHistoryAction.PLAYBACK_LINK_CLICKED, secondPlayback.get("action"));
     }
 
     /**
@@ -621,10 +624,10 @@ public class NavigationHistoryResourceTest extends UnitTestUtils {
         assertEquals(4, entity.size());
 
         // Verify order and action types
-        assertEquals("query", entity.get(0).get("action"));
-        assertEquals("search result clicked", entity.get(1).get("action"));
-        assertEquals("query", entity.get(2).get("action"));
-        assertEquals("search result clicked", entity.get(3).get("action"));
+        assertEquals(NavigationHistoryAction.QUERY, entity.get(0).get("action"));
+        assertEquals(NavigationHistoryAction.SEARCH_RESULT_CLICKED, entity.get(1).get("action"));
+        assertEquals(NavigationHistoryAction.QUERY, entity.get(2).get("action"));
+        assertEquals(NavigationHistoryAction.SEARCH_RESULT_CLICKED, entity.get(3).get("action"));
     }
 
     /**
@@ -684,6 +687,15 @@ public class NavigationHistoryResourceTest extends UnitTestUtils {
         entry.put("url", url);
         entry.put("originalUrl", originalUrl);
         entry.put("timestamp", timestamp);
+        return entry;
+    }
+
+    private Map<String, String> createPlaybackEntry(String url, String originalUrl, String timestamp, String date) {
+        Map<String, String> entry = new HashMap<>();
+        entry.put("url", url);
+        entry.put("originalUrl", originalUrl);
+        entry.put("timestamp", timestamp);
+        entry.put("date", date);
         return entry;
     }
 }


### PR DESCRIPTION
This pull request improves the consistency and structure of navigation history tracking in the application.

**Navigation history action standardisation:**

* Introduced a new `NavigationHistoryAction` enum to represent action types (e.g., QUERY, SEARCH_RESULT_CLICKED, PLAYBACK_LINK_CLICKED) instead of using raw strings, improving type safety and consistency throughout the codebase.
* Updated all usages of action strings in `NavigationHistoryUtils` and related test assertions to use the new enum values. 

**Timestamp and date handling improvements:**

* Changed timestamp formatting in `NavigationHistoryResource` to use ISO-8601 UTC format with seconds precision (truncating fractional seconds), ensuring consistency and easier parsing. 


These changes increase the maintainability and reliability of the navigation history functionality by enforcing stricter typing, improving time handling, and clarifying the distinction between different navigation actions.