### PR TITLE
Extend Solr docs for separate installs, allowPaths, and collection-id #460

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,16 @@ Absolute URL live-leaks (starting with http://domain...) will not be caught and 
 #### Warc indexer
 Documents in SolrWayback are indexed through the [warc-indexer](https://github.com/ukwa/webarchive-discovery/tree/master/warc-indexer), which is maintained by The British Library. This is a fundamental tool for indexing WARC files in SolrWayback and furthermore it is included in the [SolrWayback bundle](https://github.com/netarchivesuite/solrwayback/releases).
 
+#### Extended Solr guide
+If you install Solr separately instead of using the Solr that ships in the bundle, see the [Extended Solr guide](src/bundle/solr/SOLR.md). That guide covers Solr 9 Cloud, including uploading the webarchive-discovery Solr configuration and creating the `netarchivebuilder` collection.
+
  
 ## Requirements
  * Works on macOS/Linux/Windows
  * Java 11 (tested with OpenJDK) 
  * A nice collection of ARC/WARC files or harvest your own with Heritrix, Webrecorder, Brozzler, Wget, etc. 
  * Tomcat 9+ or another J2EE server for deploying the WAR-file
- * A Solr 9+ server with the index build from the Arc/Warc files using the Warc-Indexer version 3.2.0-SNAPSHOT+
+ * A Solr 9+ server with the index build from the Arc/Warc files using the Warc-Indexer version 3.2.0-SNAPSHOT+. For a separate Solr 9 Cloud install (not the bundle Solr), see the [Extended Solr guide](src/bundle/solr/SOLR.md).
  * (Optional) chrome/(chromium) installed for page previews to work. (headless chrome) 
  
 ## Build and usage for developers.
@@ -235,10 +238,11 @@ THREADS=2 ./warc-indexer.sh warcs1/*
 This will start indexing files from the folder warcs1 using 2 threads. Assigning a higher number of threads than CPU cores available will result in slower indexing. Each indexing job require 1GB of RAM, so this can also be a limiting factor.
 
 
-To create custom collections in your index, you can  populate the collection and collectionid field in Solr with custom values. This can be done with the following command during indexing:
+To create custom collections in your index, you can populate the `collection`, `collection_id` and `institution` fields in Solr with custom values. Pass them to the warc-indexer during indexing:
 ```
-THREADS=4 INDEXER_CUSTOM="--collection_id  collection1 --collection corona2021" ./warc-indexer.sh warcs1/*
+THREADS=4 INDEXER_CUSTOM="--collection-id collection1 --collection corona2021 --institution institution1" ./warc-indexer.sh warcs1/*
 ```
+The indexer CLI uses hyphens (`--collection-id`, `--collection`, `--institution`). Older warc-indexer releases used `--collection_id`.
 
 You can then enable faceting on these fields in the property file: `solrwaybackweb.properties`.
 
@@ -319,6 +323,7 @@ an index of about 1TB having 500M documents and this requires changing the Solr 
 
 Storing the index on a SSD drive is required to reach acceptable performance for searches.
 For collections larger than this limit Solr Cloud is required instead of the stand alone Solr that comes with the SolrWayback Bundle.
+See the [Extended Solr guide](src/bundle/solr/SOLR.md) for a Solr 9 Cloud setup that uses the webarchive-discovery Solr configuration to create the collection.
 A more advanced distributed indexing flow can be handled by the archon/arctika index workflow. See: https://github.com/netarchivesuite/netsearch 
 
  

--- a/src/bundle/solr/SOLR.md
+++ b/src/bundle/solr/SOLR.md
@@ -49,6 +49,16 @@ solr-9/bin/solr create_collection -c netarchivebuilder -d solr9/discovery/conf/ 
 ```
 Visit http://localhost:8983/solr/#/~cloud?view=graph to check that there is now a collection called `netarchivebuilder` with 2 active shards.
 
+### Index data outside Solr home
+
+From Solr 9, index files must live under Solr home unless you allow another path. If the index is on a separate volume (or any directory outside Solr home), set `solr.allowPaths` before starting Solr, for example in `solr-9/bin/solr.in.sh`:
+
+```
+SOLR_OPTS="$SOLR_OPTS -Dsolr.allowPaths=/path/to/index"
+```
+
+You can also set `<str name="allowPaths">` in `solr.xml`. Without this, Solr refuses to create or load a collection whose `dataDir` is outside Solr home.
+
 ### Solr tricks
 
 Delete all documents in the index:


### PR DESCRIPTION
I added the three doc updates from #460.

The README now points at the Extended Solr guide for a separate Solr 9 Cloud install that uses the webarchive-discovery config. SOLR.md notes `solr.allowPaths` when the index is outside Solr home. The custom indexing example uses `--collection-id` and `--institution`.

Closes #460