### PR TITLE
Update Navigation History file name

### DIFF
--- a/src/js/src/components/NavigationHistoryButton.vue
+++ b/src/js/src/components/NavigationHistoryButton.vue
@@ -93,12 +93,22 @@ export default {
         if (!response.ok) {
           throw new Error('Failed to download history')
         }
-        
+
+
+       // Parse filename header
+       const disposition = response.headers.get('content-disposition') || ''
+       let filename = 'query_history.json'     // fallback
+       const match = disposition.match(/filename[^;=\n]*=((['"]).*?\2|[^;\n]*)/)
+       if (match && match[1]) {
+         // strip surrounding quotes if any
+         filename = match[1].replace(/['"]/g, '')
+       }
+
         const content = await response.blob()
         const url = window.URL.createObjectURL(content)
         const link = document.createElement('a')
         link.href = url
-        link.download = 'query_history.json'
+        link.download = filename
         document.body.appendChild(link)
         link.click()
         document.body.removeChild(link)

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResource.java
@@ -1,5 +1,6 @@
 package dk.kb.netarchivesuite.solrwayback.service;
 
+import dk.kb.netarchivesuite.solrwayback.util.DateUtils;
 import dk.kb.netarchivesuite.solrwayback.util.JsonUtils;
 import dk.kb.netarchivesuite.solrwayback.util.NavigationHistoryUtils;
 import org.slf4j.Logger;
@@ -164,12 +165,14 @@ public class NavigationHistoryResource {
     @Path("download")
     @Produces(MediaType.APPLICATION_JSON)
     public Response downloadHistory(@Context HttpServletRequest request) {
+        String currentDate = DateUtils.currentDateYYYYMMDD();
+
         try {
             HttpSession session = request.getSession(false);
             if (session == null) {
                 List<Map<String, Object>> emptyHistory = new ArrayList<>();
                 return Response.ok(emptyHistory)
-                        .header("Content-Disposition", "attachment; filename=\"query_history.json\"")
+                        .header("Content-Disposition", "attachment; filename=\"" + currentDate + "_query_history.json\"")
                         .build();
             }
 
@@ -179,7 +182,7 @@ public class NavigationHistoryResource {
             log.info("Downloading query history with {} entries", formattedHistory.size());
 
             return Response.ok(formattedHistory)
-                    .header("Content-Disposition", "attachment; filename=\"query_history.json\"")
+                    .header("Content-Disposition", "attachment; filename=\"" + currentDate + "_query_history.json\"")
                     .build();
         } catch (Exception e) {
             log.error("Error downloading history", e);

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/util/DateUtils.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/util/DateUtils.java
@@ -6,6 +6,7 @@ import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 import java.time.Period;
 import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -283,5 +284,18 @@ public class DateUtils {
         timestamp = timestampBuilder.toString();
         log.info("Timestamp is now: '{}'", timestamp);
         return timestamp;
+    }
+
+    /**
+     * Returns the current date as a string in the form YYYYMMDD.
+     *
+     * @return the formatted date string
+     */
+    public static String currentDateYYYYMMDD() {
+        LocalDate today = LocalDate.now();
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        return today.format(formatter);
     }
 }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResourceTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/service/NavigationHistoryResourceTest.java
@@ -1,6 +1,7 @@
 package dk.kb.netarchivesuite.solrwayback.service;
 
 import dk.kb.netarchivesuite.solrwayback.UnitTestUtils;
+import dk.kb.netarchivesuite.solrwayback.util.DateUtils;
 import dk.kb.netarchivesuite.solrwayback.util.NavigationHistoryAction;
 import dk.kb.netarchivesuite.solrwayback.util.NavigationHistoryUtils;
 import org.junit.Before;
@@ -270,6 +271,8 @@ public class NavigationHistoryResourceTest extends UnitTestUtils {
      */
     @Test
     public void testDownloadHistoryNoSession() {
+        String currentDate = DateUtils.currentDateYYYYMMDD();
+
         // Setup
         when(mockRequest.getSession(false)).thenReturn(null);
 
@@ -281,7 +284,7 @@ public class NavigationHistoryResourceTest extends UnitTestUtils {
         List<Map<String, Object>> entity = (List<Map<String, Object>>) response.getEntity();
         assertNotNull(entity);
         assertEquals(0, entity.size());
-        assertEquals("attachment; filename=\"query_history.json\"",
+        assertEquals("attachment; filename=\"" + currentDate + "_query_history.json\"",
                      response.getHeaderString("Content-Disposition"));
     }
 


### PR DESCRIPTION
Our research team members are downloading a lot of their navigation history files and they wanted easier filenaming. 
I've implemented it as YYYYMMDD_navigation_history.json and @jorntx has reviewed internally. 

We will hopefully have some time during the summer or fall to work more on this feature, including creating the modal view and remove the polling completely as we have discussed earlier.