### PR TITLE
Update JSoup to 1.15.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.14.2</version>
+      <version>1.15.3</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/com.google.guava/guava -->

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriterTest.java
@@ -191,12 +191,13 @@ public class HtmlParserUrlRewriterTest {
      */
     private String normalise(String text) {
         return Arrays.stream(
-                text.replace("> <!--", ">\n<!--") // JSoup won't put comments on their own lines
-                        .replace("</style> <a", "</style>\n<a") // JSoup strangeness with lines starting with <a...>
-                        .replace("</a> <a", "</a>\n<a")
-                        .replace("--> <a", "-->\n<a")
+                // Put every tag boundary on its own line and collapse whitespace runs so that the comparison is
+                // insensitive to JSoup's pretty-printing, which differs between JSoup versions (e.g. whether
+                // adjacent inline elements, comments or <br> are separated by a newline, a space or nothing).
+                text.replaceAll(">\\s*<", ">\n<")
                         .split("\n"))
                 .map(String::trim)
+                .map(line -> line.replaceAll("\\s+", " "))
                 .filter(line -> !line.isEmpty())
                 .collect(Collectors.joining("\n"));
     }


### PR DESCRIPTION
Sorry for these small PRs, just wanting to keep them individual 

Updating JSoup.

1.15.3 is a security update fixing the following:
-  CVE-2022-36033, an XSS hole where the HTML sanitizer (Cleaner/Safelist) could let through crafted javascript: URLs. 

The important change here for SolrWayback is how output is normalised:
- SolrWayback tests compare the full serialized HTML of doc.toString() against checked-in _expected.html fixtures. Jsoup 1.14.2's pretty-printer generated those fixtures. jsoup 1.15.1 changed how that pretty-printer emits whitespace, so the output shifted even though the parsed document and the rewritten URLs are identical. 