### PR TITLE
Jira 507 follow redirects fix

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 # SolrWayback changelog
 
 ## [UNRELEASED]
-
+### Fixed
+* Fixed bug resolving redirect chain. Closing #https://github.com/netarchivesuite/solrwayback/issues/507
 
 5.4.3
 -----

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriter.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/parsers/HtmlParserUrlRewriter.java
@@ -472,9 +472,14 @@ public class HtmlParserUrlRewriter {
             Document doc, String element, String attribute, UnaryOperator<String> transformer) {
         for (Element e : doc.select(element)) {
             String content = attribute == null || attribute.isEmpty() ? e.data() : e.attr(attribute);
+                    
             if (content == null  || content.trim().isEmpty()){
                 continue;
+            }            
+            if(content.toLowerCase().trim().startsWith("javascript:")){                
+                continue;// this is allowed for HREF. Should refactor href replacement in custom method.              
             }
+            
             String newContent = transformer.apply(content);
             if (newContent != null && !newContent.equals(content)) {
                 if (attribute == null || attribute.isEmpty()) {

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -68,6 +68,8 @@ public class NetarchiveSolrClient {
     private final AtomicLong lenientAttempts = new AtomicLong(0);
     private final AtomicLong lenientSuccesses = new AtomicLong(0);
 
+    private static final int MAX_REDIRECT_DEPTH = 3;
+    
     protected Boolean solrAvailable = null;
 
     protected NetarchiveSolrClient() { // private. Singleton
@@ -1136,10 +1138,18 @@ public class NetarchiveSolrClient {
     }
 
 
+    
     /*
      * Notice here do we not fix url_norm
      */
     public IndexDoc findClosestHarvestTimeForUrl(String url, String timeStamp) throws Exception {
+        return findClosestHarvestTimeForUrl(url, timeStamp, 0);
+    }
+    
+    
+    
+    //Will follow redirects and return final URL that is not a redirect
+    private IndexDoc findClosestHarvestTimeForUrl(String url, String timeStamp, int redirectDepth) throws Exception {
 
         if (url == null || timeStamp == null) {
             throw new IllegalArgumentException("harvestUrl or timeStamp is null"); // Can happen for url-rewrites that are not corrected
@@ -1150,7 +1160,12 @@ public class NetarchiveSolrClient {
 
         String urlNormQuery = UrlUtils.fixLegacyNormaliseUrlErrorQuery(url);
 
-        String query = urlNormQuery +" AND status_code:200"; //Maybe also allow 400 and 404?: (status_code:200 OR status_code:400 OR status_code:404).          
+        // Was hardcoded to status_code:200, which meant a URL that only exists in the
+        // index as a redirect was never found at all. Broadened to include every
+        // redirect status SolrWayback can follow (see isRedirectStatus) so we can
+        // detect one and chase it down below. 303/307/308 included since SolrWayback
+        // always replays as GET, so their method-preservation semantics don't matter here.
+        String query = urlNormQuery;
 
         SolrQuery solrQuery = new SolrQuery();
         solrQuery.setQuery(query);
@@ -1212,7 +1227,7 @@ public class NetarchiveSolrClient {
             // If redirect, do not return the same url as this will give endless redirect.
             // This can happen due to the http://www.test.dk http://test.dk is normalized to
             // the same.
-            if (doc.getStatusCode() >= 300 && doc.getStatusCode() < 400) {
+            if (isRedirectStatus(doc.getStatusCode())) {
                 if (doc.getUrl().equals(url)) { // Do not return the same for redirect.
                     log.info("Stopping endless direct for url:" + url + " and found url:" + doc.getUrl());
                     continue; // skip
@@ -1231,7 +1246,29 @@ public class NetarchiveSolrClient {
         if (bestIndex != 0) {
             log.warn("Fixed Solr time sort bug, found a better match, # result:" + bestIndex);
         }
-        return indexDocs.get(bestIndex);
+
+        IndexDoc best = indexDocs.get(bestIndex);
+
+        // Follow a redirect to its target instead of returning the redirect document
+        // itself, so a URL that only ever exists in the index as a redirect still
+        // resolves to real content. Capped at MAX_REDIRECT_DEPTH hops to guard
+        // against a redirect loop (e.g. A -> B -> A).
+        if (isRedirectStatus(best.getStatusCode())) {
+            String redirectTarget = best.getRedirectToNorm();
+            if (redirectTarget == null || redirectTarget.isEmpty()) {
+                log.warn("Redirect (status " + best.getStatusCode() + ") for url:" + url + " has no redirect_to_norm value, returning the redirect document as-is.");
+                return best;
+            }
+            if (redirectDepth >= MAX_REDIRECT_DEPTH) {
+                log.warn("Reached max redirect depth (" + MAX_REDIRECT_DEPTH + ") resolving url:" + url + ", returning the redirect document as-is to avoid an endless loop.");
+                return best;
+            }
+            log.info("Following redirect (status " + best.getStatusCode() + ") from url:" + url + " to:" + redirectTarget + " (hop " + (redirectDepth + 1) + ")");
+            IndexDoc resolved = findClosestHarvestTimeForUrl(redirectTarget, timeStamp, redirectDepth + 1);
+            return resolved != null ? resolved : best; // fall back to the redirect doc if nothing found downstream
+        }
+
+        return best;
     }
 
     /**
@@ -1813,4 +1850,10 @@ public class NetarchiveSolrClient {
     public long getLenientSuccesses() {
         return lenientSuccesses.get();
     }
+    
+    private static boolean isRedirectStatus(int statusCode) {
+        return statusCode == 301 || statusCode == 302 || statusCode == 303
+            || statusCode == 307 || statusCode == 308;
+    }
+
 }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -1158,7 +1158,7 @@ public class NetarchiveSolrClient {
         // normalize will remove last slash if not slashpage
         boolean slashLast = url.endsWith("/");
 
-        String urlNormQuery = UrlUtils.fixLegacyNormaliseUrlErrorQuery(url);
+        String urlNormQuery = UrlUtils.fixLegacyNormaliseUrlErrorQuery(url); //TODO just call normal normaliser when legacy support is removed
 
         // Was hardcoded to status_code:200, which meant a URL that only exists in the
         // index as a redirect was never found at all. Broadened to include every
@@ -1229,7 +1229,7 @@ public class NetarchiveSolrClient {
             // the same.
             if (isRedirectStatus(doc.getStatusCode())) {
                 if (doc.getUrl().equals(url)) { // Do not return the same for redirect.
-                    log.info("Stopping endless direct for url:" + url + " and found url:" + doc.getUrl());
+                    log.warn("Stopping endless direct for url:" + url + " and found url:" + doc.getUrl());
                     continue; // skip
                 }
             }

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/EmbeddedSolrTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/EmbeddedSolrTest.java
@@ -99,5 +99,71 @@ public class EmbeddedSolrTest {
        assertEquals("2018-03-15T12:37:32Z", result.getCrawlDate());       
     }
     
+    
+    @Test
+    public void testRedirectChainResolvesToFinalDocument() throws Exception {
+      
+        indexRedirectChainTestData();
+
+        //Notice crawldate is 1 day before page harvested for testing.
+        IndexDoc result = server.findClosestHarvestTimeForUrl("http://test.domain/redirect1", "2026-08-25T00:00:0Z"); 
+     
+        System.out.println(result.getUrl());
+        System.out.println(result.getCrawlDate());
+        System.out.println(result.getStatusCode());
+        assertEquals("http://test.domain/final", result.getUrl()); //Resolved through 2 redirects.
+        assertEquals(200, result.getStatusCode());        
+    }
+    
+
+    private static void indexRedirectChainTestData() throws Exception {
+        String url1 = "http://test.domain/redirect1";
+        String url2 = "http://test.domain/redirect2";
+        String urlFinal = "http://test.domain/final";
+
+        // 1) redirect1 -> redirect2
+        SolrInputDocument redirect1 = new SolrInputDocument();
+        redirect1.addField("source_file_offset", 1000);
+        redirect1.addField("id", "redirect1");
+        redirect1.addField("title", "redirect1");
+        redirect1.addField("url", url1);
+        redirect1.addField("url_norm", url1);
+        redirect1.addField("record_type", "response");
+        redirect1.addField("source_file_path", "some.warc");
+        redirect1.addField("status_code", "302");
+        redirect1.addField("crawl_date", "2026-08-26T00:00:00Z");
+        redirect1.addField("redirect_to_norm", url2); // points to the NEXT record, not itself
+
+        // 2) redirect2 -> final
+        SolrInputDocument redirect2 = new SolrInputDocument();
+        redirect2.addField("source_file_offset", 2000);
+        redirect2.addField("id", "redirect2");
+        redirect2.addField("title", "redirect2");
+        redirect2.addField("url", url2);
+        redirect2.addField("url_norm", url2);
+        redirect2.addField("record_type", "response");
+        redirect2.addField("source_file_path", "some.warc");
+        redirect2.addField("status_code", "302");
+        redirect2.addField("crawl_date", "2026-08-26T00:00:01Z");
+        redirect2.addField("redirect_to_norm", urlFinal);
+
+        // 3) final 200 response — the actual page content
+        SolrInputDocument finalDoc = new SolrInputDocument();
+        finalDoc.addField("source_file_offset", 3000);
+        finalDoc.addField("id", "final");
+        finalDoc.addField("title", "final");
+        finalDoc.addField("url", urlFinal);
+        finalDoc.addField("url_norm", urlFinal);
+        finalDoc.addField("record_type", "response");
+        finalDoc.addField("source_file_path", "some.warc");
+        finalDoc.addField("status_code", "200");
+        finalDoc.addField("crawl_date", "2026-08-26T00:00:02Z");
+        // no redirect_to_norm on a 200 — nothing to redirect to
+
+        embeddedServer.add(redirect1);
+        embeddedServer.add(redirect2);
+        embeddedServer.add(finalDoc);
+        embeddedServer.commit();
+    }
 
 }


### PR DESCRIPTION
Fixed resolving redirect chain, maximum 3 jumps hardkoded.
Added unittest with 3 documents: Redirect1(301) -> redirect2(301) -> final page(200)