### PR TITLE
Enable test that works after latest changes

### DIFF
--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResourceTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResourceTest.java
@@ -120,8 +120,7 @@ public class NavigationHistoryResourceTest extends UnitTestUtils {
     /**
      * Test tracking playback navigation successfully
      */
-    /* DISABLED UNTIL VICTOR FIX!
-    @Test   
+    @Test
     public void testTrackPlaybackSuccess() {
         // Setup
         when(mockRequest.getSession(true)).thenReturn(mockSession);
@@ -151,7 +150,7 @@ public class NavigationHistoryResourceTest extends UnitTestUtils {
         assertEquals("http://example.com/page.html", capturedHistory.get(0).get("originalUrl"));
         assertNotNull(capturedHistory.get(0).get("timestamp"));
      }
-    */
+
     
     /**
      * Test tracking playback with multiple entries


### PR DESCRIPTION
Simple PR which enables the unittest which failed earlier. 
Changes in previous PRs have made this work correctly. 
Closes #489 