### PR TITLE
Host-level granularity to the Toolbox's WordCloud, Stats and LinkGraph

### DIFF
--- a/src/js/src/assets/styles/search.scss
+++ b/src/js/src/assets/styles/search.scss
@@ -452,7 +452,7 @@ color:var(--secondary-text-color);
 }
 
 .wordcloudContainer .wordcloudButton {
-  margin-top: 15px !important;
+  /*margin-top: 15px !important;*/
   width: 100% !important;
   margin-bottom: 15px !important;
 }
@@ -525,9 +525,45 @@ color:var(--secondary-text-color);
   top:0px !important;
 }
 
-.directionContainer .label {
+.wordcloudContainer .domainHostChoiceSettings .contain {
+  padding: 10px 3px;
+}
+
+.directionContainer .label,
+.domainHostChoiceContainer .label{
   position: relative;
-	top: -5px;
+  top: -5px;
+}
+
+.linkGraphContainer .directionContainer,
+.linkGraphContainer .domainHostChoiceContainer {
+  display: inline-flex;
+  align-items: center;
+  height: 40px;
+  padding: 0 20px;
+  box-sizing: border-box;
+  gap: 8px;
+  vertical-align: middle;
+}
+
+.linkGraphContainer .directionContainer .label,
+.linkGraphContainer .domainHostChoiceContainer .label {
+  position: static;
+  top: auto;
+  display: inline-flex;
+  align-items: center;
+  margin: 0;
+  line-height: 1;
+}
+
+.linkGraphContainer .domainHostChoiceContainer {
+  margin-left: 20px;
+}
+
+.linkGraphContainer .directionContainer input[type=radio],
+.linkGraphContainer .domainHostChoiceContainer input[type=radio] {
+  margin: 0;
+  vertical-align: middle;
 }
 
 .graphControlsContainer {
@@ -554,6 +590,15 @@ color:var(--secondary-text-color);
 	color: var(--main-highlight-color);
 	height: 30px;
 	box-shadow: inset 0 0 7px var(--seethrough-black);
+}
+
+.domainHostChoiceContainer input[type=radio]{
+  width:20px;
+  height:20px;
+  border:1px solid var(--main-highlight-color);
+  box-shadow: none;
+  margin: 0;
+  vertical-align: middle;
 }
 
 .linkGraphContainer input {
@@ -599,12 +644,49 @@ img.imageEntry.noPointer {
 .domainContentContainer {
   padding:5px 15px 5px 15px;
 }
+
 .domainContentSettings {
-  display:flex;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 10px 12px;
+}
+
+.domainContentSettings > * {
+  display: flex;
+  align-items: center;
 }
 
 .domainContentContainer input {
-  width:280px;
+  width: 280px;
+}
+
+.domainHostChoiceSettings {
+  display: flex;
+  align-items: center;
+}
+
+.domainHostChoiceContainer {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.domainHostChoiceContainer .label {
+  position: static;
+  top: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0;
+}
+
+.domainContentContainer .domainStatsButton,
+.domainContentContainer .toggleViewButton {
+  float: none;
+  align-self: center;
 }
 
 .refiner {
@@ -638,6 +720,10 @@ img.imageEntry.noPointer {
 
 .directionContainer {
   display:inline-block;
+}
+
+.linkGraphContainer .directionContainer {
+  display: inline-flex;
 }
 
 .searchForm .sortOptions .marginRight {

--- a/src/js/src/components/Toolbox.vue
+++ b/src/js/src/components/Toolbox.vue
@@ -15,11 +15,11 @@
         <button :class="currentTool === 'wordcloud' ? 'activeTool' : ''" @click="setCurrentTool('wordcloud')">
           Wordcloud
         </button>
+        <button :class="currentTool === 'stats' ? 'activeTool' : ''" @click="setCurrentTool('stats')">
+          Stats
+        </button>
         <button :class="currentTool === 'linkgraph' ? 'activeTool' : ''" @click="setCurrentTool('linkgraph')">
           Link graph
-        </button>
-        <button :class="currentTool === 'domainstats' ? 'activeTool' : ''" @click="setCurrentTool('domainstats')">
-          Domain stats
         </button>
         <button :class="currentTool === 'gephiexport' ? 'activeTool' : ''" @click="setCurrentTool('gephiexport')">
           Link graph Gephi export
@@ -31,7 +31,7 @@
       </div>
       <wordcloud v-if="currentTool === 'wordcloud'" />
       <link-graph v-if="currentTool === 'linkgraph'" />
-      <domain-stats v-if="currentTool === 'domainstats'" />
+      <domain-stats v-if="currentTool === 'stats'" />
       <gephi-export v-if="currentTool === 'gephiexport'" />
       <ngram-netarchive v-if="currentTool === 'ngramnetarchive'" />
     </div>

--- a/src/js/src/components/ToolboxComponents/DomainStats.vue
+++ b/src/js/src/components/ToolboxComponents/DomainStats.vue
@@ -1,13 +1,13 @@
 <template>
   <div class="domainStatsContainer">
     <h2 class="toolboxHeadline">
-      Domain stats
+      Stats
     </h2>
     <div class="domainContentContainer">
       <div class="domainContentSettings">
         <input
           v-model="domain"
-          placeholder="Enter domain, like 'kb.dk'"
+          :placeholder="getPlaceholder()"
           :class="$_checkDomain(domain) ? '' : 'urlNotTrue'"
           @keyup.enter="loadGraphData(domain)"
         >
@@ -17,7 +17,16 @@
           @startdate="(sdate) => startDate = sdate"
           @enddate="(edate) => endDate = edate"
         />
-        <div class="generateButtonContainer contain">
+        <div class="domainHostChoiceSettings">
+          <div class="domainHostChoiceContainer contain">
+            <label class="domainHostChoiceLabel label">Search for:</label>
+            <input id="domainHostChoiceRadioOne" v-model="isDomain" type="radio" :value="true">
+            <label class="label" for="domainHostChoiceRadioOne">domain</label>
+            <input id="domainHostChoiceRadioTwo" v-model="isDomain" type="radio" :value="false">
+            <label class="label" for="domainHostChoiceRadioTwo">host</label>
+          </div>
+        </div>
+        <div class="generateButtonContainer contain refiner">
           <button
             :disabled="loading"
             class="domainStatsButton"
@@ -175,10 +184,13 @@ export default {
       startDate:'',
       endDate:'',
       timeScale:'',
-      showCombinedChart: true
+      showCombinedChart: true,
+      isDomain: true
     }
   },
-
+  mounted () {
+      isDomain: true
+  },
   methods: {
     ...mapActions(useNotifierStore, {
       setNotification: 'setNotification'
@@ -202,7 +214,7 @@ export default {
       // this.rawData = null
       this.loading = true
       this.timeScale = this.$refs.refiner.timeScaleInput
-      requestService.getDomainStatistics(this.prepareDomainForGetRequest(),this.startDate, this.endDate, this.timeScale)
+      requestService.getDomainStatistics(this.prepareDomainForGetRequest(),this.startDate, this.endDate, this.timeScale, this.isDomain)
         .then(result => {
           this.sanitizeResponseData(result)
           this.loading = false // <-- Move this line up
@@ -306,6 +318,9 @@ export default {
       domainScript.drawCombinedChart(this.graphData.chartLabels, this.graphData.sizeInKb,
                              this.graphData.numberOfPages, this.graphData.ingoingLinks,
                              this.graphData.textSize)
+    },
+    getPlaceholder() {
+      return this.isDomain ? "Enter domain, like 'kb.dk'" : "Enter host, like 'pro.kb.dk'"
     }
   }
 }

--- a/src/js/src/components/ToolboxComponents/LinkGraph.vue
+++ b/src/js/src/components/ToolboxComponents/LinkGraph.vue
@@ -7,7 +7,7 @@
       <div class="linkGraphSettings">
         <div class="linkGraphDomainContainer contain">
           <input v-model="domain"
-                 placeholder="Enter domain, like 'kb.dk'"
+                 :placeholder="getPlaceholder()"
                  :class="$_checkDomain(domain) ? '' : 'urlNotTrue'"
                  @keyup.enter="!loading ? loadLinkGraph(domain) : null">
         </div>
@@ -37,8 +37,16 @@
                  type="radio"
                  value="false">
           <label class="label" for="linkGraphRadioTwo">Outgoing</label>
-        </div> 
+        </div>
+      <div class="domainHostChoiceContainer contain">
+        <label class="domainHostChoiceLabel label">Search for:</label>
+        <input id="domainHostChoiceRadioOne" v-model="isDomain" type="radio" :value="true">
+        <label class="label" for="domainHostChoiceRadioOne">domain</label>
+        <input id="domainHostChoiceRadioTwo" v-model="isDomain" type="radio" :value="false">
+        <label class="label" for="domainHostChoiceRadioTwo">host</label>
       </div>
+    </div>
+
       <div class="sliderContainer">
         <label class="linkGraphLabel">Time frame:</label>
         <vue-slider v-model="sliderValues"
@@ -80,6 +88,7 @@ export default {
       ingoing:false,
       loading:false,
       domain:'',
+      isDomain: true
     }
   },
   mounted () {
@@ -99,13 +108,13 @@ export default {
         routerQuery.ingoing === 'true' ? this.ingoing = true : this.ingoing = false
       }
       this.loading = true
-      requestService.getLinkGraph(this.domain,this.linkNumber, this.ingoing, this.sliderValues[0], this.sliderValues[1]).then(result => (this.buildSvg(result)), error => console.log('Error, no link graph created.'))
+      requestService.getLinkGraph(this.domain,this.linkNumber, this.ingoing, this.sliderValues[0], this.sliderValues[1], this.isDomain).then(result => (this.buildSvg(result)), error => console.log('Error, no link graph created.'))
     }
   },
   methods: {
     loadLinkGraph(domain) {
       this.loading = true
-      requestService.getLinkGraph(this.domain,this.linkNumber, this.ingoing, this.sliderValues[0], this.sliderValues[1]).then(result => (this.buildSvg(result)), error => console.log('Error, no link graph created.'))
+      requestService.getLinkGraph(this.domain,this.linkNumber, this.ingoing, this.sliderValues[0], this.sliderValues[1], this.isDomain).then(result => (this.buildSvg(result)), error => console.log('Error, no link graph created.'))
     },
     createDateFromNumber(date) {
       const time = new Date(date)
@@ -294,7 +303,7 @@ export default {
             document.getElementById('graphContainer').innerHTML = ''
             _this.loading = true
             _this.domain = domain
-            requestService.getLinkGraph(domain,_this.linkNumber, _this.ingoing, _this.sliderValues[0], _this.sliderValues[1])
+            requestService.getLinkGraph(domain,_this.linkNumber, _this.ingoing, _this.sliderValues[0], _this.sliderValues[1], _this.isDomain)
             .then(result => (_this.buildSvg(result)), error => console.log('Error, no link graph created.'))
           })
 
@@ -316,6 +325,9 @@ export default {
       })
       this.loading = false
     },
+    getPlaceholder() {
+      return this.isDomain ? "Enter domain, like 'kb.dk'" : "Enter host, like 'pro.kb.dk'"
+    }
   }
 }
 </script>

--- a/src/js/src/components/ToolboxComponents/Wordcloud.vue
+++ b/src/js/src/components/ToolboxComponents/Wordcloud.vue
@@ -6,23 +6,36 @@
     <div class="wordcloudContainer">
       <div class="wordcloudExplanation">
         <input v-model="domain"
-               placeholder="Enter domain, like 'kb.dk'"
+               :placeholder="getPlaceholder()"
                :class="$_checkDomain(domain) ? '' : 'urlNotTrue'"
-               @keyup.enter="setDomainImage()">
-        <button :disabled="loadingImage" class="wordcloudButton" @click.prevent="setDomainImage()">
+               @keyup.enter="setWordcloudImage()">
+        <div class="domainHostChoiceSettings">
+          <div class="domainHostChoiceContainer contain">
+            <label class="domainHostChoiceLabel label">Search for:</label>
+            <input id="domainHostChoiceRadioOne" v-model="isDomain" type="radio" :value="true">
+            <label class="label" for="domainHostChoiceRadioOne">domain</label>
+            <input id="domainHostChoiceRadioTwo" v-model="isDomain" type="radio" :value="false">
+            <label class="label" for="domainHostChoiceRadioTwo">host</label>
+          </div>
+        </div>
+        <button :disabled="loadingImage" class="wordcloudButton" @click.prevent="setWordcloudImage()">
           Create wordcloud
         </button>
         <br>
         <p>
-          Simply enter the domain you wish to see a wordcloud of, and generate the wordcloud. The image is generated in real time, so it might take some time.
+          Enter the domain or the host you wish to see a wordcloud of, and generate the wordcloud. The image is generated in real time, so it might take some time.
         </p>
         <br>
         <p>
-          The domain entered must be without http://www, and only contain the trailing domain, like 'kb.dk' or 'statsbiblioteket.dk'.
+          The domain entered must be without http://www, and only contain the trailing domain, like 'kb.dk'.
         </p>
         <br>
         <p>
-          If the image returned is black, it simply means the archive holds no data on the entered domain.
+          The host entered must also be without http:// or www, and only contain the trailing host, like 'pro.kb.dk'.
+        </p>
+        <br>
+        <p>
+          If the image returned is black, it simply means the archive holds no data on the entered domain or host.
         </p>
       </div>
       <div class="imgContainer">
@@ -48,18 +61,25 @@ export default {
   data() {
     return {
       domain:'',
+      isDomain: true,
       imgSrc:'',
       loadingImage:false
     }
   },
   mounted () {
-    this.domain = '',
+    this.domain = ''
     this.imgSrc = ''
+    this.isDomain = true
+
   },
   methods: {
-    setDomainImage() {
+    setWordcloudImage() {
         this.loadingImage = true
-        this.imgSrc = 'services/frontend/wordcloud/domain?domain=' + this.domain + '&time=' + new Date().getTime()
+        const paramName = this.isDomain ? 'domain' : 'host'
+        this.imgSrc = `services/frontend/wordcloud/url?${paramName}=${encodeURIComponent(this.domain)}&time=${Date.now()}`
+    },
+    getPlaceholder() {
+      return this.isDomain ? "Enter domain, like 'kb.dk'" : "Enter host, like 'pro.kb.dk'"
     },
     doneLoading() {
     this.loadingImage = false

--- a/src/js/src/services/RequestService.js
+++ b/src/js/src/services/RequestService.js
@@ -245,12 +245,13 @@ async function getHarvestedPageResources(source_file_path, offset) {
 
 }
 
-async function getDomainStatistics(domain, startDate, endDate, timeScale) {
+async function getDomainStatistics(target, startDate, endDate, timeScale, isDomain) {
   let settings = ''
   if (timeScale != null && timeScale != '') {
       settings = '&startdate=' + startDate +'&enddate='+ endDate + '&scale=' + timeScale
   }
-  const url = `services/statistics/domain/?domain=${domain + settings}`
+  const paramName = isDomain ? 'domain' : 'host'
+  const url = `services/statistics/url?${paramName}=${target + settings}`
 
   try{
     const response = await axios.get(url)
@@ -331,8 +332,9 @@ async function getWarcHeader(sourceFilePath, offset) {
 
 }
 
-async function getLinkGraph(domain, facetLimit, ingoing, dateStart, dateEnd) {
-  const url = `services/frontend/tools/linkgraph/?domain=${domain}&facetLimit=${facetLimit}&ingoing=${ingoing}&dateStart=${dateStart}&dateEnd=${dateEnd}`
+async function getLinkGraph(target, facetLimit, ingoing, dateStart, dateEnd, isDomain) {
+  const paramName = isDomain ? 'domain' : 'host'
+  const url = `services/frontend/tools/linkgraph/?${paramName}=${target}&facetLimit=${facetLimit}&ingoing=${ingoing}&dateStart=${dateStart}&dateEnd=${dateEnd}`
 
   try{
     const response = await axios.get(url)

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/facade/Facade.java
@@ -252,14 +252,15 @@ public class Facade {
 
     /**
      * Get statistics for a specific domain.
-     * @param domain the domain to get statistics for, e.g. "example.com".
+     * @param target the domain or host to get statistics for, e.g. "example.com".
+     * @param isDomain true if the statics are for the domain, false if they are for the host
      * @param start the start date for the statistics, in ISO format (YYYY-MM-DD).
      * @param end the end date for the statistics, in ISO format (YYYY-MM-DD).
      * @param scale the time scale for the statistics, e.g. "day", "month", "year".
-     * @return a List of DomainStatistics objects containing the statistics for the domain.
+     * @return a List of DomainStatistics objects containing the statistics for the domain (or host).
      */
-    public static List<DomainStatistics> statisticsDomain(String domain, LocalDate start, LocalDate end, String scale) throws Exception {
-        log.info("Statistics for domain: " + domain + ", startdate:" + start.toString() + ", enddate:" + end.toString() + ", timescale:" + scale);
+    public static List<DomainStatistics> statisticsDomainHost(String target, Boolean isDomain, LocalDate start, LocalDate end, String scale) throws Exception {
+        log.info("Statistics for target: " + target + ", startdate:" + start.toString() + ", enddate:" + end.toString() + ", timescale:" + scale);
 
         List<DomainStatistics> stats = new ArrayList<>();
         String dateStr = "";
@@ -269,7 +270,7 @@ public class Facade {
             dateStr = period.first().format(DateTimeFormatter.ISO_DATE);
             nextDateStr = period.second().format(DateTimeFormatter.ISO_DATE);
             
-            DomainStatistics stat = NetarchiveSolrClient.getInstance().domainStatistics(domain, dateStr, nextDateStr);
+            DomainStatistics stat = NetarchiveSolrClient.getInstance().statisticsDomainHost(target, isDomain, dateStr, nextDateStr);
             stats.add(stat);
         }
         return stats;
@@ -464,10 +465,16 @@ public class Facade {
     /*
      * Can be deleted when frontend has switched
      */
-    public static BufferedImage wordCloudForDomain(String domain) throws Exception {
-        log.info("getting wordcloud for url:" + domain);
-        String query = "domain:\"" + domain + "\"";
-        String text = NetarchiveSolrClient.getInstance().getConcatedTextFromHtmlForQuery(query,null); // Only contains the required fields for this method
+    public static BufferedImage wordCloud(String target, boolean isDomain) throws Exception {
+        log.info("getting wordcloud for url: {}", target);
+
+        String query;
+        if (isDomain) {
+            query = "domain:\"" + target + "\"";
+        } else {
+            query = "host:\"" + target + "\"";
+        }
+        String text = NetarchiveSolrClient.getInstance().getConcatedTextFromHtmlForQuery(query, null); // Only contains the required fields for this method
         BufferedImage bufferedImage = WordCloudImageGenerator.wordCloudForDomain(text);
 
         return bufferedImage;
@@ -778,25 +785,25 @@ public class Facade {
     }
 
 
-    public static D3Graph waybackgraph(String domain, int facetLimit, boolean ingoing, String dateStart, String dateEnd) throws Exception {
+    public static D3Graph waybackgraph(String target, boolean isDomain, int facetLimit, boolean ingoing, String dateStart, String dateEnd) throws Exception {
 
 
         Date start = new Date(Long.valueOf(dateStart));
         Date end = new Date(Long.valueOf(dateEnd));
 
-        log.info("Creating graph for domain:" + domain + " ingoing:" + ingoing + " and facetLimit:" + facetLimit +" start:"+start +" end:"+end);
+        log.info("Creating graph for target:" + target + " ingoing:" + ingoing + " and facetLimit:" + facetLimit + " start:" +start + " end:" + end);
 
-        List<FacetCount> facets = NetarchiveSolrClient.getInstance().getDomainFacets(domain, facetLimit, ingoing, start, end);
+        List<FacetCount> facets = NetarchiveSolrClient.getInstance().getLinksFacets(target, isDomain, facetLimit, ingoing, start, end);
 
 
         HashMap<String, List<FacetCount>> domainFacetMap = new HashMap<String, List<FacetCount>>();
         // Also find facet for all facets from first call.
-        domainFacetMap.put(domain, facets); // add this center domain
+        domainFacetMap.put(target, facets); // add this center domain
 
         // Do all queries
         for (FacetCount f : facets) {
             String facetDomain = f.getValue();
-            List<FacetCount> fc = NetarchiveSolrClient.getInstance().getDomainFacets(facetDomain, facetLimit, ingoing, start, end);
+            List<FacetCount> fc = NetarchiveSolrClient.getInstance().getLinksFacets(facetDomain, isDomain, facetLimit, ingoing, start, end);
             domainFacetMap.put(f.getValue(), fc);
         }
 
@@ -811,7 +818,7 @@ public class Facade {
         }
 
 
-        D3Graph g = mapDomainsToD3LinkGraph(domain, ingoing, domainFacetMap, allDomains);
+        D3Graph g = mapDomainsToD3LinkGraph(target, ingoing, domainFacetMap, allDomains);
         return g;
     }
 

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResource.java
@@ -109,13 +109,28 @@ public class SolrWaybackResource {
   
   
   @GET
-  @Path("statistics/domain")
+  @Path("statistics/url")
   @Produces({ MediaType.APPLICATION_JSON})
-  public  List<DomainStatistics> statisticsDomain (@QueryParam("domain") String domain, @QueryParam("startdate") String startdate,
+  public  List<DomainStatistics> statisticsDomainHost (@QueryParam("domain") String domain, @QueryParam("host") String host, @QueryParam("startdate") String startdate,
           @QueryParam("enddate") String enddate, @QueryParam("scale") String scale) throws SolrWaybackServiceException {
       int limit = 90;
       LocalDate start = LocalDate.parse(startdate, DateTimeFormatter.ISO_DATE);
       LocalDate end = LocalDate.parse(enddate, DateTimeFormatter.ISO_DATE);
+      
+      String target = null;
+      boolean isDomain = true;
+      if (domain != null && host != null) {
+          throw new InvalidArgumentServiceException("Use either domain or host, not both.");
+      }
+      if (domain != null) {
+          target = domain;
+          isDomain = true;
+      } else if (host != null) {
+          target = host;
+          isDomain = false;
+      } else {
+          throw new InvalidArgumentServiceException("Either domain or host is required.");
+      }
       
       // If the period is too big for the scale, block the statistics
       int buckets = DateUtils.calculateBucket(start, end, scale);
@@ -125,7 +140,7 @@ public class SolrWaybackResource {
           throw new InvalidArgumentServiceException(msg);
       }
       try {
-        return Facade.statisticsDomain(domain, start , end, scale);
+        return Facade.statisticsDomainHost(target, isDomain, start , end, scale);
       } catch (Exception e) {
           throw handleServiceExceptions(e);
       }

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/service/SolrWaybackResourceWeb.java
@@ -300,16 +300,30 @@ public class SolrWaybackResourceWeb {
      */
     
     @GET
-    @Path("/wordcloud/domain")
+    @Path("/wordcloud/url")
     @Produces("image/png")
-    public Response  wordCloudForDomain(@QueryParam("domain") String domain) throws SolrWaybackServiceException {
-      try {                        
-          BufferedImage image = Facade.wordCloudForDomain(domain);           
-          return convertToPng(image);
-          
-      } catch (Exception e) {           
-        throw handleServiceExceptions(e);
-      }
+    public Response wordCloud(@QueryParam("domain") String domain, @QueryParam("host") String host) throws SolrWaybackServiceException {
+        try {
+            String target = null;
+            boolean isDomain = true;
+            if (domain != null && host != null) {
+                throw new InvalidArgumentServiceException("Use either domain or host, not both.");
+            }
+            if (domain != null) {
+                target = domain;
+                isDomain = true;
+            } else if (host != null) {
+                target = host;
+                isDomain = false;
+            } else {
+                throw new InvalidArgumentServiceException("Either domain or host is required.");
+            }
+            BufferedImage image = Facade.wordCloud(target, isDomain);
+            return convertToPng(image);
+            
+        } catch (Exception e) {
+            throw handleServiceExceptions(e);
+        }
     }
 
     @GET
@@ -496,31 +510,48 @@ public class SolrWaybackResourceWeb {
     @GET
     @Path("/tools/linkgraph")
     @Produces(MediaType.APPLICATION_JSON)
-    public D3Graph waybackgraph(@QueryParam("domain") String domain, @QueryParam("ingoing") Boolean ingoing, @QueryParam("facetLimit") Integer facetLimit, @QueryParam("dateStart") String dateStart, @QueryParam("dateEnd") String dateEnd) throws SolrWaybackServiceException {
-      try{        
-        int fLimit =10;//Default
-        boolean in=false;//Default
-        if (facetLimit != null){
-          fLimit=facetLimit.intValue();
-        }
-        if(ingoing != null){
-          in=ingoing.booleanValue();
-        }
+    public D3Graph waybackgraph(@QueryParam("domain") String domain, @QueryParam("host") String host,
+            @QueryParam("ingoing") Boolean ingoing, @QueryParam("facetLimit") Integer facetLimit,
+            @QueryParam("dateStart") String dateStart, @QueryParam("dateEnd") String dateEnd)
+            throws SolrWaybackServiceException {
+        try {
+            String target = null;
+            boolean isDomain = true;
+            if (domain != null && host != null) {
+                throw new InvalidArgumentServiceException("Use either domain or host, not both.");
+            }
+            if (domain != null) {
+                target = domain;
+                isDomain = true;
+            } else if (host != null) {
+                target = host;
+                isDomain = false;
+            } else {
+                throw new InvalidArgumentServiceException("Either domain or host is required.");
+            }
+            int fLimit = 10;// Default
+            boolean in = false;// Default
+            if (facetLimit != null) {
+                fLimit = facetLimit.intValue();
+            }
+            if (ingoing != null) {
+                in = ingoing.booleanValue();
+            }
 
-        // Default dates if not in input        
-       if (dateStart == null) {
-          int startYear=PropertiesLoaderWeb.ARCHIVE_START_YEAR;        
-          dateStart = ""+new GregorianCalendar(startYear, 00, 1).getTime();
-       }
-       if (dateEnd== null) {
-           dateEnd=""+System.currentTimeMillis();
-       }
-        
-        return Facade.waybackgraph(domain, fLimit,in,dateStart,dateEnd);        
+            // Default dates if not in input
+            if (dateStart == null) {
+                int startYear = PropertiesLoaderWeb.ARCHIVE_START_YEAR;
+                dateStart = "" + new GregorianCalendar(startYear, 00, 1).getTime();
+            }
+            if (dateEnd == null) {
+                dateEnd = "" + System.currentTimeMillis();
+            }
 
-      } catch (Exception e) {
-        throw handleServiceExceptions(e);
-      }
+            return Facade.waybackgraph(target, isDomain, fLimit, in, dateStart, dateEnd);
+
+        } catch (Exception e) {
+            throw handleServiceExceptions(e);
+        }
 
     }
     

--- a/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
+++ b/src/main/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClient.java
@@ -150,56 +150,62 @@ public class NetarchiveSolrClient {
 
 
     /**
-     * Retrieve domain facets for a given domain.
+     * Retrieve domain/host facets for a given domain/host.
      * <p>
-     * This method delegates to either {@link #getDomainFacetsIngoing(String, int, Date, Date)} or
-     * {@link #getDomainFacetsOutgoing(String, int, Date, Date)} depending on the {@code ingoing} flag.
-     * @param domain to get facets for
+     * This method delegates to either {@link #getLinksFacetsIngoing(String, boolean, int, Date, Date)} or
+     * {@link #getLinksFacetsOutgoing(String, boolean, int, Date, Date)} depending on the {@code ingoing} flag.
+     * @param target or host to get facets for
+     * @param isDomain to determinate if it's a domain or an host
      * @param facetLimit the maximum number of facet values to return
-     * @param ingoing if true, return domains that link to {@code domain}; if false, return domains that {@code domain} links to
+     * @param ingoing if true, return domains/hosts that link to {@code target}; if false, return domains that {@code target} links to
      * @param crawlDateStart start of crawl date range (inclusive)
      * @param crawlDateEnd end of crawl date range (inclusive)
      * @return list of {@link FacetCount} objects representing facet values and counts
      */
-    public List<FacetCount> getDomainFacets(String domain, int facetLimit, boolean ingoing, Date crawlDateStart, Date crawlDateEnd) throws Exception {
+    public List<FacetCount> getLinksFacets(String target, boolean isDomain, int facetLimit, boolean ingoing, Date crawlDateStart, Date crawlDateEnd) throws Exception {
 
         if (ingoing) {
-            return getDomainFacetsIngoing(domain, facetLimit, crawlDateStart, crawlDateEnd);
+            return getLinksFacetsIngoing(target, isDomain, facetLimit, crawlDateStart, crawlDateEnd);
         } else {
-            return getDomainFacetsOutgoing(domain, facetLimit, crawlDateStart, crawlDateEnd);
+            return getLinksFacetsOutgoing(target, isDomain, facetLimit, crawlDateStart, crawlDateEnd);
         }
     }
 
     /**
-     * Returns a list of domains that link to the provided {@code domain} within the given crawl date range.
-     * The method executes a facet query on the {@code domain} field for documents that contain
-     * {@code links_domains:"<domain>"} while excluding documents where {@code domain} equals the provided
-     * {@code domain} (to avoid self-links).
+     * Returns a list of domains or hosts that link to the provided {@code target} within the given crawl date range.
+     * The method executes depending on the parameter {@code isDomain} :
+     * <ul><li>a facet query on the {@code domain} field for documents that contain {@code links_domains:"<target>"} 
+     * while excluding documents where {@code domain} equals the provided {@code target} (to avoid self-links),</li>
+     * <li>a facet query on the {@code host} field for documents that contain {@code links_hosts:"<target>"} 
+     * while excluding documents where {@code host} equals the provided {@code target} (to avoid self-links)</li></ul>
      *
-     * @param domain to find incoming links for
+     * @param target to find incoming links for
+     * @param isDomain to determinate if it's a domain or an host
      * @param facetLimit maximum number of facet values to return
      * @param crawlDateStart start of crawl date range (inclusive)
      * @param crawlDateEnd end of crawl date range (inclusive)
-     * @return list of {@link FacetCount} with domain names and counts
+     * @return list of {@link FacetCount} with domain/host names and counts
      */
-    public List<FacetCount> getDomainFacetsIngoing(String domain, int facetLimit, Date crawlDateStart, Date crawlDateEnd) throws Exception {
+    public List<FacetCount> getLinksFacetsIngoing(String target, boolean isDomain, int facetLimit, Date crawlDateStart, Date crawlDateEnd) throws Exception {
+
+        String parameter = isDomain ? "domain" : "host";
 
         String dateStart = DateUtils.getSolrDate(crawlDateStart);
         String dateEnd = DateUtils.getSolrDate(crawlDateEnd);
 
         SolrQuery solrQuery = new SolrQuery();
-        solrQuery.setQuery("links_domains:\"" + domain + "\" AND -domain:\"" + domain + "\"");
+        solrQuery.setQuery("links_" + parameter + "s:\"" + target + "\" AND -" + parameter + ":\"" + target + "\"");
 
         solrQuery.setRows(0);
         solrQuery.set("facet", "true");
-        solrQuery.add("facet.field", "domain");
+        solrQuery.add("facet.field", parameter);
         solrQuery.add("facet.limit", "" + facetLimit);
         solrQuery.addFilterQuery("crawl_date:[" + dateStart + " TO " + dateEnd + "]");
 
         solrQuery.add("fl","id");
         QueryResponse rsp = solrServer.query(solrQuery, METHOD.POST);
-        List<FacetCount> facetList = new ArrayList<FacetCount>();
-        FacetField facet = rsp.getFacetField("domain");
+        List<FacetCount> facetList = new ArrayList<>();
+        FacetField facet = rsp.getFacetField(parameter);
         for (Count c : facet.getValues()) {
             FacetCount fc = new FacetCount();
             fc.setValue(c.getName());
@@ -210,36 +216,41 @@ public class NetarchiveSolrClient {
     }
 
     /**
-     * Returns a list of domains that the provided {@code domain} links to within the given crawl date range.
-     * The method facets on the {@code links_domains} field for documents where {@code domain:"<domain>"}.
+     * Returns a list of domains that the provided {@code target} links to within the given crawl date range.
+     * Depending on the parameter {@code isDomain},the method facets 
+     * <ul><li>on the {@code links_domains} field for documents where {@code domain:"<target>"}. if {@code isDomain} is true</li>
+     * <li>on the {@code links_hosts} field for documents where {@code host:"<target>"}. if {@code isDomain} is false</li></ul>
      *
-     * @param domain to find outgoing links for
+     * @param target to find outgoing links for
+     * @param isDomain to determinate if it's a domain or an host
      * @param facetLimit maximum number of facet values to return
      * @param crawlDateStart start of crawl date range (inclusive)
      * @param crawlDateEnd end of crawl date range (inclusive)
-     * @return list of {@link FacetCount} with domain names and counts
+     * @return list of {@link FacetCount} with domain/host names and counts
      */
-    public List<FacetCount> getDomainFacetsOutgoing(String domain, int facetLimit, Date crawlDateStart, Date crawlDateEnd) throws Exception {
+    public List<FacetCount> getLinksFacetsOutgoing(String target, boolean isDomain, int facetLimit, Date crawlDateStart, Date crawlDateEnd) throws Exception {
+
+        String parameter = isDomain ? "domain" : "host";
 
         String dateStart = DateUtils.getSolrDate(crawlDateStart);
         String dateEnd = DateUtils.getSolrDate(crawlDateEnd);
 
         SolrQuery solrQuery = new SolrQuery();
-        solrQuery.setQuery("domain:\"" + domain + "\"");
+        solrQuery.setQuery(parameter + ":\"" + target + "\"");
 
         solrQuery.setRows(0);
         solrQuery.set("facet", "true");
-        solrQuery.add("facet.field", "links_domains");
+        solrQuery.add("facet.field", "links_" + parameter + "s");
         solrQuery.add("facet.limit", "" + (facetLimit + 1)); // +1 because itself will be removed and is almost certain of resultset is self-linking
         solrQuery.addFilterQuery("crawl_date:[" + dateStart + " TO " + dateEnd + "]");
         solrQuery.add("fl","id");                                                                                                                                                                  // request
         QueryResponse rsp = noCacheSolrServer.query(solrQuery, METHOD.POST); //do not cache
-        List<FacetCount> facetList = new ArrayList<FacetCount>();
-        FacetField facet = rsp.getFacetField("links_domains");
+        List<FacetCount> facetList = new ArrayList<>();
+        FacetField facet = rsp.getFacetField("links_" + parameter + "s");
 
         // We have to remove the domain itself.
         for (Count c : facet.getValues()) {
-            if (!c.getName().equalsIgnoreCase(domain)) {
+            if (!c.getName().equalsIgnoreCase(target)) {
                 FacetCount fc = new FacetCount();
                 fc.setValue(c.getName());
                 fc.setCount(c.getCount());
@@ -1608,32 +1619,42 @@ public class NetarchiveSolrClient {
         }
     }
 
-    /*
+    /**
      * Uses the stats component and hyperloglog for ultra fast performance instead
      * of grouping, which does not work well over many shards.
      * <p>
-     * Extract statistics for a given domain and year. Number of unique pages (very
-     * precise due to hyperloglog) Number of ingoing links (very precise due to
-     * hyperloglog) Total size (of the unique pages). (not so precise due, tests
-     * show max 10% error, less for if there are many pages)
+     * Extract statistics for a given domain or host and year. 
+     * Number of unique pages (very precise due to hyperloglog).
+     * Number of ingoing links (very precise due to hyperloglog).
+     * Total size (of the unique pages). (not so precise due, tests show max 10% error, less for if there are many pages).
+     * </p>
+     * @param target or host to get statistics for
+     * @param isDomain to determinate if it's a domain or an host
+     * @param startDate used to limit crawl dates returned
+     * @param endDate used to limit crawl dates returned
+     * @return {@link DomainStatistics} statistics for domain or host
      */
-    public DomainStatistics domainStatistics(String domain, String startDate, String endDate) throws Exception {
+    public DomainStatistics statisticsDomainHost(String target, Boolean isDomain, String startDate, String endDate) throws Exception {
 
         DomainStatistics stats = new DomainStatistics();
         stats.setDate(startDate);
-        stats.setDomain(domain);
+        stats.setDomain(target);
 
-        String searchString = "domain:\"" + domain + "\"";
+        String searchField = "domain";
+        if (Boolean.FALSE.equals(isDomain)) {
+            searchField = "host";
+        }
+        String searchString = searchField + ":\"" + target + "\"";
 
         QueryResponse statsResponse = getStatsResponse(startDate, endDate, searchString);
 
         Map<String, FieldStatsInfo> statsMap = statsResponse.getFieldStatsInfo();
         addSolrStatsToDomainStatisticsObject(statsMap, stats);
 
-        QueryResponse linksStatsResponse = getLinksStatsResponse(domain, startDate, endDate);
+        QueryResponse linksStatsResponse = getLinksStatsResponse(target, startDate, endDate, isDomain);
         Map<String, FieldStatsInfo> stats2 = linksStatsResponse.getFieldStatsInfo();
 
-        FieldStatsInfo statsLinks = stats2.get("domain");
+        FieldStatsInfo statsLinks = stats2.get(searchField);
         long links_cardinality = statsLinks.getCardinality();
         stats.setIngoingLinks((int) links_cardinality);
 
@@ -1670,17 +1691,21 @@ public class NetarchiveSolrClient {
      * @param endDate used to limit crawl dates returned.
      * @return a {@link QueryResponse} object with SolrStats available for ingoing links
      */
-    private static QueryResponse getLinksStatsResponse(String domain, String startDate, String endDate) throws SolrServerException, IOException {
+    private static QueryResponse getLinksStatsResponse(String domain, String startDate, String endDate, Boolean isDomain) throws SolrServerException, IOException {
         // Links
-        String searchString = "domain:\"" + domain + "\"";
+    	String searchField = "domain";
+        if (Boolean.FALSE.equals(isDomain)) {
+            searchField = "host";
+        }
+        String searchString = searchField + ":\"" + domain + "\"";
         SolrQuery solrQuery = new SolrQuery();
-        solrQuery.setQuery("links_domains:\"" + domain + "\" -" + searchString); // links to, but not from same domain
+        solrQuery.setQuery("links_"+ searchField +"s:\"" + domain + "\" -" + searchString); // links to, but not from same domain
         solrQuery.addFilterQuery("content_type_norm:html AND status_code:200");
         solrQuery.addFilterQuery("crawl_date:[" + startDate + "T00:00:00Z TO " + endDate + "T23:59:59Z]");
         solrQuery.setRows(0);
         solrQuery.add("stats", "true");
         solrQuery.add("fl", "id");
-        solrQuery.add("stats.field", "{!cardinality=true}domain"); // Important, use cardinality and not unique.
+        solrQuery.add("stats.field", "{!cardinality=true}"+ searchField); // Important, use cardinality and not unique.
         return solrServer.query(solrQuery);
     }
 

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClientTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/NetarchiveSolrClientTest.java
@@ -306,7 +306,7 @@ public class NetarchiveSolrClientTest {
         Date end = DateUtils.solrTimestampToJavaDate("2020-12-31T23:59:59Z");
 
         // Outgoing for alpha.com should include beta.com and gamma.com
-        List<FacetCount> outgoing = client.getDomainFacets("alpha.com", 10, false, start, end);
+        List<FacetCount> outgoing = client.getLinksFacets("alpha.com", true, 10, false, start, end);
         assertNotNull(outgoing);
         // Convert to map for easy lookup
         Map<String, Long> outMap = new HashMap<>();
@@ -317,7 +317,7 @@ public class NetarchiveSolrClientTest {
         assertEquals(Long.valueOf(1), outMap.get("gamma.com"));
 
         // Ingoing for alpha.com should include beta.com and gamma.com (both link to alpha)
-        List<FacetCount> ingoing = client.getDomainFacets("alpha.com", 10, true, start, end);
+        List<FacetCount> ingoing = client.getLinksFacets("alpha.com", true, 10, true, start, end);
         assertNotNull(ingoing);
         Map<String, Long> inMap = new HashMap<>();
         for (FacetCount fc : ingoing) {

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/SolrClientTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/solr/SolrClientTest.java
@@ -164,7 +164,7 @@ public class SolrClientTest {
     Date start= new Date(System.currentTimeMillis()-25L*365*86400*1000); //25 years ago
     Date end = new Date();
 
-    List<FacetCount>  fc = solr.getDomainFacets("denstoredanske.dk",20, true, start,end);      
+    List<FacetCount>  fc = solr.getLinksFacets("denstoredanske.dk", true, 20, true, start, end);
 
     for (FacetCount f : fc){
       System.out.println(f.getValue() +" : " +f.getCount());
@@ -180,7 +180,7 @@ public class SolrClientTest {
     Date start= new Date(System.currentTimeMillis()-25L*365*86400*1000); //25 years ago
     Date end = new Date();
 
-    List<FacetCount>  fc = solr.getDomainFacetsIngoing("denstoredanske.dk",10000, start,end);      
+    List<FacetCount>  fc = solr.getLinksFacetsIngoing("denstoredanske.dk", true, 10000, start, end);
 
     for (FacetCount f : fc){
       System.out.println(f.getValue() +" : " +f.getCount());

--- a/src/test/java/dk/kb/netarchivesuite/solrwayback/wordcloud/WordCloudTest.java
+++ b/src/test/java/dk/kb/netarchivesuite/solrwayback/wordcloud/WordCloudTest.java
@@ -46,6 +46,7 @@ public class WordCloudTest {
         createTestDocument(3, "word frequency analysis and word cloud image generation", "example.com");
         createTestDocument(4, "the quick brown fox jumps over the lazy dog and the cat", "test.com");
         createTestDocument(5, "cloud computing with word processing software", "example.com");
+        createTestDocument(5, "test host domain word cloud", "domain.com", "host.domain.com");
 
         embeddedServer.commit();
     }
@@ -60,6 +61,9 @@ public class WordCloudTest {
         }
     }
 
+    private void createTestDocument(int id, String textContent, String domain) throws Exception {
+        createTestDocument(id, textContent, domain, null);
+    }
     /**
      * Helper method to create and add a test document to the embedded Solr server.
      *
@@ -68,12 +72,15 @@ public class WordCloudTest {
      * @param domain      Domain associated with the document.
      * @throws Exception if there is an error adding the document.
      */
-    private void createTestDocument(int id, String textContent, String domain) throws Exception {
+    private void createTestDocument(int id, String textContent, String domain, String host) throws Exception {
         SolrInputDocument document = new SolrInputDocument();
         document.addField("id", "doc" + id);
         document.addField("url", "http://" + domain + "/page" + id);
         document.addField("url_norm", "http://" + domain + "/page" + id);
         document.addField("domain", domain);
+        if (host!= null) {
+            document.addField("host", host);
+        }
         document.addField("content_type_norm", "html");
         document.addField("record_type", "response");
         document.addField("source_file_path", "test.warc");
@@ -92,13 +99,27 @@ public class WordCloudTest {
     }
 
     /**
-     * Test the deprecated wordCloudForDomain method.
+     * Test the deprecated wordCloud method.
      * Verifies that a BufferedImage is generated for a domain query.
      */
     @Test
     public void testWordCloudForDomain() throws Exception {
         String domain = "example.com";
-        BufferedImage result = Facade.wordCloudForDomain(domain);
+        BufferedImage result = Facade.wordCloud(domain, true);
+        
+        // Verify image was generated with correct size
+        assertEquals("Image should have expected width", 800, result.getWidth());
+        assertEquals("Image should have expected height", 600, result.getHeight());
+    }
+
+    /**
+     * Test the deprecated wordCloud method.
+     * Verifies that a BufferedImage is generated for a host query.
+     */
+    @Test
+    public void testWordCloudForHost() throws Exception {
+        String host = "host.domain.com";
+        BufferedImage result = Facade.wordCloud(host, false);
 
         // Verify image was generated with correct size
         assertEquals("Image should have expected width", 800, result.getWidth());
@@ -116,6 +137,22 @@ public class WordCloudTest {
         
         BufferedImage result = Facade.wordCloudForQuery(query, filter);
 
+        // Verify image was generated with correct size
+        assertEquals("Image should have expected width", 800, result.getWidth());
+        assertEquals("Image should have expected height", 600, result.getHeight());
+    }
+    
+    /**
+     * Test wordCloudForQuery with query and filter.
+     * Verifies that a BufferedImage is generated for a custom query.
+     */
+    @Test
+    public void testWordCloudForQuery_WithHostFilter() throws Exception {
+        String query = "host:host.domain.com";
+        String filter = "content_type_norm:html";
+        
+        BufferedImage result = Facade.wordCloudForQuery(query, filter);
+        
         // Verify image was generated with correct size
         assertEquals("Image should have expected width", 800, result.getWidth());
         assertEquals("Image should have expected height", 600, result.getHeight());
@@ -273,8 +310,8 @@ public class WordCloudTest {
         embeddedServer.commit();
         
         String domain = "unique.com";
-        BufferedImage result = Facade.wordCloudForDomain(domain);
-
+        BufferedImage result = Facade.wordCloud(domain, true);
+        
         // Verify image was generated
         assertNotNull("Word cloud image should not be null", result);
         assertTrue("Image width should be greater than 0", result.getWidth() > 0);
@@ -286,8 +323,37 @@ public class WordCloudTest {
         // Should find at least one of our distinctive words
         boolean hasDistinctiveWord = wordFreq.stream()
                 .anyMatch(w -> "unique".equals(w.getWord()) || 
+                        "special".equals(w.getWord()) || 
+                        "distinctive".equals(w.getWord()));
+        assertTrue("Should find distinctive words from the domain", hasDistinctiveWord);
+    }
+    /**
+     * Test word cloud generation with specific domain query.
+     * Verifies that domain filtering works correctly.
+     */
+    @Test
+    public void testWordCloudForHost_SpecificHost() throws Exception {
+        // Add a document with very distinctive text for a different domain
+        embeddedServer.deleteByQuery("*:*");
+        createTestDocument(100, "unique special distinctive remarkable extraordinary", "specific.com", "host.specific.com");
+        embeddedServer.commit();
+        
+        String host = "host.specific.com";
+        BufferedImage result = Facade.wordCloud(host, false);
+
+        // Verify image was generated
+        assertNotNull("Word cloud image should not be null", result);
+        assertTrue("Image width should be greater than 0", result.getWidth() > 0);
+        
+        // Verify word frequency for the same domain
+        List<WordCloudWordAndCount> wordFreq = Facade.wordCloudWordFrequency("host:\"" + host + "\"", null);
+        assertNotNull("Word frequency should not be null", wordFreq);
+        
+        // Should find at least one of our distinctive words
+        boolean hasDistinctiveWord = wordFreq.stream()
+                .anyMatch(w -> "unique".equals(w.getWord()) || 
                                "special".equals(w.getWord()) || 
                                "distinctive".equals(w.getWord()));
-        assertTrue("Should find distinctive words from the domain", hasDistinctiveWord);
+        assertTrue("Should find distinctive words from the host", hasDistinctiveWord);
     }
 }


### PR DESCRIPTION
Linked to #510.

For the wordcloud : I saw that the method wordCloudForDomain will be deleted when the frontend will change. In the meantime, I change it in "wordCloud" and it generates the image for a domain or an host.

For the domain stats : I renamed the tab from Domain stats to Stats and a few methods but I didn't change the DomainStatistics object, the DomainStats.vue and all the associated css. Should I harmonize the code ?